### PR TITLE
fix: room page UX — toasts, confirmations, loading states, moderation controls

### DIFF
--- a/__tests__/components/confirm-dialog.test.tsx
+++ b/__tests__/components/confirm-dialog.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    title: 'Test Title',
+    description: 'Test description text',
+    onConfirm: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders title and description when open', () => {
+    render(<ConfirmDialog {...defaultProps} />)
+    expect(screen.getByText('Test Title')).toBeDefined()
+    expect(screen.getByText('Test description text')).toBeDefined()
+  })
+
+  it('does not render content when closed', () => {
+    render(<ConfirmDialog {...defaultProps} open={false} />)
+    expect(screen.queryByText('Test Title')).toBeNull()
+  })
+
+  it('renders default button labels', () => {
+    render(<ConfirmDialog {...defaultProps} />)
+    expect(screen.getByText('CANCEL')).toBeDefined()
+    expect(screen.getByText('CONFIRM')).toBeDefined()
+  })
+
+  it('renders custom button labels', () => {
+    render(<ConfirmDialog {...defaultProps} confirmLabel="KICK" cancelLabel="NEVERMIND" />)
+    expect(screen.getByText('KICK')).toBeDefined()
+    expect(screen.getByText('NEVERMIND')).toBeDefined()
+  })
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    render(<ConfirmDialog {...defaultProps} />)
+    fireEvent.click(screen.getByText('CONFIRM'))
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables buttons when loading', () => {
+    render(<ConfirmDialog {...defaultProps} loading={true} />)
+    const confirmBtn = screen.getByText('CONFIRM').closest('button')
+    const cancelBtn = screen.getByText('CANCEL').closest('button')
+    expect(confirmBtn?.disabled).toBe(true)
+    expect(cancelBtn?.disabled).toBe(true)
+  })
+
+  it('shows spinner when loading', () => {
+    render(<ConfirmDialog {...defaultProps} loading={true} />)
+    // Radix portals render outside container, query the document body
+    const spinner = document.body.querySelector('.animate-spin')
+    expect(spinner).not.toBeNull()
+  })
+
+  it('uses destructive variant styling on confirm button', () => {
+    render(<ConfirmDialog {...defaultProps} variant="destructive" confirmLabel="DELETE" />)
+    const deleteBtn = screen.getByText('DELETE').closest('button')
+    expect(deleteBtn).toBeDefined()
+  })
+})

--- a/__tests__/debate.test.ts
+++ b/__tests__/debate.test.ts
@@ -27,6 +27,7 @@ import {
   pauseDebate,
   resumeDebate,
   endDebate,
+  extendTurn,
 } from '@/lib/actions/debate'
 
 const MOCK_HOST_ID = 'host-uuid'
@@ -314,5 +315,79 @@ describe('endDebate', () => {
   it('does not throw if debate state already gone', async () => {
     ;(prisma.debateState.delete as any).mockRejectedValue(new Error('not found'))
     await expect(endDebate(MOCK_SESSION_ID)).resolves.not.toThrow()
+  })
+})
+
+// ── extendTurn ──
+describe('extendTurn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_HOST_ID)
+    mockSession()
+    ;(prisma.debateState.update as any).mockResolvedValue({})
+  })
+
+  it('throws if not authorized', async () => {
+    mockSession({ host_id: 'other', moderator_id: null })
+    await expect(extendTurn(MOCK_SESSION_ID, 30)).rejects.toThrow('Not authorized')
+  })
+
+  it('throws if no active debate', async () => {
+    ;(prisma.debateState.findUnique as any).mockResolvedValue(null)
+    await expect(extendTurn(MOCK_SESSION_ID, 30)).rejects.toThrow('No active debate')
+  })
+
+  it('adds extra seconds to turn_ends_at when debate is live', async () => {
+    const currentTurnEndsAt = Date.now() + 30_000
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false,
+      turn_ends_at: currentTurnEndsAt,
+      paused_time_remaining: 0,
+    })
+    await extendTurn(MOCK_SESSION_ID, 30)
+    const update = (prisma.debateState.update as any).mock.calls[0][0]
+    expect(update.data.turn_ends_at).toBe(currentTurnEndsAt + 30_000)
+  })
+
+  it('adds extra seconds to paused_time_remaining when debate is paused', async () => {
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: true,
+      turn_ends_at: null,
+      paused_time_remaining: 45,
+    })
+    await extendTurn(MOCK_SESSION_ID, 30)
+    const update = (prisma.debateState.update as any).mock.calls[0][0]
+    expect(update.data.paused_time_remaining).toBe(75)
+  })
+
+  it('throws if live but turn_ends_at is null', async () => {
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false,
+      turn_ends_at: null,
+      paused_time_remaining: 0,
+    })
+    await expect(extendTurn(MOCK_SESSION_ID, 30)).rejects.toThrow('No active turn')
+  })
+
+  it('allows moderator to extend turn', async () => {
+    mockSession({ host_id: 'other', moderator_id: MOCK_HOST_ID })
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false,
+      turn_ends_at: Date.now() + 20_000,
+      paused_time_remaining: 0,
+    })
+    await extendTurn(MOCK_SESSION_ID, 60)
+    expect(prisma.debateState.update).toHaveBeenCalled()
+  })
+
+  it('handles extending by different amounts', async () => {
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: true,
+      turn_ends_at: null,
+      paused_time_remaining: 10,
+    })
+    await extendTurn(MOCK_SESSION_ID, 120)
+    const update = (prisma.debateState.update as any).mock.calls[0][0]
+    expect(update.data.paused_time_remaining).toBe(130)
   })
 })

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/lib/prisma', () => ({
       create: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
   },
 }))
@@ -35,6 +36,7 @@ import {
   joinSessionAsDebater,
   leaveSession,
   updateSessionStatus,
+  promoteToDebater,
 } from '@/lib/actions/session'
 
 // Helper to set up auth mock
@@ -432,5 +434,80 @@ describe('updateSessionStatus', () => {
     expect(call.data.status).toBe(SessionStatus.ENDED)
     expect(call.data.ended_at).toBeInstanceOf(Date)
     expect(call.data.ended_at.getTime()).toBeGreaterThanOrEqual(before)
+  })
+})
+
+// ── promoteToDebater ──
+describe('promoteToDebater', () => {
+  const TARGET_USER_ID = 'target-user-uuid'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.update as any).mockResolvedValue({})
+  })
+
+  function mockSessionForPromote(overrides: Record<string, unknown> = {}) {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+      status: SessionStatus.WAITING,
+      ...overrides,
+    })
+  }
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws if session not found', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Session not found')
+  })
+
+  it('throws if caller is not host or moderator', async () => {
+    mockSessionForPromote({ host_id: 'other-user', moderator_id: null })
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Only moderators or hosts')
+  })
+
+  it('throws if session is not in WAITING status', async () => {
+    mockSessionForPromote({ status: SessionStatus.LIVE })
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Can only promote participants before the debate starts')
+  })
+
+  it('throws if trying to promote yourself', async () => {
+    mockSessionForPromote()
+    await expect(promoteToDebater(MOCK_SESSION_ID, MOCK_USER_ID)).rejects.toThrow('Cannot promote yourself')
+  })
+
+  it('updates participant role to DEBATER', async () => {
+    mockSessionForPromote()
+    await promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)
+    expect(prisma.participatesIn.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id_session_id: { user_id: TARGET_USER_ID, session_id: MOCK_SESSION_ID },
+        }),
+        data: expect.objectContaining({ session_role: SessionRole.DEBATER }),
+      })
+    )
+  })
+
+  it('allows moderator to promote', async () => {
+    mockSessionForPromote({ host_id: 'some-host', moderator_id: MOCK_USER_ID })
+    await promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)
+    expect(prisma.participatesIn.update).toHaveBeenCalled()
+  })
+
+  it('throws when session is PAUSED', async () => {
+    mockSessionForPromote({ status: SessionStatus.PAUSED })
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Can only promote participants before the debate starts')
+  })
+
+  it('throws when session is ENDED', async () => {
+    mockSessionForPromote({ status: SessionStatus.ENDED })
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Can only promote participants before the debate starts')
   })
 })

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import AuthSync from "@/components/AuthSync";
+import { Toaster } from "@/components/ui/toaster";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -16,6 +17,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="antialiased">
         <AuthSync />
+        <Toaster />
         {children}
       </body>
     </html>

--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
 import {
   Users,
@@ -13,21 +13,27 @@ import {
   Pause,
   Play,
   SkipForward,
+  Timer,
   Volume2,
   Video,
   VideoOff,
   Settings,
   Loader2,
-  Swords
+  Swords,
+  ArrowUp,
+  RefreshCw,
 } from 'lucide-react'
+import { toast } from 'sonner'
 import { useMediasoup } from '@/hooks/useMediasoup'
 import { useDebateChannel } from '@/hooks/useDebateChannel'
 import { createClient } from '@/lib/supabase/client'
 import VideoPanel from '@/components/VideoPanel'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { userStub, getInitials, formatTime } from '@/lib/utils'
-import { leaveSession, updateSessionStatus, joinSession, joinSessionAsDebater, kickParticipant, assignModerator } from '@/lib/actions/session'
+import { leaveSession, updateSessionStatus, joinSession, joinSessionAsDebater, kickParticipant, assignModerator, promoteToDebater } from '@/lib/actions/session'
+import { extendTurn } from '@/lib/actions/debate'
 import { useRouter } from 'next/navigation'
 import { SessionRole, SessionStatus, SessionType } from '@/lib/generated/prisma'
 
@@ -63,10 +69,25 @@ export default function RoomClient({
   currentUsername: string
 }) {
   const router = useRouter()
-  const [isPaused, setIsPaused] = useState(session.status === SessionStatus.PAUSED)
-  const [timeRemaining, setTimeRemaining] = useState(session.turnLength)
   const [isJoining, setIsJoining] = useState(false)
   const [showDebaterOptions, setShowDebaterOptions] = useState(false)
+
+  // Loading states for async operations
+  const [isStarting, setIsStarting] = useState(false)
+  const [isPauseToggling, setIsPauseToggling] = useState(false)
+  const [isEnding, setIsEnding] = useState(false)
+  const [isAdvancingTurn, setIsAdvancingTurn] = useState(false)
+  const [isExtendingTurn, setIsExtendingTurn] = useState(false)
+  const [isAssigningModerator, setIsAssigningModerator] = useState<string | null>(null)
+  const [isKicking, setIsKicking] = useState<string | null>(null)
+  const [isPromoting, setIsPromoting] = useState<string | null>(null)
+
+  // Confirmation dialog state
+  const [confirmDialog, setConfirmDialog] = useState<{
+    type: 'kick' | 'end' | 'moderator' | 'promote'
+    targetUserId?: string
+    targetName?: string
+  } | null>(null)
 
   const isModeratorOrCreator = currentRole === SessionRole.MODERATOR || currentRole === SessionRole.HOST
   const isHost = currentRole === SessionRole.HOST
@@ -82,6 +103,7 @@ export default function RoomClient({
     toggleMute,
     toggleVideo,
     disconnect: disconnectSfu,
+    reconnect: reconnectSfu,
   } = useMediasoup({
     sfuUrl: process.env.NEXT_PUBLIC_SFU_URL,
     roomId: session.code,
@@ -93,6 +115,18 @@ export default function RoomClient({
     sessionId: session.id,
     userId: currentUserId,
   })
+
+  // Derive isPaused from debate channel (authoritative source via Supabase Realtime)
+  const isPaused = debate.isPaused || session.status === SessionStatus.PAUSED
+
+  // Toast on video connection error
+  const prevConnectionState = useRef(connectionState)
+  useEffect(() => {
+    if (prevConnectionState.current !== 'error' && connectionState === 'error') {
+      toast.error('Video connection failed')
+    }
+    prevConnectionState.current = connectionState
+  }, [connectionState])
 
   // Refresh page when participants change (via Supabase Realtime)
   useEffect(() => {
@@ -126,6 +160,7 @@ export default function RoomClient({
         }
       } catch (err) {
         console.error('Auto-join failed:', err)
+        toast.error('Failed to join room automatically')
       }
     }
     autoJoin()
@@ -148,9 +183,6 @@ export default function RoomClient({
   }, [isParticipant, session.id])
 
   // Filter participants by role
-  const moderators = session.participatesIns.filter(
-    (p) => p.sessionRole === SessionRole.MODERATOR || p.sessionRole === SessionRole.HOST
-  )
   const debaters = session.participatesIns.filter(
     (p) => p.sessionRole === SessionRole.DEBATER || p.sessionRole === SessionRole.HOST
   )
@@ -176,12 +208,12 @@ export default function RoomClient({
     currentRole === SessionRole.AUDIENCE && canJoinAsDebater
 
   // Check proponent/opponent specific availability
-  const proponentsFull = 
-    session.type !== SessionType.PANEL && 
+  const proponentsFull =
+    session.type !== SessionType.PANEL &&
     (session.debaterCapacityProponent ?? 0) > 0 &&
     debaters.filter(d => d.sessionRole === SessionRole.DEBATER).length >= (session.debaterCapacityProponent ?? 0)
-  
-  const opponentsFull = 
+
+  const opponentsFull =
     session.type !== SessionType.PANEL &&
     (session.debaterCapacityOpponent ?? 0) > 0 &&
     debaters.filter(d => d.sessionRole === SessionRole.DEBATER).length >= totalDebaterCapacity
@@ -192,52 +224,56 @@ export default function RoomClient({
       ? debate.timeRemaining
       : session.turnLength
 
-  // Timer countdown
-  useEffect(() => {
-    if (!isPaused && session.status === SessionStatus.LIVE) {
-      const interval = setInterval(() => {
-        setTimeRemaining((prev) => (prev > 0 ? prev - 1 : 0))
-      }, 1000)
-      return () => clearInterval(interval)
-    }
-  }, [isPaused, session.status])
+  // --- Handlers with toast + loading ---
 
   async function handleLeave() {
     disconnectSfu()
     try {
       await leaveSession(session.id)
-      router.push('/browse')
     } catch (err) {
       console.error('Failed to leave:', err)
-      router.push('/browse')
+      toast.error('Failed to leave session')
     }
+    router.push('/browse')
   }
 
   async function handleTogglePause() {
+    setIsPauseToggling(true)
     try {
       if (isPaused) {
         await debate.resume()
         await updateSessionStatus(session.id, 'LIVE')
+        toast.success('Debate resumed')
       } else {
         await debate.pause()
         await updateSessionStatus(session.id, 'PAUSED')
+        toast.success('Debate paused')
       }
     } catch (err) {
       console.error('Failed to toggle pause:', err)
+      toast.error('Failed to toggle pause')
+    } finally {
+      setIsPauseToggling(false)
     }
   }
 
   async function handleEndSession() {
+    setIsEnding(true)
     try {
       await debate.endDebate()
       await updateSessionStatus(session.id, SessionStatus.ENDED)
+      toast.success('Session ended')
       router.push('/browse')
     } catch (err) {
       console.error('Failed to end session:', err)
+      toast.error('Failed to end session')
+    } finally {
+      setIsEnding(false)
     }
   }
 
   async function handleStartSession() {
+    setIsStarting(true)
     try {
       await updateSessionStatus(session.id, 'LIVE')
 
@@ -252,9 +288,13 @@ export default function RoomClient({
       }
 
       await updateSessionStatus(session.id, SessionStatus.LIVE)
+      toast.success('Debate started')
       router.refresh()
     } catch (err) {
       console.error('Failed to start session:', err)
+      toast.error('Failed to start debate')
+    } finally {
+      setIsStarting(false)
     }
   }
 
@@ -262,9 +302,11 @@ export default function RoomClient({
     setIsJoining(true)
     try {
       await joinSessionAsDebater(session.id, isProponent)
+      toast.success('Joined as debater')
       router.refresh()
     } catch (err) {
       console.error('Failed to upgrade to debater:', err)
+      toast.error('Failed to join as debater')
     } finally {
       setIsJoining(false)
       setShowDebaterOptions(false)
@@ -272,28 +314,92 @@ export default function RoomClient({
   }
 
   async function handleAssignModerator(userId: string) {
+    setIsAssigningModerator(userId)
     try {
       await assignModerator(session.id, userId)
+      toast.success('Moderator assigned')
       router.refresh()
     } catch (err) {
       console.error('Failed to assign moderator:', err)
+      toast.error('Failed to assign moderator')
+    } finally {
+      setIsAssigningModerator(null)
     }
   }
 
   async function handleNextTurn() {
+    setIsAdvancingTurn(true)
     try {
       await debate.nextTurn()
+      toast.success('Turn advanced')
     } catch (err) {
       console.error('Failed to advance turn:', err)
+      toast.error('Failed to advance turn')
+    } finally {
+      setIsAdvancingTurn(false)
+    }
+  }
+
+  async function handleExtendTurn() {
+    setIsExtendingTurn(true)
+    try {
+      await extendTurn(session.id, 30)
+      toast.success('Turn extended by 30s')
+    } catch (err) {
+      console.error('Failed to extend turn:', err)
+      toast.error('Failed to extend turn')
+    } finally {
+      setIsExtendingTurn(false)
     }
   }
 
   async function handleKick(userId: string) {
+    setIsKicking(userId)
     try {
       await kickParticipant(session.id, userId)
+      toast.success('Participant removed')
       router.refresh()
     } catch (err) {
       console.error('Failed to kick participant:', err)
+      toast.error('Failed to remove participant')
+    } finally {
+      setIsKicking(null)
+    }
+  }
+
+  async function handlePromote(userId: string) {
+    setIsPromoting(userId)
+    try {
+      await promoteToDebater(session.id, userId)
+      toast.success('Participant promoted to debater')
+      router.refresh()
+    } catch (err) {
+      console.error('Failed to promote participant:', err)
+      toast.error('Failed to promote participant')
+    } finally {
+      setIsPromoting(null)
+    }
+  }
+
+  // Confirmation dialog handler
+  async function handleConfirmAction() {
+    if (!confirmDialog) return
+    const { type, targetUserId } = confirmDialog
+    setConfirmDialog(null)
+
+    switch (type) {
+      case 'kick':
+        if (targetUserId) await handleKick(targetUserId)
+        break
+      case 'end':
+        await handleEndSession()
+        break
+      case 'moderator':
+        if (targetUserId) await handleAssignModerator(targetUserId)
+        break
+      case 'promote':
+        if (targetUserId) await handlePromote(targetUserId)
+        break
     }
   }
 
@@ -325,6 +431,34 @@ export default function RoomClient({
     : displayTime <= 30
     ? 'text-orange-400'
     : 'text-white'
+
+  // Confirm dialog config
+  const confirmDialogConfig = confirmDialog ? {
+    kick: {
+      title: 'KICK PARTICIPANT',
+      description: `Remove ${confirmDialog.targetName} from this session? They can rejoin if the room is still open.`,
+      confirmLabel: 'KICK',
+      variant: 'destructive' as const,
+    },
+    end: {
+      title: 'END SESSION',
+      description: 'End the debate for all participants? This action cannot be undone.',
+      confirmLabel: 'END SESSION',
+      variant: 'destructive' as const,
+    },
+    moderator: {
+      title: 'ASSIGN MODERATOR',
+      description: `Promote ${confirmDialog.targetName} to moderator? The current moderator will be demoted to audience.`,
+      confirmLabel: 'PROMOTE',
+      variant: 'default' as const,
+    },
+    promote: {
+      title: 'PROMOTE TO DEBATER',
+      description: `Promote ${confirmDialog.targetName} from audience to debater?`,
+      confirmLabel: 'PROMOTE',
+      variant: 'default' as const,
+    },
+  }[confirmDialog.type] : null
 
   return (
     <div className="min-h-screen debate-container bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 dark">
@@ -418,9 +552,16 @@ export default function RoomClient({
                             <Button
                               className="debate-button bg-red-600 text-white border-red-700"
                               onClick={handleStartSession}
-                              disabled={!canStartDebate}
+                              disabled={!canStartDebate || isStarting}
                             >
-                              START DEBATE
+                              {isStarting ? (
+                                <>
+                                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                  STARTING...
+                                </>
+                              ) : (
+                                'START DEBATE'
+                              )}
                             </Button>
                           )}
                         </div>
@@ -505,7 +646,16 @@ export default function RoomClient({
                                 <div className="min-h-[250px] bg-gradient-to-br from-gray-900 to-gray-700 rounded-md border-2 border-red-600/50 flex items-center justify-center">
                                   <div className="text-center">
                                     <VideoOff className="w-10 h-10 text-red-400/60 mx-auto mb-2" />
-                                    <p className="text-red-400/60 debate-mono text-sm">VIDEO CONNECTION FAILED</p>
+                                    <p className="text-red-400/60 debate-mono text-sm mb-3">VIDEO CONNECTION FAILED</p>
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      className="debate-button"
+                                      onClick={reconnectSfu}
+                                    >
+                                      <RefreshCw className="w-4 h-4 mr-2" />
+                                      RETRY CONNECTION
+                                    </Button>
                                   </div>
                                 </div>
                               ) : connectionState === 'connected' ? (
@@ -702,8 +852,15 @@ export default function RoomClient({
                         size="sm"
                         onClick={handleTogglePause}
                         className="debate-button col-span-2"
+                        disabled={isPauseToggling}
                       >
-                        {isPaused ? <Play className="w-4 h-4 mr-2" /> : <Pause className="w-4 h-4 mr-2" />}
+                        {isPauseToggling ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : isPaused ? (
+                          <Play className="w-4 h-4 mr-2" />
+                        ) : (
+                          <Pause className="w-4 h-4 mr-2" />
+                        )}
                         {isPaused ? 'RESUME' : 'PAUSE'}
                       </Button>
                       <Button
@@ -711,16 +868,39 @@ export default function RoomClient({
                         size="sm"
                         className="debate-button"
                         onClick={handleNextTurn}
+                        disabled={isAdvancingTurn}
                       >
-                        <SkipForward className="w-4 h-4 mr-1" />
+                        {isAdvancingTurn ? (
+                          <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                        ) : (
+                          <SkipForward className="w-4 h-4 mr-1" />
+                        )}
                         NEXT
                       </Button>
                       <Button
                         variant="outline"
                         size="sm"
                         className="debate-button"
-                        onClick={handleEndSession}
+                        onClick={handleExtendTurn}
+                        disabled={isExtendingTurn}
                       >
+                        {isExtendingTurn ? (
+                          <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                        ) : (
+                          <Timer className="w-4 h-4 mr-1" />
+                        )}
+                        +30s
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="debate-button col-span-2"
+                        onClick={() => setConfirmDialog({ type: 'end' })}
+                        disabled={isEnding}
+                      >
+                        {isEnding ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : null}
                         END
                       </Button>
                     </div>
@@ -737,8 +917,19 @@ export default function RoomClient({
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="p-4 h-64 overflow-y-auto">
-                  <div className="h-full flex items-center justify-center">
-                    <p className="text-gray-500 debate-mono text-sm">Transcript will appear here during the debate</p>
+                  <div className="h-full flex flex-col items-center justify-center space-y-3">
+                    <div className="w-12 h-12 border-2 border-dashed border-white/20 flex items-center justify-center">
+                      <MessageSquare className="w-6 h-6 text-white/20" />
+                    </div>
+                    <div className="text-center">
+                      <p className="text-white/40 debate-title text-sm mb-1">COMING SOON</p>
+                      <p className="text-gray-500 debate-mono text-xs max-w-[200px]">
+                        Live transcription will be available in a future update
+                      </p>
+                    </div>
+                    <span className="debate-badge bg-gray-800 text-gray-400 text-[10px]">
+                      PLANNED FEATURE
+                    </span>
                   </div>
                 </CardContent>
               </Card>
@@ -765,26 +956,64 @@ export default function RoomClient({
                             {displayName(person.user)}
                           </span>
                         </div>
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-1">
                           <span className="text-xs debate-mono text-gray-400">
                             {person.sessionRole}
                           </span>
-                          {isHost && person.userId !== currentUserId && person.sessionRole !== SessionRole.MODERATOR && (
+                          {/* Promote audience to debater (WAITING only) */}
+                          {isModeratorOrCreator && person.userId !== currentUserId && person.sessionRole === SessionRole.AUDIENCE && session.status === SessionStatus.WAITING && canJoinAsDebater && (
                             <button
-                              onClick={() => handleAssignModerator(person.userId)}
-                              className="text-blue-400 hover:text-blue-300 text-xs opacity-60 hover:opacity-100"
-                              title="Assign as moderator"
+                              onClick={() => setConfirmDialog({ type: 'promote', targetUserId: person.userId, targetName: displayName(person.user) })}
+                              className="text-green-400 hover:text-green-300 text-xs opacity-60 hover:opacity-100"
+                              title="Promote to debater"
+                              disabled={isPromoting === person.userId}
                             >
-                              MOD
+                              {isPromoting === person.userId ? (
+                                <Loader2 className="w-3 h-3 animate-spin" />
+                              ) : (
+                                <ArrowUp className="w-3 h-3" />
+                              )}
                             </button>
                           )}
+                          {/* Mute stub for debaters */}
+                          {isModeratorOrCreator && person.userId !== currentUserId && (person.sessionRole === SessionRole.DEBATER || person.sessionRole === SessionRole.HOST) && session.status !== SessionStatus.WAITING && (
+                            <button
+                              onClick={() => toast.info('Remote mute is not yet supported. Ask the participant to mute themselves.')}
+                              className="text-yellow-400 hover:text-yellow-300 text-xs opacity-60 hover:opacity-100"
+                              title="Mute participant (coming soon)"
+                            >
+                              {/* TODO: Implement server-side mute via SFU pauseProducer */}
+                              <MicOff className="w-3 h-3" />
+                            </button>
+                          )}
+                          {/* Assign moderator */}
+                          {isHost && person.userId !== currentUserId && person.sessionRole !== SessionRole.MODERATOR && (
+                            <button
+                              onClick={() => setConfirmDialog({ type: 'moderator', targetUserId: person.userId, targetName: displayName(person.user) })}
+                              className="text-blue-400 hover:text-blue-300 text-xs opacity-60 hover:opacity-100"
+                              title="Assign as moderator"
+                              disabled={isAssigningModerator === person.userId}
+                            >
+                              {isAssigningModerator === person.userId ? (
+                                <Loader2 className="w-3 h-3 animate-spin" />
+                              ) : (
+                                'MOD'
+                              )}
+                            </button>
+                          )}
+                          {/* Kick participant */}
                           {isModeratorOrCreator && person.userId !== currentUserId && (
                             <button
-                              onClick={() => handleKick(person.userId)}
+                              onClick={() => setConfirmDialog({ type: 'kick', targetUserId: person.userId, targetName: displayName(person.user) })}
                               className="text-red-400 hover:text-red-300 text-xs ml-1 opacity-60 hover:opacity-100"
                               title="Kick participant"
+                              disabled={isKicking === person.userId}
                             >
-                              ✕
+                              {isKicking === person.userId ? (
+                                <Loader2 className="w-3 h-3 animate-spin" />
+                              ) : (
+                                '✕'
+                              )}
                             </button>
                           )}
                         </div>
@@ -797,6 +1026,20 @@ export default function RoomClient({
           </div>
         </div>
       </main>
+
+      {/* Confirmation Dialog */}
+      {confirmDialogConfig && (
+        <ConfirmDialog
+          open={confirmDialog !== null}
+          onOpenChange={(open) => { if (!open) setConfirmDialog(null) }}
+          title={confirmDialogConfig.title}
+          description={confirmDialogConfig.description}
+          confirmLabel={confirmDialogConfig.confirmLabel}
+          variant={confirmDialogConfig.variant}
+          loading={isEnding || isKicking !== null || isAssigningModerator !== null || isPromoting !== null}
+          onConfirm={handleConfirmAction}
+        />
+      )}
     </div>
   )
 }

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import * as Dialog from '@radix-ui/react-dialog'
+import { Button } from '@/components/ui/button'
+import { Loader2, X } from 'lucide-react'
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'default' | 'destructive'
+  loading?: boolean
+  onConfirm: () => void | Promise<void>
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'CONFIRM',
+  cancelLabel = 'CANCEL',
+  variant = 'default',
+  loading = false,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 border-2 border-white/20 bg-gray-900 p-6 shadow-[6px_6px_0px_rgba(0,0,0,0.3)]">
+          <div className="flex items-center justify-between mb-4">
+            <Dialog.Title className="text-lg font-bold debate-title text-white">
+              {title}
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button className="text-gray-400 hover:text-white transition-colors">
+                <X className="w-5 h-5" />
+              </button>
+            </Dialog.Close>
+          </div>
+          <Dialog.Description className="text-gray-400 debate-mono text-sm mb-6">
+            {description}
+          </Dialog.Description>
+          <div className="flex justify-end gap-3">
+            <Dialog.Close asChild>
+              <Button variant="outline" size="sm" className="debate-button" disabled={loading}>
+                {cancelLabel}
+              </Button>
+            </Dialog.Close>
+            <Button
+              variant={variant === 'destructive' ? 'destructive' : 'default'}
+              size="sm"
+              className="debate-button"
+              onClick={onConfirm}
+              disabled={loading}
+            >
+              {loading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              {confirmLabel}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { Toaster as Sonner } from 'sonner'
+
+export function Toaster() {
+  return (
+    <Sonner
+      position="bottom-right"
+      theme="dark"
+      toastOptions={{
+        className: 'debate-mono',
+        style: {
+          background: 'rgb(17 24 39)',
+          border: '2px solid rgba(255,255,255,0.2)',
+          boxShadow: '4px 4px 0px rgba(0,0,0,0.3)',
+          color: 'white',
+        },
+      }}
+    />
+  )
+}

--- a/hooks/useMediasoup.ts
+++ b/hooks/useMediasoup.ts
@@ -26,6 +26,7 @@ interface UseMediasoupReturn {
   toggleMute: () => void
   toggleVideo: () => void
   disconnect: () => void
+  reconnect: () => void
 }
 
 // Socket.io emit with ack helper
@@ -52,6 +53,7 @@ export function useMediasoup({
   const [remoteStreams, setRemoteStreams] = useState<Map<string, RemoteStream>>(new Map())
   const [audioMuted, setAudioMuted] = useState(false)
   const [videoOff, setVideoOff] = useState(false)
+  const [reconnectTrigger, setReconnectTrigger] = useState(0)
 
   const socketRef = useRef<any>(null)
   const deviceRef = useRef<any>(null)
@@ -132,6 +134,12 @@ export function useMediasoup({
       setVideoOff((prev) => !prev)
     }
   }, [])
+
+  const reconnect = useCallback(() => {
+    cleanup()
+    cleanedUpRef.current = false
+    setReconnectTrigger((n) => n + 1)
+  }, [cleanup])
 
   useEffect(() => {
     if (!enabled || !sfuUrl || !roomId || !displayName) {
@@ -231,6 +239,16 @@ export function useMediasoup({
             localStreamRef.current = stream
             setLocalStream(stream)
 
+            // Start 15s timeout after getUserMedia (not before, since permission dialog can take arbitrarily long)
+            const connectionTimeout = setTimeout(() => {
+              if (!cancelled) {
+                console.error('SFU connection timed out after 15s')
+                cleanup()
+                cleanedUpRef.current = false
+                setConnectionState('error')
+              }
+            }, 15000)
+
             const videoTrack = stream.getVideoTracks()[0]
             if (videoTrack) {
               const videoProducer = await sendTransport.produce({ track: videoTrack })
@@ -249,6 +267,7 @@ export function useMediasoup({
               await consumeProducer(socket, recvTransport, p.producerId)
             }
 
+            clearTimeout(connectionTimeout)
             setConnectionState('connected')
           } catch (err: any) {
             console.error('SFU setup error:', err)
@@ -355,7 +374,7 @@ export function useMediasoup({
       cancelled = true
       cleanup()
     }
-  }, [enabled, sfuUrl, roomId, displayName, cleanup])
+  }, [enabled, sfuUrl, roomId, displayName, cleanup, reconnectTrigger])
 
   return {
     connectionState,
@@ -366,5 +385,6 @@ export function useMediasoup({
     toggleMute,
     toggleVideo,
     disconnect,
+    reconnect,
   }
 }

--- a/lib/actions/debate.ts
+++ b/lib/actions/debate.ts
@@ -163,6 +163,32 @@ export async function resumeDebate(sessionId: string) {
   })
 }
 
+export async function extendTurn(sessionId: string, extraSeconds: number) {
+  await requireModerator(sessionId)
+
+  const state = await prisma.debateState.findUnique({
+    where: { session_id: sessionId },
+  })
+  if (!state) throw new Error("No active debate")
+
+  if (state.is_paused) {
+    await prisma.debateState.update({
+      where: { session_id: sessionId },
+      data: {
+        paused_time_remaining: state.paused_time_remaining + extraSeconds,
+      },
+    })
+  } else {
+    if (!state.turn_ends_at) throw new Error("No active turn")
+    await prisma.debateState.update({
+      where: { session_id: sessionId },
+      data: {
+        turn_ends_at: state.turn_ends_at + extraSeconds * 1000,
+      },
+    })
+  }
+}
+
 export async function endDebate(sessionId: string) {
   await requireModerator(sessionId)
   await prisma.debateState

--- a/lib/actions/session.ts
+++ b/lib/actions/session.ts
@@ -367,6 +367,35 @@ export async function kickParticipant(sessionId: string, targetUserId: string) {
   })
 }
 
+export async function promoteToDebater(sessionId: string, targetUserId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { host_id: true, moderator_id: true, status: true },
+  })
+  if (!session) throw new Error("Session not found")
+  if (session.host_id !== user.id && session.moderator_id !== user.id) {
+    throw new Error("Only moderators or hosts can promote participants")
+  }
+  if (session.status !== SessionStatus.WAITING) {
+    throw new Error("Can only promote participants before the debate starts")
+  }
+  if (targetUserId === user.id) throw new Error("Cannot promote yourself")
+
+  await prisma.participatesIn.update({
+    where: {
+      user_id_session_id: {
+        user_id: targetUserId,
+        session_id: sessionId,
+      },
+    },
+    data: { session_role: SessionRole.DEBATER },
+  })
+}
+
 export async function updateSessionStatus(sessionId: string, status: SessionStatus) {
     
     const supabase = await createClient()

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -168,6 +169,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -532,6 +534,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -580,6 +583,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -589,7 +593,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -2104,6 +2109,7 @@
       "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.1"
       },
@@ -4134,6 +4140,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.93.3.tgz",
       "integrity": "sha512-paUqEqdBI9ztr/4bbMoCgeJ6M8ZTm2fpfjSOlzarPuzYveKFM20ZfDZqUpi9CFfYagYj5Iv3m3ztUjaI9/tM1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.93.3",
         "@supabase/functions-js": "2.93.3",
@@ -4431,7 +4438,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4452,7 +4458,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4501,8 +4506,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -4578,6 +4582,7 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4588,6 +4593,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4646,6 +4652,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -5319,6 +5326,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5740,6 +5748,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6301,7 +6310,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6347,8 +6355,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -6798,6 +6805,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6983,6 +6991,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7920,6 +7929,7 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9127,7 +9137,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9853,6 +9862,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -10117,7 +10127,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10133,7 +10142,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10144,7 +10152,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10157,8 +10164,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prisma": {
       "version": "7.3.0",
@@ -10167,6 +10173,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.3.0",
         "@prisma/dev": "0.20.0",
@@ -10289,6 +10296,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10298,6 +10306,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11011,6 +11020,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -11513,6 +11532,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11751,6 +11771,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11977,6 +11998,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -12082,6 +12104,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -12524,6 +12547,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['__tests__/**/*.test.ts'],
+    include: ['__tests__/**/*.test.{ts,tsx}'],
     exclude: ['tests/**', 'node_modules/**', '__tests__/sfu/**'],
   },
   resolve: {


### PR DESCRIPTION
## Summary
Closes #18

- Add **sonner toast notifications** (success/error) for all async operations — no more silent failures
- Add **confirmation dialogs** for destructive actions: kick, end session, assign moderator, promote to debater
- Add **loading spinners** for every async button (start, pause, next, extend, end, kick, promote, assign mod)
- **Fix `isPaused` stale state bug** — replaced local state with `debate.isPaused` from Supabase Realtime
- Add moderator controls: **extend turn (+30s)**, **promote audience to debater** (WAITING only), **mute stub** with info toast
- Add **WebRTC retry button** on connection failure + **15s connection timeout** (after getUserMedia)
- Improve **transcript panel** with clear "COMING SOON" / "PLANNED FEATURE" design
- New server actions: `promoteToDebater()`, `extendTurn()` (handles both paused and live states)

## Test plan
- [x] All 120 unit tests pass (`npx vitest run`)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] ESLint clean on all changed files
- [x] 8 new tests for `promoteToDebater` (auth, authorization, status restrictions)
- [x] 7 new tests for `extendTurn` (live/paused state handling, edge cases)
- [x] 8 new tests for `ConfirmDialog` component (render, labels, loading, callbacks)