### PR TITLE
fix: address security vulnerabilities

### DIFF
--- a/__tests__/debate.test.ts
+++ b/__tests__/debate.test.ts
@@ -14,6 +14,10 @@ vi.mock('@/lib/prisma', () => ({
       updateMany: vi.fn(),
       delete: vi.fn(),
     },
+    participatesIn: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
   },
 }))
 
@@ -58,7 +62,10 @@ const debaters = [
 
 // ── getDebateState ──
 describe('getDebateState', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth('any-user')
+  })
 
   it('returns null when no state exists', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue(null)
@@ -90,6 +97,11 @@ describe('startDebate', () => {
     mockAuth(MOCK_HOST_ID)
     mockSession()
     ;(prisma.debateState.upsert as any).mockResolvedValue({})
+    // Mock: both debaters are active participants
+    ;(prisma.participatesIn.findMany as any).mockResolvedValue([
+      { user_id: 'u1' },
+      { user_id: 'u2' },
+    ])
   })
 
   it('throws if not authenticated', async () => {
@@ -179,6 +191,12 @@ describe('advanceTurnIfExpired', () => {
     vi.clearAllMocks()
     mockAuth('any-user')
     ;(prisma.debateState.updateMany as any).mockResolvedValue({ count: 1 })
+    // Mock: user is an active participant
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: 'any-user',
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
   })
 
   it('does nothing if unauthenticated', async () => {
@@ -314,5 +332,125 @@ describe('endDebate', () => {
   it('does not throw if debate state already gone', async () => {
     ;(prisma.debateState.delete as any).mockRejectedValue(new Error('not found'))
     await expect(endDebate(MOCK_SESSION_ID)).resolves.not.toThrow()
+  })
+})
+
+// ── Security: getDebateState auth check ──
+describe('getDebateState — security', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(getDebateState(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns state when authenticated', async () => {
+    mockAuth('any-user')
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      session_id: MOCK_SESSION_ID,
+      debater_order: debaters,
+      current_index: 0,
+      turn_length: 120,
+      turn_ends_at: 9999999,
+      is_paused: false,
+      paused_time_remaining: 0,
+    })
+    const result = await getDebateState(MOCK_SESSION_ID)
+    expect(result).not.toBeNull()
+    expect(result?.session_id).toBe(MOCK_SESSION_ID)
+  })
+})
+
+// ── Security: startDebate input validation ──
+describe('startDebate — security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_HOST_ID)
+    mockSession()
+    ;(prisma.debateState.upsert as any).mockResolvedValue({})
+    // Mock participants found for debater IDs
+    ;(prisma.participatesIn.findMany as any).mockResolvedValue([
+      { user_id: 'u1' },
+      { user_id: 'u2' },
+    ])
+  })
+
+  it('throws if turnLength is less than 1', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 0)).rejects.toThrow(
+      'Turn length must be at least 1 second'
+    )
+  })
+
+  it('throws if turnLength exceeds 1800', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 1801)).rejects.toThrow(
+      'Turn length cannot exceed 30 minutes'
+    )
+  })
+
+  it('allows turnLength of exactly 1', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 1)).resolves.not.toThrow()
+  })
+
+  it('allows turnLength of exactly 1800', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 1800)).resolves.not.toThrow()
+  })
+
+  it('throws if debater IDs are not active participants', async () => {
+    ;(prisma.participatesIn.findMany as any).mockResolvedValue([
+      { user_id: 'u1' },
+      // u2 is missing — not a participant
+    ])
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 120)).rejects.toThrow(
+      'is not an active participant'
+    )
+  })
+
+  it('succeeds when both debaters are active participants', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 120)).resolves.not.toThrow()
+    expect(prisma.debateState.upsert).toHaveBeenCalled()
+  })
+})
+
+// ── Security: advanceTurnIfExpired participant check ──
+describe('advanceTurnIfExpired — security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth('any-user')
+    ;(prisma.debateState.updateMany as any).mockResolvedValue({ count: 1 })
+  })
+
+  it('does nothing if user is not a participant', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false, turn_ends_at: Date.now() - 2000, current_index: 0, turn_length: 60,
+    })
+    await advanceTurnIfExpired(MOCK_SESSION_ID)
+    expect(prisma.debateState.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('does nothing if user has left the session', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: 'any-user',
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false, turn_ends_at: Date.now() - 2000, current_index: 0, turn_length: 60,
+    })
+    await advanceTurnIfExpired(MOCK_SESSION_ID)
+    expect(prisma.debateState.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('advances turn when user is active participant and turn expired', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: 'any-user',
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false, turn_ends_at: Date.now() - 2000, current_index: 0, turn_length: 60,
+    })
+    await advanceTurnIfExpired(MOCK_SESSION_ID)
+    expect(prisma.debateState.updateMany).toHaveBeenCalled()
   })
 })

--- a/__tests__/hooks/useMediasoup.test.ts
+++ b/__tests__/hooks/useMediasoup.test.ts
@@ -43,6 +43,18 @@ vi.mock('mediasoup-client', () => ({
   Device: vi.fn(() => mockDevice),
 }))
 
+// ── Mock Supabase client (for auth token) ──
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: { access_token: 'mock-jwt-token' } },
+      }),
+    },
+  })),
+}))
+
 // ── Mock getUserMedia ──
 
 const mockVideoTrack = {

--- a/__tests__/security/auth.test.ts
+++ b/__tests__/security/auth.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SignJWT } from 'jose'
+
+const TEST_SECRET = 'test-jwt-secret-that-is-long-enough'
+const SECRET_KEY = new TextEncoder().encode(TEST_SECRET)
+
+async function createValidToken(sub = 'user-123') {
+  return new SignJWT({ sub })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime('1h')
+    .sign(SECRET_KEY)
+}
+
+async function createExpiredToken() {
+  return new SignJWT({ sub: 'user-123' })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime('-1h')
+    .sign(SECRET_KEY)
+}
+
+async function createTokenWithoutSub() {
+  return new SignJWT({})
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime('1h')
+    .sign(SECRET_KEY)
+}
+
+function createMockSocket(token?: string) {
+  return {
+    handshake: {
+      auth: token !== undefined ? { token } : {},
+    },
+    data: {} as Record<string, unknown>,
+  }
+}
+
+describe('createAuthMiddleware', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('skips auth when SUPABASE_JWT_SECRET is not set (dev mode)', async () => {
+    delete process.env.SUPABASE_JWT_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const socket = createMockSocket()
+    const next = vi.fn()
+
+    middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects connection when no token is provided', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const socket = createMockSocket()
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Authentication required')
+  })
+
+  it('accepts connection with valid token and attaches userId', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const token = await createValidToken('user-456')
+    const socket = createMockSocket(token)
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(socket.data.userId).toBe('user-456')
+  })
+
+  it('rejects connection with expired token', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const token = await createExpiredToken()
+    const socket = createMockSocket(token)
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Invalid or expired token')
+  })
+
+  it('rejects connection with invalid token', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const socket = createMockSocket('garbage-token')
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Invalid or expired token')
+  })
+
+  it('rejects connection with token signed by wrong secret', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const wrongKey = new TextEncoder().encode('wrong-secret-key-long-enough-here')
+    const wrongToken = await new SignJWT({ sub: 'user-123' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setExpirationTime('1h')
+      .sign(wrongKey)
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const socket = createMockSocket(wrongToken)
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Invalid or expired token')
+  })
+
+  it('rejects token without sub claim', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const token = await createTokenWithoutSub()
+    const socket = createMockSocket(token)
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Invalid token: missing sub claim')
+  })
+
+  it('exits process in production when SUPABASE_JWT_SECRET is not set', async () => {
+    process.env.NODE_ENV = 'production'
+    delete process.env.SUPABASE_JWT_SECRET
+
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    createAuthMiddleware()
+
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
+  })
+})

--- a/__tests__/security/path-traversal.test.ts
+++ b/__tests__/security/path-traversal.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import path from 'node:path'
+
+/**
+ * Tests for the path traversal protection logic used in realtime/src/index.ts.
+ * We test the pure logic here rather than spinning up the HTTP server.
+ */
+
+const testClientDir = '/app/test-client'
+
+function isPathSafe(requestUrl: string): { safe: boolean; resolvedPath?: string; error?: string } {
+  let decodedUrl: string
+  try {
+    decodedUrl = decodeURIComponent(requestUrl)
+  } catch {
+    return { safe: false, error: 'bad-request' }
+  }
+
+  const requestedPath = decodedUrl === '/' ? '/index.html' : decodedUrl
+  const resolvedPath = path.resolve(testClientDir, '.' + requestedPath)
+
+  if (resolvedPath !== testClientDir && !resolvedPath.startsWith(testClientDir + path.sep)) {
+    return { safe: false, error: 'forbidden' }
+  }
+
+  return { safe: true, resolvedPath }
+}
+
+describe('Path traversal protection', () => {
+  it('allows root path', () => {
+    const result = isPathSafe('/')
+    expect(result.safe).toBe(true)
+    expect(result.resolvedPath).toBe(path.join(testClientDir, 'index.html'))
+  })
+
+  it('allows normal file paths', () => {
+    const result = isPathSafe('/client.js')
+    expect(result.safe).toBe(true)
+    expect(result.resolvedPath).toBe(path.join(testClientDir, 'client.js'))
+  })
+
+  it('allows nested file paths', () => {
+    const result = isPathSafe('/css/style.css')
+    expect(result.safe).toBe(true)
+    expect(result.resolvedPath).toBe(path.join(testClientDir, 'css', 'style.css'))
+  })
+
+  it('blocks basic directory traversal', () => {
+    const result = isPathSafe('/../../../etc/passwd')
+    expect(result.safe).toBe(false)
+    expect(result.error).toBe('forbidden')
+  })
+
+  it('blocks URL-encoded directory traversal (%2e%2e)', () => {
+    const result = isPathSafe('/%2e%2e/%2e%2e/%2e%2e/etc/passwd')
+    expect(result.safe).toBe(false)
+    expect(result.error).toBe('forbidden')
+  })
+
+  it('blocks double-encoded traversal', () => {
+    // %252e decodes to %2e on first pass, which would decode to . on second
+    // But decodeURIComponent only decodes once, so %252e → %2e
+    // path.resolve would treat %2e as literal characters, not dots
+    // This should still be safe as the resolved path would contain literal %2e
+    const result = isPathSafe('/%252e%252e/%252e%252e/etc/passwd')
+    expect(result.safe).toBe(true) // %2e is literal, stays in testClientDir
+  })
+
+  it('blocks traversal with backslashes (Windows-style)', () => {
+    const result = isPathSafe('/..\\..\\..\\etc\\passwd')
+    // On POSIX, backslashes are literal chars — not path separators
+    // The resolved path stays within testClientDir on POSIX
+    // On Windows, path.resolve treats them as separators, so this would be blocked
+    if (process.platform === 'win32') {
+      expect(result.safe).toBe(false)
+    } else {
+      // On POSIX, backslash is a valid filename char — path stays within dir
+      expect(result.safe).toBe(true)
+    }
+  })
+
+  it('blocks traversal to parent directory', () => {
+    const result = isPathSafe('/..')
+    expect(result.safe).toBe(false)
+    expect(result.error).toBe('forbidden')
+  })
+
+  it('returns bad-request for malformed URL encoding', () => {
+    const result = isPathSafe('/%ZZ')
+    expect(result.safe).toBe(false)
+    expect(result.error).toBe('bad-request')
+  })
+
+  it('allows file with dots in name', () => {
+    const result = isPathSafe('/bundle.min.js')
+    expect(result.safe).toBe(true)
+  })
+})

--- a/__tests__/security/validation.test.ts
+++ b/__tests__/security/validation.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest'
+import { schemas, validatePayload } from '../../realtime/src/validation'
+
+// ── validatePayload helper ──
+describe('validatePayload', () => {
+  it('returns success with parsed data for valid input', () => {
+    const result = validatePayload(schemas.getRouterRtpCapabilities, { roomId: 'room-1' })
+    expect(result).toEqual({ success: true, data: { roomId: 'room-1' } })
+  })
+
+  it('returns error string for invalid input', () => {
+    const result = validatePayload(schemas.getRouterRtpCapabilities, {})
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('Invalid payload')
+    }
+  })
+
+  it('returns error for completely wrong type', () => {
+    const result = validatePayload(schemas.getRouterRtpCapabilities, 'not-an-object')
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── getRouterRtpCapabilities schema ──
+describe('schemas.getRouterRtpCapabilities', () => {
+  it('accepts valid roomId', () => {
+    const result = schemas.getRouterRtpCapabilities.safeParse({ roomId: 'room-123' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing roomId', () => {
+    const result = schemas.getRouterRtpCapabilities.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty roomId', () => {
+    const result = schemas.getRouterRtpCapabilities.safeParse({ roomId: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects roomId exceeding 100 chars', () => {
+    const result = schemas.getRouterRtpCapabilities.safeParse({ roomId: 'a'.repeat(101) })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── joinRoom schema ──
+describe('schemas.joinRoom', () => {
+  const validPayload = {
+    roomId: 'room-1',
+    displayName: 'Alice',
+    rtpCapabilities: { codecs: [] },
+  }
+
+  it('accepts valid payload', () => {
+    const result = schemas.joinRoom.safeParse(validPayload)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing displayName', () => {
+    const result = schemas.joinRoom.safeParse({ roomId: 'room-1', rtpCapabilities: {} })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects displayName exceeding 50 chars', () => {
+    const result = schemas.joinRoom.safeParse({
+      ...validPayload,
+      displayName: 'a'.repeat(51),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing rtpCapabilities', () => {
+    const result = schemas.joinRoom.safeParse({ roomId: 'room-1', displayName: 'Alice' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── createWebRtcTransport schema ──
+describe('schemas.createWebRtcTransport', () => {
+  it('accepts "send" direction', () => {
+    const result = schemas.createWebRtcTransport.safeParse({ direction: 'send' })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts "recv" direction', () => {
+    const result = schemas.createWebRtcTransport.safeParse({ direction: 'recv' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid direction', () => {
+    const result = schemas.createWebRtcTransport.safeParse({ direction: 'both' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing direction', () => {
+    const result = schemas.createWebRtcTransport.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── connectTransport schema ──
+describe('schemas.connectTransport', () => {
+  it('accepts valid payload', () => {
+    const result = schemas.connectTransport.safeParse({
+      transportId: 'transport-1',
+      dtlsParameters: { fingerprints: [] },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing transportId', () => {
+    const result = schemas.connectTransport.safeParse({ dtlsParameters: {} })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing dtlsParameters', () => {
+    const result = schemas.connectTransport.safeParse({ transportId: 'transport-1' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── produce schema ──
+describe('schemas.produce', () => {
+  const validPayload = {
+    transportId: 'transport-1',
+    kind: 'audio' as const,
+    rtpParameters: { codecs: [] },
+  }
+
+  it('accepts valid payload with audio kind', () => {
+    const result = schemas.produce.safeParse(validPayload)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts valid payload with video kind', () => {
+    const result = schemas.produce.safeParse({ ...validPayload, kind: 'video' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid kind', () => {
+    const result = schemas.produce.safeParse({ ...validPayload, kind: 'data' })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts optional appData', () => {
+    const result = schemas.produce.safeParse({ ...validPayload, appData: { source: 'webcam' } })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing rtpParameters', () => {
+    const result = schemas.produce.safeParse({ transportId: 'transport-1', kind: 'audio' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── consume schema ──
+describe('schemas.consume', () => {
+  it('accepts valid producerId', () => {
+    const result = schemas.consume.safeParse({ producerId: 'prod-1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing producerId', () => {
+    const result = schemas.consume.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty producerId', () => {
+    const result = schemas.consume.safeParse({ producerId: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── resumeConsumer schema ──
+describe('schemas.resumeConsumer', () => {
+  it('accepts valid consumerId', () => {
+    const result = schemas.resumeConsumer.safeParse({ consumerId: 'cons-1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing consumerId', () => {
+    const result = schemas.resumeConsumer.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── closeProducer schema ──
+describe('schemas.closeProducer', () => {
+  it('accepts valid producerId', () => {
+    const result = schemas.closeProducer.safeParse({ producerId: 'prod-1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing producerId', () => {
+    const result = schemas.closeProducer.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── getProducers schema ──
+describe('schemas.getProducers', () => {
+  it('accepts any data (no strict schema)', () => {
+    const result = schemas.getProducers.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts undefined', () => {
+    const result = schemas.getProducers.safeParse(undefined)
+    expect(result.success).toBe(true)
+  })
+})

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -22,7 +22,9 @@ vi.mock('@/lib/prisma', () => ({
       create: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
+    $transaction: vi.fn(),
   },
 }))
 
@@ -35,6 +37,8 @@ import {
   joinSessionAsDebater,
   leaveSession,
   updateSessionStatus,
+  assignModerator,
+  kickParticipant,
 } from '@/lib/actions/session'
 
 // Helper to set up auth mock
@@ -432,5 +436,126 @@ describe('updateSessionStatus', () => {
     expect(call.data.status).toBe(SessionStatus.ENDED)
     expect(call.data.ended_at).toBeInstanceOf(Date)
     expect(call.data.ended_at.getTime()).toBeGreaterThanOrEqual(before)
+  })
+})
+
+// ── Security: Input bounds validation ──
+describe('createSession — security bounds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    ;(prisma.session.create as any).mockResolvedValue({ id: MOCK_SESSION_ID, code: 'ARG-1234' })
+  })
+
+  it('throws if audienceCapacity exceeds 1000', async () => {
+    await expect(createSession(sessionForm({ audienceCapacity: 1001 }) as any)).rejects.toThrow(
+      'Audience capacity cannot exceed 1000'
+    )
+  })
+
+  it('allows audienceCapacity of exactly 1000', async () => {
+    await expect(createSession(sessionForm({ audienceCapacity: 1000 }) as any)).resolves.not.toThrow()
+  })
+
+  it('throws if turnLength exceeds 1800', async () => {
+    await expect(createSession(sessionForm({ turnLength: 1801 }) as any)).rejects.toThrow(
+      'Turn length cannot exceed 30 minutes'
+    )
+  })
+
+  it('allows turnLength of exactly 1800', async () => {
+    await expect(createSession(sessionForm({ turnLength: 1800 }) as any)).resolves.not.toThrow()
+  })
+})
+
+// ── Security: assignModerator participant check ──
+describe('assignModerator — participant check', () => {
+  const TARGET_USER_ID = 'target-user-id'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    })
+    ;(prisma.$transaction as any).mockResolvedValue([])
+  })
+
+  it('throws if target user is not an active participant', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(assignModerator(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow(
+      'Target user is not an active participant'
+    )
+  })
+
+  it('throws if target user has left the session', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: TARGET_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(assignModerator(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow(
+      'Target user is not an active participant'
+    )
+  })
+
+  it('succeeds when target user is an active participant', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: TARGET_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    await expect(assignModerator(MOCK_SESSION_ID, TARGET_USER_ID)).resolves.not.toThrow()
+  })
+})
+
+// ── Security: kickParticipant participant check ──
+describe('kickParticipant — participant check', () => {
+  const TARGET_USER_ID = 'target-user-id'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    })
+    ;(prisma.participatesIn.update as any).mockResolvedValue({})
+  })
+
+  it('throws if target user is not an active participant', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(kickParticipant(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow(
+      'Target user is not an active participant'
+    )
+  })
+
+  it('throws if target user has already left', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: TARGET_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(kickParticipant(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow(
+      'Target user is not an active participant'
+    )
+  })
+
+  it('kicks active participant successfully', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: TARGET_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    await kickParticipant(MOCK_SESSION_ID, TARGET_USER_ID)
+    expect(prisma.participatesIn.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ left_at: expect.any(Date) }),
+      })
+    )
   })
 })

--- a/hooks/useMediasoup.ts
+++ b/hooks/useMediasoup.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { createClient } from '@/lib/supabase/client'
 
 type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error'
 
@@ -153,7 +154,19 @@ export function useMediasoup({
 
         if (cancelled) return
 
-        const socket = io(sfuUrl!, { transports: ['websocket'] })
+        // Get Supabase auth token for Socket.IO authentication
+        const supabase = createClient()
+        const { data: { session } } = await supabase.auth.getSession()
+        if (!session?.access_token) {
+          console.error('No auth token available — cannot connect to SFU')
+          setConnectionState('error')
+          return
+        }
+
+        const socket = io(sfuUrl!, {
+          transports: ['websocket'],
+          auth: { token: session.access_token },
+        })
         socketRef.current = socket
 
         socket.on('connect', async () => {

--- a/lib/actions/debate.ts
+++ b/lib/actions/debate.ts
@@ -23,6 +23,11 @@ async function requireModerator(sessionId: string) {
 }
 
 export async function getDebateState(sessionId: string) {
+  // Auth check: require authenticated user
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
   })
@@ -48,6 +53,24 @@ export async function startDebate(
 ) {
   await requireModerator(sessionId)
   if (debaters.length !== 2) throw new Error("Exactly 2 debaters required")
+  if (turnLength < 1) throw new Error("Turn length must be at least 1 second")
+  if (turnLength > 1800) throw new Error("Turn length cannot exceed 30 minutes (1800 seconds)")
+
+  // Validate debater IDs are active participants in the session
+  const participants = await prisma.participatesIn.findMany({
+    where: {
+      session_id: sessionId,
+      left_at: null,
+      user_id: { in: debaters.map((d) => d.userId) },
+    },
+    select: { user_id: true },
+  })
+  const participantIds = new Set(participants.map((p: { user_id: string }) => p.user_id))
+  for (const debater of debaters) {
+    if (!participantIds.has(debater.userId)) {
+      throw new Error(`Debater ${debater.userId} is not an active participant in this session`)
+    }
+  }
 
   const now = Date.now()
   await prisma.debateState.upsert({
@@ -98,6 +121,12 @@ export async function advanceTurnIfExpired(sessionId: string) {
     data: { user },
   } = await supabase.auth.getUser()
   if (!user) return
+
+  // Verify user is an active participant in this session
+  const participation = await prisma.participatesIn.findUnique({
+    where: { user_id_session_id: { user_id: user.id, session_id: sessionId } },
+  })
+  if (!participation || participation.left_at !== null) return
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },

--- a/lib/actions/session.ts
+++ b/lib/actions/session.ts
@@ -23,9 +23,11 @@ export async function createSession(formData: {
 
     if (!formData.name.trim()) throw new Error("Room name is required")
 
-    // Validate capacities
+    // Validate capacities and bounds
     if (formData.audienceCapacity < 0) throw new Error("Audience capacity cannot be negative")
+    if (formData.audienceCapacity > 1000) throw new Error("Audience capacity cannot exceed 1000")
     if (formData.turnLength < 1) throw new Error("Turn length must be at least 1 second")
+    if (formData.turnLength > 1800) throw new Error("Turn length cannot exceed 30 minutes (1800 seconds)")
 
     // Panel-specific validation
     if (formData.type === SessionType.PANEL) {
@@ -319,6 +321,14 @@ export async function assignModerator(sessionId: string, targetUserId: string) {
   if (session.host_id !== user.id) throw new Error("Only the host can assign a moderator")
   if (targetUserId === user.id) throw new Error("Host cannot assign themselves as moderator")
 
+  // Verify target is an active participant
+  const targetParticipation = await prisma.participatesIn.findUnique({
+    where: { user_id_session_id: { user_id: targetUserId, session_id: sessionId } },
+  })
+  if (!targetParticipation || targetParticipation.left_at !== null) {
+    throw new Error("Target user is not an active participant in this session")
+  }
+
   // Demote previous moderator back to AUDIENCE (if any)
   if (session.moderator_id && session.moderator_id !== targetUserId) {
     await prisma.participatesIn.updateMany({
@@ -355,6 +365,14 @@ export async function kickParticipant(sessionId: string, targetUserId: string) {
   }
   // Cannot kick yourself
   if (targetUserId === user.id) throw new Error("Cannot kick yourself")
+
+  // Verify target is an active participant
+  const targetParticipation = await prisma.participatesIn.findUnique({
+    where: { user_id_session_id: { user_id: targetUserId, session_id: sessionId } },
+  })
+  if (!targetParticipation || targetParticipation.left_at !== null) {
+    throw new Error("Target user is not an active participant in this session")
+  }
 
   await prisma.participatesIn.update({
     where: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@vitest/coverage-v8": "^2.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "jose": "^6.2.2",
         "jsdom": "^29.0.1",
         "prisma": "^7.3.0",
         "socket.io": "^4.8.3",
@@ -8588,6 +8589,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@vitest/coverage-v8": "^2.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "jose": "^6.2.2",
     "jsdom": "^29.0.1",
     "prisma": "^7.3.0",
     "socket.io": "^4.8.3",

--- a/realtime/.env.example
+++ b/realtime/.env.example
@@ -20,5 +20,9 @@ TURN_PORT=3478
 TURN_USERNAME=arguably
 TURN_PASSWORD=CHANGE_ME_IN_PRODUCTION
 
-# CORS: comma-separated allowed origins (omit for wildcard in dev)
+# CORS: comma-separated allowed origins (required in production, defaults to localhost in dev)
 # ALLOWED_ORIGINS=https://your-app.vercel.app
+
+# Authentication: Supabase JWT secret for Socket.IO auth (required in production)
+# Get this from Supabase dashboard: Settings > API > JWT Secret
+# SUPABASE_JWT_SECRET=your-jwt-secret

--- a/realtime/package-lock.json
+++ b/realtime/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "dotenv": "^16.4.7",
+        "jose": "^6.2.2",
         "mediasoup": "^3.19.0",
-        "socket.io": "^4.8.0"
+        "socket.io": "^4.8.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "^20.17.0",
@@ -762,6 +764,15 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/mediasoup": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/mediasoup/-/mediasoup-3.19.3.tgz",
@@ -1055,6 +1066,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "dotenv": "^16.4.7",
+    "jose": "^6.2.2",
     "mediasoup": "^3.19.0",
-    "socket.io": "^4.8.0"
+    "socket.io": "^4.8.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^20.17.0",

--- a/realtime/src/auth.ts
+++ b/realtime/src/auth.ts
@@ -1,0 +1,51 @@
+import { jwtVerify } from "jose";
+import type { Socket } from "socket.io";
+
+const isProduction = process.env.NODE_ENV === "production";
+
+export function createAuthMiddleware() {
+  const secret = process.env.SUPABASE_JWT_SECRET;
+
+  if (!secret && isProduction) {
+    console.error(
+      "\n[FATAL] SUPABASE_JWT_SECRET is required in production.\n" +
+        "Get it from your Supabase dashboard: Settings > API > JWT Secret.\n",
+    );
+    process.exit(1);
+  }
+
+  if (!secret) {
+    console.warn(
+      "[WARN] SUPABASE_JWT_SECRET not set — Socket.IO auth disabled. " +
+        "Set it for authenticated connections.",
+    );
+    return (_socket: Socket, next: (err?: Error) => void) => {
+      next();
+    };
+  }
+
+  const encodedSecret = new TextEncoder().encode(secret);
+
+  return async (socket: Socket, next: (err?: Error) => void) => {
+    const token = socket.handshake.auth?.token as string | undefined;
+
+    if (!token) {
+      return next(new Error("Authentication required"));
+    }
+
+    try {
+      const { payload } = await jwtVerify(token, encodedSecret, {
+        algorithms: ["HS256"],
+      });
+
+      if (!payload.sub) {
+        return next(new Error("Invalid token: missing sub claim"));
+      }
+
+      socket.data.userId = payload.sub;
+      next();
+    } catch {
+      next(new Error("Invalid or expired token"));
+    }
+  };
+}

--- a/realtime/src/config.ts
+++ b/realtime/src/config.ts
@@ -19,8 +19,25 @@ const RTC_MAX_PORT = parseInt(process.env.RTC_MAX_PORT || "40100", 10);
 
 const TURN_HOST = process.env.TURN_HOST || ANNOUNCED_IP;
 const TURN_PORT = parseInt(process.env.TURN_PORT || "3478", 10);
-const TURN_USERNAME = process.env.TURN_USERNAME || "arguably";
-const TURN_PASSWORD = process.env.TURN_PASSWORD || "arguably-turn-password";
+
+const DEFAULT_TURN_USERNAME = "arguably";
+const DEFAULT_TURN_PASSWORD = "arguably-turn-password";
+const TURN_USERNAME = process.env.TURN_USERNAME || DEFAULT_TURN_USERNAME;
+const TURN_PASSWORD = process.env.TURN_PASSWORD || DEFAULT_TURN_PASSWORD;
+
+// Warn if default TURN credentials are used in production
+if (process.env.NODE_ENV === "production") {
+  if (TURN_USERNAME === DEFAULT_TURN_USERNAME || TURN_PASSWORD === DEFAULT_TURN_PASSWORD) {
+    console.warn(
+      "\n╔══════════════════════════════════════════════════════════╗\n" +
+        "║  WARNING: Default TURN credentials detected in prod!    ║\n" +
+        "║  Set TURN_USERNAME and TURN_PASSWORD env vars to        ║\n" +
+        "║  strong, unique values. Default creds are public in     ║\n" +
+        "║  source code and can be abused for bandwidth theft.     ║\n" +
+        "╚══════════════════════════════════════════════════════════╝\n",
+    );
+  }
+}
 
 // ── mediasoup worker settings ──
 

--- a/realtime/src/index.ts
+++ b/realtime/src/index.ts
@@ -6,12 +6,36 @@ import { Server as SocketIOServer } from "socket.io";
 import { createWorkers } from "./mediasoup/workers.js";
 import { setupSignaling } from "./signaling.js";
 import { LISTEN_PORT } from "./config.js";
+import { createAuthMiddleware } from "./auth.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const isProduction = process.env.NODE_ENV === "production";
+
 // Resolve test-client directory (works for both src/ and dist/)
 const testClientDir = path.resolve(__dirname, "..", "test-client");
+
+// ── CORS configuration ──
+
+function getCorsOrigin(): string[] {
+  const envOrigins = process.env.ALLOWED_ORIGINS;
+  if (envOrigins) {
+    return envOrigins.split(",").map((o) => o.trim());
+  }
+  if (isProduction) {
+    console.error(
+      "\n[FATAL] ALLOWED_ORIGINS env var is required in production.\n" +
+        "Set it to a comma-separated list of allowed origins.\n",
+    );
+    process.exit(1);
+  }
+  console.warn(
+    "[WARN] ALLOWED_ORIGINS not set — defaulting to localhost only. " +
+      "Set ALLOWED_ORIGINS for non-local access.",
+  );
+  return ["http://localhost:3000", "http://127.0.0.1:3000"];
+}
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
@@ -30,14 +54,30 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // Serve static test-client files
-  let filePath = req.url === "/" ? "/index.html" : req.url || "/index.html";
-  filePath = path.join(testClientDir, filePath);
+  // Serve static test-client files — with path traversal protection
+  let decodedUrl: string;
+  try {
+    decodedUrl = decodeURIComponent(req.url || "/");
+  } catch {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end("Bad Request");
+    return;
+  }
 
-  const ext = path.extname(filePath);
+  const requestedPath = decodedUrl === "/" ? "/index.html" : decodedUrl;
+  const resolvedPath = path.resolve(testClientDir, "." + requestedPath);
+
+  // Verify resolved path is within testClientDir
+  if (resolvedPath !== testClientDir && !resolvedPath.startsWith(testClientDir + path.sep)) {
+    res.writeHead(403, { "Content-Type": "text/plain" });
+    res.end("Forbidden");
+    return;
+  }
+
+  const ext = path.extname(resolvedPath);
   const contentType = MIME_TYPES[ext] || "application/octet-stream";
 
-  fs.readFile(filePath, (err, data) => {
+  fs.readFile(resolvedPath, (err, data) => {
     if (err) {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not Found");
@@ -52,10 +92,13 @@ const server = http.createServer((req, res) => {
 
 const io = new SocketIOServer(server, {
   cors: {
-    origin: process.env.ALLOWED_ORIGINS?.split(",") || "*",
+    origin: getCorsOrigin(),
     methods: ["GET", "POST"],
   },
 });
+
+// ── Socket.IO authentication middleware ──
+io.use(createAuthMiddleware());
 
 // ── Start ──
 

--- a/realtime/src/signaling.ts
+++ b/realtime/src/signaling.ts
@@ -1,20 +1,13 @@
 import type { Server as SocketIOServer, Socket } from "socket.io";
-import type {
-  Peer,
-  JoinRequest,
-  CreateTransportRequest,
-  ConnectTransportRequest,
-  ProduceRequest,
-  ConsumeRequest,
-  ResumeConsumerRequest,
-  CloseProducerRequest,
-} from "./types.js";
+import type { Peer } from "./types.js";
 import { iceServers } from "./config.js";
 import { getOrCreateRoom, addPeerToRoom, removePeerFromRoom, getRoom } from "./mediasoup/rooms.js";
 import { createWebRtcTransport, getTransportOptions } from "./mediasoup/transports.js";
 import { createProducer } from "./mediasoup/producers.js";
 import { createConsumer } from "./mediasoup/consumers.js";
 import type { RtpCapabilities } from "mediasoup/types";
+import { schemas, validatePayload } from "./validation.js";
+
 // Track which room each socket is in
 const socketRoomMap = new Map<string, string>();
 const socketPeerMap = new Map<string, { rtpCapabilities: RtpCapabilities }>();
@@ -24,9 +17,12 @@ export function setupSignaling(io: SocketIOServer): void {
     console.log(`Socket connected [id:${socket.id}]`);
 
     // ── getRouterRtpCapabilities ──
-    socket.on("getRouterRtpCapabilities", async (data: { roomId: string }, callback) => {
+    socket.on("getRouterRtpCapabilities", async (data: unknown, callback) => {
       try {
-        const room = await getOrCreateRoom(data.roomId);
+        const parsed = validatePayload(schemas.getRouterRtpCapabilities, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
+        const room = await getOrCreateRoom(parsed.data.roomId);
         callback({
           success: true,
           rtpCapabilities: room.router.rtpCapabilities,
@@ -39,29 +35,33 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── joinRoom ──
-    socket.on("joinRoom", async (data: JoinRequest, callback) => {
+    socket.on("joinRoom", async (data: unknown, callback) => {
       try {
-        const room = await getOrCreateRoom(data.roomId);
+        const parsed = validatePayload(schemas.joinRoom, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
+        const { roomId, displayName, rtpCapabilities } = parsed.data;
+        const room = await getOrCreateRoom(roomId);
 
         const peer: Peer = {
           id: socket.id,
-          displayName: data.displayName,
+          displayName,
           transports: new Map(),
           producers: new Map(),
           consumers: new Map(),
         };
 
         addPeerToRoom(room, peer);
-        socketRoomMap.set(socket.id, data.roomId);
-        socketPeerMap.set(socket.id, { rtpCapabilities: data.rtpCapabilities });
+        socketRoomMap.set(socket.id, roomId);
+        socketPeerMap.set(socket.id, { rtpCapabilities: rtpCapabilities as RtpCapabilities });
 
         // Join socket.io room for broadcasting
-        socket.join(data.roomId);
+        socket.join(roomId);
 
         // Notify other peers
-        socket.to(data.roomId).emit("peerJoined", {
+        socket.to(roomId).emit("peerJoined", {
           peerId: socket.id,
-          displayName: data.displayName,
+          displayName,
         });
 
         // Return list of existing peers
@@ -77,8 +77,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── createWebRtcTransport ──
-    socket.on("createWebRtcTransport", async (data: CreateTransportRequest, callback) => {
+    socket.on("createWebRtcTransport", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.createWebRtcTransport, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -109,8 +112,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── connectTransport ──
-    socket.on("connectTransport", async (data: ConnectTransportRequest, callback) => {
+    socket.on("connectTransport", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.connectTransport, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -120,10 +126,12 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const transport = peer.transports.get(data.transportId);
+        const transport = peer.transports.get(parsed.data.transportId);
         if (!transport) throw new Error("Transport not found");
 
-        await transport.connect({ dtlsParameters: data.dtlsParameters });
+        await transport.connect({
+          dtlsParameters: parsed.data.dtlsParameters,
+        } as Parameters<typeof transport.connect>[0]);
 
         callback({ success: true });
       } catch (error) {
@@ -133,8 +141,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── produce ──
-    socket.on("produce", async (data: ProduceRequest, callback) => {
+    socket.on("produce", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.produce, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -144,14 +155,14 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const transport = peer.transports.get(data.transportId);
+        const transport = peer.transports.get(parsed.data.transportId);
         if (!transport) throw new Error("Transport not found");
 
         const producer = await createProducer(
           transport,
-          data.kind,
-          data.rtpParameters,
-          data.appData,
+          parsed.data.kind,
+          parsed.data.rtpParameters as Parameters<typeof createProducer>[2],
+          parsed.data.appData,
         );
 
         peer.producers.set(producer.id, producer);
@@ -176,8 +187,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── consume ──
-    socket.on("consume", async (data: ConsumeRequest, callback) => {
+    socket.on("consume", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.consume, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -199,7 +213,7 @@ export function setupSignaling(io: SocketIOServer): void {
         let producerPeerId = "";
         let producerDisplayName = "";
         for (const [, roomPeer] of room.peers) {
-          if (roomPeer.producers.has(data.producerId)) {
+          if (roomPeer.producers.has(parsed.data.producerId)) {
             producerPeerId = roomPeer.id;
             producerDisplayName = roomPeer.displayName;
             break;
@@ -209,7 +223,7 @@ export function setupSignaling(io: SocketIOServer): void {
         const consumer = await createConsumer(
           room.router,
           transport,
-          data.producerId,
+          parsed.data.producerId,
           peerData.rtpCapabilities,
         );
 
@@ -221,13 +235,13 @@ export function setupSignaling(io: SocketIOServer): void {
 
         consumer.on("producerclose", () => {
           peer.consumers.delete(consumer.id);
-          socket.emit("producerClosed", { producerId: data.producerId });
+          socket.emit("producerClosed", { producerId: parsed.data.producerId });
         });
 
         callback({
           success: true,
           id: consumer.id,
-          producerId: data.producerId,
+          producerId: parsed.data.producerId,
           kind: consumer.kind,
           rtpParameters: consumer.rtpParameters,
           peerId: producerPeerId,
@@ -240,8 +254,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── resumeConsumer ──
-    socket.on("resumeConsumer", async (data: ResumeConsumerRequest, callback) => {
+    socket.on("resumeConsumer", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.resumeConsumer, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -251,7 +268,7 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const consumer = peer.consumers.get(data.consumerId);
+        const consumer = peer.consumers.get(parsed.data.consumerId);
         if (!consumer) throw new Error("Consumer not found");
 
         await consumer.resume();
@@ -263,8 +280,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── closeProducer ──
-    socket.on("closeProducer", async (data: CloseProducerRequest, callback) => {
+    socket.on("closeProducer", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.closeProducer, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -274,15 +294,15 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const producer = peer.producers.get(data.producerId);
+        const producer = peer.producers.get(parsed.data.producerId);
         if (!producer) throw new Error("Producer not found");
 
         producer.close();
-        peer.producers.delete(data.producerId);
+        peer.producers.delete(parsed.data.producerId);
 
         // Notify other peers
         socket.to(roomId).emit("producerClosed", {
-          producerId: data.producerId,
+          producerId: parsed.data.producerId,
         });
 
         callback({ success: true });
@@ -293,8 +313,10 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── getProducers ──
-    socket.on("getProducers", async (_data: unknown, callback) => {
+    socket.on("getProducers", async (data: unknown, callback) => {
       try {
+        validatePayload(schemas.getProducers, data);
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -347,7 +369,6 @@ export function setupSignaling(io: SocketIOServer): void {
         socketRoomMap.delete(socket.id);
         socketPeerMap.delete(socket.id);
       }
-
     });
   });
 }

--- a/realtime/src/validation.ts
+++ b/realtime/src/validation.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+// ── Shared field schemas ──
+
+const roomId = z.string().min(1).max(100);
+const transportId = z.string().min(1).max(100);
+const producerId = z.string().min(1).max(100);
+const consumerId = z.string().min(1).max(100);
+const displayName = z.string().min(1).max(50);
+
+// Mediasoup-opaque objects: validate shape exists, don't deep-validate internals
+const rtpCapabilities = z.record(z.string(), z.unknown());
+const dtlsParameters = z.record(z.string(), z.unknown());
+const rtpParameters = z.record(z.string(), z.unknown());
+
+// ── Event payload schemas ──
+
+export const schemas = {
+  getRouterRtpCapabilities: z.object({
+    roomId,
+  }),
+
+  joinRoom: z.object({
+    roomId,
+    displayName,
+    rtpCapabilities,
+  }),
+
+  createWebRtcTransport: z.object({
+    direction: z.enum(["send", "recv"]),
+  }),
+
+  connectTransport: z.object({
+    transportId,
+    dtlsParameters,
+  }),
+
+  produce: z.object({
+    transportId,
+    kind: z.enum(["audio", "video"]),
+    rtpParameters,
+    appData: z.record(z.string(), z.unknown()).optional(),
+  }),
+
+  consume: z.object({
+    producerId,
+  }),
+
+  resumeConsumer: z.object({
+    consumerId,
+  }),
+
+  closeProducer: z.object({
+    producerId,
+  }),
+
+  getProducers: z.unknown(),
+} as const;
+
+// ── Validation helper ──
+
+export type ValidationResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export function validatePayload<T>(
+  schema: z.ZodType<T>,
+  data: unknown,
+): ValidationResult<T> {
+  const result = schema.safeParse(data);
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+  const message = result.error.issues
+    .map((i) => `${i.path.join(".")}: ${i.message}`)
+    .join("; ");
+  return { success: false, error: `Invalid payload: ${message}` };
+}


### PR DESCRIPTION
## Summary
Fixes #14 — addresses all 6 security vulnerabilities identified in the realtime server and server actions.

- **CORS**: Fail-closed in production (require `ALLOWED_ORIGINS`), localhost default in dev
- **Path traversal**: `decodeURIComponent` + `path.resolve` + prefix validation, returns 403
- **TURN credentials**: Prominent warning if default credentials used in production
- **Input validation**: Upper bounds on `audienceCapacity` (≤1000) and `turnLength` (≤1800s), participant existence checks on `assignModerator`/`kickParticipant`, auth on `getDebateState`, participant check on `advanceTurnIfExpired`, debater ID validation in `startDebate`
- **Socket.IO schema validation**: Zod schemas for all 9 event handlers with structured error acks
- **Socket.IO JWT auth**: `jose`-based middleware verifying Supabase JWTs (HS256), fail-closed in production

## New dependencies
- `zod` (realtime) — runtime schema validation
- `jose` (realtime + root devDep) — JWT verification (ESM-native)

## Test plan
- [x] 167/167 unit tests pass (`npm run test:unit`)
- [x] 32 Zod validation schema tests (all 9 events + helper)
- [x] 8 JWT auth middleware tests (valid/expired/invalid/missing tokens, dev skip, prod fail-closed)
- [x] 10 path traversal tests (directory traversal, URL encoding, edge cases)
- [x] Session bounds validation tests (audienceCapacity, turnLength upper bounds)
- [x] Debate validation tests (turnLength bounds, debater ID check, auth + participant checks)
- [x] `useMediasoup` auth token flow tested with Supabase client mock
- [x] Realtime TypeScript compiles (`npx tsc --noEmit`)

Closes #14