### PR TITLE
feat: add missing database tables for planned features

### DIFF
--- a/__tests__/action-utils.test.ts
+++ b/__tests__/action-utils.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+    },
+    participatesIn: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import { requireAuth, requireHostOrModerator, requireParticipant } from '@/lib/actions/utils'
+
+function mockAuth(user: { id: string } | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+      }),
+    },
+  })
+}
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+
+describe('requireAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws "Not authenticated" when no user', async () => {
+    mockAuth(null)
+    await expect(requireAuth()).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns user when authenticated', async () => {
+    const mockUser = { id: MOCK_USER_ID }
+    mockAuth(mockUser)
+    const result = await requireAuth()
+    expect(result).toEqual(mockUser)
+  })
+})
+
+describe('requireHostOrModerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(requireHostOrModerator(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Session not found" when session does not exist', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(requireHostOrModerator(MOCK_SESSION_ID)).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Not authorized" when user is neither host nor moderator', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user-1',
+      moderator_id: 'other-user-2',
+    })
+    await expect(requireHostOrModerator(MOCK_SESSION_ID)).rejects.toThrow('Not authorized')
+  })
+
+  it('returns {user, session} when user is host', async () => {
+    const mockUser = { id: MOCK_USER_ID }
+    const mockSession = {
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    }
+    mockAuth(mockUser)
+    ;(prisma.session.findUnique as any).mockResolvedValue(mockSession)
+
+    const result = await requireHostOrModerator(MOCK_SESSION_ID)
+
+    expect(result).toEqual({
+      user: mockUser,
+      session: mockSession,
+    })
+  })
+
+  it('returns {user, session} when user is moderator', async () => {
+    const mockUser = { id: MOCK_USER_ID }
+    const mockSession = {
+      id: MOCK_SESSION_ID,
+      host_id: 'some-other-user',
+      moderator_id: MOCK_USER_ID,
+    }
+    mockAuth(mockUser)
+    ;(prisma.session.findUnique as any).mockResolvedValue(mockSession)
+
+    const result = await requireHostOrModerator(MOCK_SESSION_ID)
+
+    expect(result).toEqual({
+      user: mockUser,
+      session: mockSession,
+    })
+  })
+})
+
+describe('requireParticipant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(requireParticipant(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Not a participant" when no participation record', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(requireParticipant(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('throws "Not a participant" when participation has left_at set', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(requireParticipant(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('returns user when active participant', async () => {
+    const mockUser = { id: MOCK_USER_ID }
+    mockAuth(mockUser)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+
+    const result = await requireParticipant(MOCK_SESSION_ID)
+
+    expect(result).toEqual(mockUser)
+  })
+})

--- a/__tests__/queue.test.ts
+++ b/__tests__/queue.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SessionRole, SessionStatus } from '@/lib/generated/prisma'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+    },
+    participatesIn: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    audienceQueue: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    roleHistory: {
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import {
+  joinQueue,
+  leaveQueue,
+  getQueue,
+  promoteFromQueue,
+} from '@/lib/actions/queue'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+const MOCK_HOST_ID = 'host-uuid'
+const MOCK_QUEUE_USER_ID = 'queue-user-uuid'
+
+// Helper to set up auth mock
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── joinQueue ──
+describe('joinQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      status: SessionStatus.LIVE,
+    })
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.AUDIENCE,
+      left_at: null,
+    })
+    ;(prisma.audienceQueue.create as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Session not found"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Session is not live"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      status: SessionStatus.WAITING,
+    })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Session is not live')
+  })
+
+  it('throws "Not a participant" when no record', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow(
+      'Not a participant in this session'
+    )
+  })
+
+  it('throws "Only audience members can join the queue" when role is DEBATER', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.DEBATER,
+      left_at: null,
+    })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow(
+      'Only audience members can join the queue'
+    )
+  })
+
+  it('calls prisma.audienceQueue.create on success', async () => {
+    await joinQueue(MOCK_SESSION_ID)
+    expect(prisma.audienceQueue.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        user_id: MOCK_USER_ID,
+      },
+    })
+  })
+})
+
+// ── leaveQueue ──
+describe('leaveQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.audienceQueue.delete as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(leaveQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('calls prisma.audienceQueue.delete with correct compound key', async () => {
+    await leaveQueue(MOCK_SESSION_ID)
+    expect(prisma.audienceQueue.delete).toHaveBeenCalledWith({
+      where: {
+        session_id_user_id: {
+          session_id: MOCK_SESSION_ID,
+          user_id: MOCK_USER_ID,
+        },
+      },
+    })
+  })
+})
+
+// ── getQueue ──
+describe('getQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(prisma.audienceQueue.findMany as any).mockResolvedValue([])
+  })
+
+  it('calls prisma.audienceQueue.findMany ordered by joined_queue asc', async () => {
+    await getQueue(MOCK_SESSION_ID)
+    expect(prisma.audienceQueue.findMany).toHaveBeenCalledWith({
+      where: { session_id: MOCK_SESSION_ID },
+      orderBy: { joined_queue: 'asc' },
+      include: {
+        user: { select: { id: true, username: true, realname: true } },
+      },
+    })
+  })
+})
+
+// ── promoteFromQueue ──
+describe('promoteFromQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_HOST_ID)
+
+    // Mock the transaction callback pattern
+    const mockTx = {
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue({
+          user_id: MOCK_QUEUE_USER_ID,
+          session_id: MOCK_SESSION_ID,
+        }),
+        findUnique: vi.fn().mockResolvedValue({
+          user_id: MOCK_QUEUE_USER_ID,
+          session_id: MOCK_SESSION_ID,
+        }),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      participatesIn: {
+        update: vi.fn().mockResolvedValue({}),
+      },
+      roleHistory: {
+        create: vi.fn().mockResolvedValue({}),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (cb: any) => cb(mockTx))
+
+    // Mock session with host
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_HOST_ID,
+      moderator_id: null,
+      host: { id: MOCK_HOST_ID },
+      moderator: null,
+    })
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Not authorized" when user is not host/moderator', async () => {
+    mockAuth('other-user-id')
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_HOST_ID,
+      moderator_id: null,
+      host: { id: MOCK_HOST_ID },
+      moderator: null,
+    })
+    await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authorized')
+  })
+
+  it('throws "No one in the queue" when queue is empty', async () => {
+    const mockTx = {
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        findUnique: vi.fn(),
+        delete: vi.fn(),
+      },
+      participatesIn: {
+        update: vi.fn(),
+      },
+      roleHistory: {
+        create: vi.fn(),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (cb: any) => cb(mockTx))
+
+    await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('No one in the queue')
+  })
+
+  it('calls $transaction on success', async () => {
+    await promoteFromQueue(MOCK_SESSION_ID)
+    expect(prisma.$transaction).toHaveBeenCalled()
+  })
+
+  it('promotes FIFO user when no userId specified', async () => {
+    const mockTx = {
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue({
+          user_id: MOCK_QUEUE_USER_ID,
+          session_id: MOCK_SESSION_ID,
+        }),
+        findUnique: vi.fn(),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      participatesIn: {
+        update: vi.fn().mockResolvedValue({}),
+      },
+      roleHistory: {
+        create: vi.fn().mockResolvedValue({}),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (cb: any) => cb(mockTx))
+
+    const result = await promoteFromQueue(MOCK_SESSION_ID)
+
+    expect(mockTx.audienceQueue.findFirst).toHaveBeenCalledWith({
+      where: { session_id: MOCK_SESSION_ID },
+      orderBy: { joined_queue: 'asc' },
+    })
+    expect(mockTx.participatesIn.update).toHaveBeenCalledWith({
+      where: {
+        user_id_session_id: {
+          user_id: MOCK_QUEUE_USER_ID,
+          session_id: MOCK_SESSION_ID,
+        },
+      },
+      data: { session_role: SessionRole.DEBATER },
+    })
+    expect(mockTx.audienceQueue.delete).toHaveBeenCalledWith({
+      where: {
+        session_id_user_id: {
+          session_id: MOCK_SESSION_ID,
+          user_id: MOCK_QUEUE_USER_ID,
+        },
+      },
+    })
+    expect(mockTx.roleHistory.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        user_id: MOCK_QUEUE_USER_ID,
+        old_role: SessionRole.AUDIENCE,
+        new_role: SessionRole.DEBATER,
+        reason: 'Promoted from queue',
+      },
+    })
+    expect(result).toEqual({ promotedUserId: MOCK_QUEUE_USER_ID })
+  })
+
+  it('promotes specific user when userId is provided', async () => {
+    const specificUserId = 'specific-user-uuid'
+    const mockTx = {
+      audienceQueue: {
+        findFirst: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({
+          user_id: specificUserId,
+          session_id: MOCK_SESSION_ID,
+        }),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      participatesIn: {
+        update: vi.fn().mockResolvedValue({}),
+      },
+      roleHistory: {
+        create: vi.fn().mockResolvedValue({}),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (cb: any) => cb(mockTx))
+
+    const result = await promoteFromQueue(MOCK_SESSION_ID, specificUserId)
+
+    expect(mockTx.audienceQueue.findUnique).toHaveBeenCalledWith({
+      where: { session_id_user_id: { session_id: MOCK_SESSION_ID, user_id: specificUserId } },
+    })
+    expect(mockTx.participatesIn.update).toHaveBeenCalledWith({
+      where: {
+        user_id_session_id: {
+          user_id: specificUserId,
+          session_id: MOCK_SESSION_ID,
+        },
+      },
+      data: { session_role: SessionRole.DEBATER },
+    })
+    expect(result).toEqual({ promotedUserId: specificUserId })
+  })
+
+  it('allows moderator to promote from queue', async () => {
+    mockAuth('moderator-uuid')
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_HOST_ID,
+      moderator_id: 'moderator-uuid',
+      host: { id: MOCK_HOST_ID },
+      moderator: { id: 'moderator-uuid' },
+    })
+
+    await promoteFromQueue(MOCK_SESSION_ID)
+    expect(prisma.$transaction).toHaveBeenCalled()
+  })
+})

--- a/__tests__/recording.test.ts
+++ b/__tests__/recording.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+    },
+    participatesIn: {
+      findUnique: vi.fn(),
+    },
+    recording: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import {
+  createRecording,
+  getRecordingsBySession,
+  deleteRecording,
+} from '@/lib/actions/recording'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_HOST_ID = 'host-uuid-5678'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+const MOCK_RECORDING_ID = 'recording-id-1234'
+
+// Helper to set up auth mock
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── createRecording ──
+describe('createRecording', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    })
+    ;(prisma.recording.create as any).mockResolvedValue({
+      id: MOCK_RECORDING_ID,
+    })
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Session not found"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(
+      createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    ).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Not authorized" when not host/moderator', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user',
+      moderator_id: null,
+    })
+    await expect(
+      createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    ).rejects.toThrow('Not authorized')
+  })
+
+  it('calls prisma.recording.create on success', async () => {
+    await createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4', 3600, 1024000, 'video/mp4')
+    expect(prisma.recording.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        recorded_by: MOCK_USER_ID,
+        url: 'https://example.com/recording.mp4',
+        duration: 3600,
+        file_size: 1024000,
+        mime_type: 'video/mp4',
+      },
+    })
+  })
+
+  it('calls prisma.recording.create with null for optional fields', async () => {
+    await createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    expect(prisma.recording.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        recorded_by: MOCK_USER_ID,
+        url: 'https://example.com/recording.mp4',
+        duration: null,
+        file_size: null,
+        mime_type: null,
+      },
+    })
+  })
+
+  it('allows moderator to create recording', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user',
+      moderator_id: MOCK_USER_ID,
+    })
+    await createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    expect(prisma.recording.create).toHaveBeenCalled()
+  })
+})
+
+// ── getRecordingsBySession ──
+describe('getRecordingsBySession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.recording.findMany as any).mockResolvedValue([])
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(getRecordingsBySession(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Not a participant"', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(getRecordingsBySession(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('returns recordings ordered by created_at desc', async () => {
+    await getRecordingsBySession(MOCK_SESSION_ID)
+    expect(prisma.recording.findMany).toHaveBeenCalledWith({
+      where: { session_id: MOCK_SESSION_ID },
+      orderBy: { created_at: 'desc' },
+      include: {
+        recorder: { select: { id: true, username: true, realname: true } },
+      },
+    })
+  })
+})
+
+// ── deleteRecording ──
+describe('deleteRecording', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.recording.findUnique as any).mockResolvedValue({
+      id: MOCK_RECORDING_ID,
+      recorded_by: MOCK_USER_ID,
+      session: { host_id: MOCK_HOST_ID },
+    })
+    ;(prisma.recording.delete as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(deleteRecording(MOCK_RECORDING_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Recording not found"', async () => {
+    ;(prisma.recording.findUnique as any).mockResolvedValue(null)
+    await expect(deleteRecording(MOCK_RECORDING_ID)).rejects.toThrow('Recording not found')
+  })
+
+  it('throws "Not authorized" when user is not recorder and not host', async () => {
+    ;(prisma.recording.findUnique as any).mockResolvedValue({
+      id: MOCK_RECORDING_ID,
+      recorded_by: 'other-user',
+      session: { host_id: 'other-host' },
+    })
+    await expect(deleteRecording(MOCK_RECORDING_ID)).rejects.toThrow('Not authorized to delete this recording')
+  })
+
+  it('calls prisma.recording.delete when user is recorder', async () => {
+    await deleteRecording(MOCK_RECORDING_ID)
+    expect(prisma.recording.delete).toHaveBeenCalledWith({
+      where: { id: MOCK_RECORDING_ID },
+    })
+  })
+
+  it('calls prisma.recording.delete when user is host (even if not recorder)', async () => {
+    mockAuth(MOCK_HOST_ID)
+    ;(prisma.recording.findUnique as any).mockResolvedValue({
+      id: MOCK_RECORDING_ID,
+      recorded_by: 'other-user',
+      session: { host_id: MOCK_HOST_ID },
+    })
+    await deleteRecording(MOCK_RECORDING_ID)
+    expect(prisma.recording.delete).toHaveBeenCalledWith({
+      where: { id: MOCK_RECORDING_ID },
+    })
+  })
+})

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -22,7 +22,12 @@ vi.mock('@/lib/prisma', () => ({
       create: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
+    roleHistory: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+    $transaction: vi.fn().mockResolvedValue([]),
   },
 }))
 

--- a/__tests__/team.test.ts
+++ b/__tests__/team.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SessionType } from '@/lib/generated/prisma'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+    },
+    teamAssignment: {
+      upsert: vi.fn(),
+      findMany: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import {
+  assignTeam,
+  getTeamAssignments,
+  removeFromTeam,
+} from '@/lib/actions/team'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+const MOCK_TARGET_USER_ID = 'target-user-uuid'
+
+// Helper to set up auth mock
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── assignTeam ──
+describe('assignTeam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+      type: SessionType.TEAM,
+    })
+    ;(prisma.teamAssignment.upsert as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Session not found"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    ).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Not authorized"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user',
+      moderator_id: null,
+      type: SessionType.TEAM,
+    })
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    ).rejects.toThrow('Not authorized')
+  })
+
+  it('throws "Team assignments are only for TEAM format sessions" (mock session.type as ONE_ON_ONE)', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+      type: SessionType.ONE_ON_ONE,
+    })
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    ).rejects.toThrow('Team assignments are only for TEAM format sessions')
+  })
+
+  it('throws "Team must be \'proponent\' or \'opponent\'" with invalid team name', async () => {
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'invalid-team')
+    ).rejects.toThrow("Team must be 'proponent' or 'opponent'")
+  })
+
+  it('calls prisma.teamAssignment.upsert on success', async () => {
+    await assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    expect(prisma.teamAssignment.upsert).toHaveBeenCalledWith({
+      where: {
+        session_id_user_id: {
+          session_id: MOCK_SESSION_ID,
+          user_id: MOCK_TARGET_USER_ID,
+        },
+      },
+      create: {
+        session_id: MOCK_SESSION_ID,
+        user_id: MOCK_TARGET_USER_ID,
+        team: 'proponent',
+      },
+      update: { team: 'proponent' },
+    })
+  })
+
+  it('allows moderator to assign team', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user',
+      moderator_id: MOCK_USER_ID,
+      type: SessionType.TEAM,
+    })
+    await assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'opponent')
+    expect(prisma.teamAssignment.upsert).toHaveBeenCalled()
+  })
+})
+
+// ── getTeamAssignments ──
+describe('getTeamAssignments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(prisma.teamAssignment.findMany as any).mockResolvedValue([])
+  })
+
+  it('calls prisma.teamAssignment.findMany with user include', async () => {
+    await getTeamAssignments(MOCK_SESSION_ID)
+    expect(prisma.teamAssignment.findMany).toHaveBeenCalledWith({
+      where: { session_id: MOCK_SESSION_ID },
+      include: {
+        user: { select: { id: true, username: true, realname: true } },
+      },
+      orderBy: { assigned_at: 'asc' },
+    })
+  })
+})
+
+// ── removeFromTeam ──
+describe('removeFromTeam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    })
+    ;(prisma.teamAssignment.delete as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      removeFromTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('calls prisma.teamAssignment.delete with correct key', async () => {
+    await removeFromTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+    expect(prisma.teamAssignment.delete).toHaveBeenCalledWith({
+      where: {
+        session_id_user_id: {
+          session_id: MOCK_SESSION_ID,
+          user_id: MOCK_TARGET_USER_ID,
+        },
+      },
+    })
+  })
+})

--- a/__tests__/transcript.test.ts
+++ b/__tests__/transcript.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    participatesIn: {
+      findUnique: vi.fn(),
+    },
+    transcript: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import {
+  createTranscriptSegment,
+  getTranscriptBySession,
+} from '@/lib/actions/transcript'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+
+// Helper to set up auth mock
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── createTranscriptSegment ──
+describe('createTranscriptSegment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.transcript.create as any).mockResolvedValue({
+      id: 'transcript-id',
+    })
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000)
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Not a participant" when no participation', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(
+      createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000)
+    ).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('throws "Not a participant" when left_at is set', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(
+      createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000)
+    ).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('calls prisma.transcript.create with correct data on success', async () => {
+    await createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000, 5, 0.95)
+    expect(prisma.transcript.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        speaker_id: MOCK_USER_ID,
+        content: 'Test content',
+        timestamp: 1000,
+        duration: 5,
+        confidence: 0.95,
+      },
+    })
+  })
+
+  it('calls prisma.transcript.create with null for optional duration/confidence', async () => {
+    await createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000)
+    expect(prisma.transcript.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        speaker_id: MOCK_USER_ID,
+        content: 'Test content',
+        timestamp: 1000,
+        duration: null,
+        confidence: null,
+      },
+    })
+  })
+})
+
+// ── getTranscriptBySession ──
+describe('getTranscriptBySession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.transcript.findMany as any).mockResolvedValue([])
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(getTranscriptBySession(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Not a participant"', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(getTranscriptBySession(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('calls prisma.transcript.findMany ordered by timestamp asc, with speaker include', async () => {
+    await getTranscriptBySession(MOCK_SESSION_ID)
+    expect(prisma.transcript.findMany).toHaveBeenCalledWith({
+      where: { session_id: MOCK_SESSION_ID },
+      orderBy: { timestamp: 'asc' },
+      include: {
+        speaker: { select: { id: true, username: true, realname: true } },
+      },
+    })
+  })
+})

--- a/__tests__/user-preferences.test.ts
+++ b/__tests__/user-preferences.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import { getUserPreferences, updateUserPreferences } from '@/lib/actions/user'
+
+function mockAuth(user: { id: string } | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+      }),
+    },
+  })
+}
+
+const MOCK_USER_ID = 'user-uuid-1234'
+
+describe('getUserPreferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(getUserPreferences()).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns user preferences when authenticated', async () => {
+    const mockPreferences = {
+      username: 'testuser',
+      email: 'test@example.com',
+      realname: 'Test User',
+      bio: 'Test bio',
+      notify_invitations: true,
+      notify_messages: true,
+      notify_weekly_digest: false,
+      profile_visibility: 'public',
+      show_online_status: true,
+      allow_direct_messages: true,
+      theme: 'dark',
+      font_size: 'medium',
+      animations_enabled: true,
+      language: 'en',
+      timezone: 'America/Toronto',
+      date_format: 'YYYY-MM-DD',
+    }
+
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.findUnique as any).mockResolvedValue(mockPreferences)
+
+    const result = await getUserPreferences()
+
+    expect(result).toEqual(mockPreferences)
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: MOCK_USER_ID },
+      select: {
+        username: true,
+        email: true,
+        realname: true,
+        bio: true,
+        notify_invitations: true,
+        notify_messages: true,
+        notify_weekly_digest: true,
+        profile_visibility: true,
+        show_online_status: true,
+        allow_direct_messages: true,
+        theme: true,
+        font_size: true,
+        animations_enabled: true,
+        language: true,
+        timezone: true,
+        date_format: true,
+      },
+    })
+  })
+})
+
+describe('updateUserPreferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(updateUserPreferences({ bio: 'test' })).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws when invalid theme value', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    await expect(updateUserPreferences({ theme: 'invalid' })).rejects.toThrow(
+      "Theme must be 'dark', 'light', or 'system'"
+    )
+  })
+
+  it('throws when invalid font_size', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    await expect(updateUserPreferences({ font_size: 'huge' })).rejects.toThrow(
+      "Font size must be 'small', 'medium', or 'large'"
+    )
+  })
+
+  it('throws when invalid profile_visibility', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    await expect(updateUserPreferences({ profile_visibility: 'hidden' })).rejects.toThrow(
+      "Profile visibility must be 'public' or 'private'"
+    )
+  })
+
+  it('updates successfully with valid partial data', async () => {
+    const updateData = {
+      bio: 'Updated bio',
+      notify_invitations: false,
+    }
+    const mockUpdatedUser = {
+      id: MOCK_USER_ID,
+      username: 'testuser',
+      ...updateData,
+    }
+
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue(mockUpdatedUser)
+
+    const result = await updateUserPreferences(updateData)
+
+    expect(result).toEqual(mockUpdatedUser)
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: MOCK_USER_ID },
+      data: updateData,
+    })
+  })
+
+  it('updates with all fields', async () => {
+    const updateData = {
+      bio: 'Full update bio',
+      notify_invitations: true,
+      notify_messages: false,
+      notify_weekly_digest: true,
+      profile_visibility: 'private',
+      show_online_status: false,
+      allow_direct_messages: true,
+      theme: 'light',
+      font_size: 'large',
+      animations_enabled: false,
+      language: 'fr',
+      timezone: 'Europe/Paris',
+      date_format: 'DD/MM/YYYY',
+    }
+    const mockUpdatedUser = {
+      id: MOCK_USER_ID,
+      username: 'testuser',
+      email: 'test@example.com',
+      ...updateData,
+    }
+
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue(mockUpdatedUser)
+
+    const result = await updateUserPreferences(updateData)
+
+    expect(result).toEqual(mockUpdatedUser)
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: MOCK_USER_ID },
+      data: updateData,
+    })
+  })
+
+  it('accepts valid theme values', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue({ id: MOCK_USER_ID })
+
+    await expect(updateUserPreferences({ theme: 'dark' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ theme: 'light' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ theme: 'system' })).resolves.not.toThrow()
+  })
+
+  it('accepts valid font_size values', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue({ id: MOCK_USER_ID })
+
+    await expect(updateUserPreferences({ font_size: 'small' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ font_size: 'medium' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ font_size: 'large' })).resolves.not.toThrow()
+  })
+
+  it('accepts valid profile_visibility values', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue({ id: MOCK_USER_ID })
+
+    await expect(updateUserPreferences({ profile_visibility: 'public' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ profile_visibility: 'private' })).resolves.not.toThrow()
+  })
+})

--- a/__tests__/vote.test.ts
+++ b/__tests__/vote.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SessionStatus, VoteType } from '@/lib/generated/prisma'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+    },
+    participatesIn: {
+      findUnique: vi.fn(),
+    },
+    vote: {
+      upsert: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import { castVote, retractVote, getVoteCounts } from '@/lib/actions/vote'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+const MOCK_TARGET_USER_ID = 'target-user-uuid'
+
+// Helper to set up auth mock
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── castVote ──
+describe('castVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      status: SessionStatus.LIVE,
+    })
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.vote.upsert as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Cannot vote for yourself"', async () => {
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Cannot vote for yourself')
+  })
+
+  it('throws "Session not found"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Session is not live" when status is WAITING', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      status: SessionStatus.WAITING,
+    })
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Session is not live')
+  })
+
+  it('throws "Not a participant" when no participation record', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('throws "Not a participant" when left_at is set', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('calls prisma.vote.upsert with correct compound key on success', async () => {
+    await castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    expect(prisma.vote.upsert).toHaveBeenCalledWith({
+      where: {
+        session_id_voter_id_target_user_id_vote_type: {
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+          target_user_id: MOCK_TARGET_USER_ID,
+          vote_type: VoteType.KICK,
+        },
+      },
+      create: {
+        session_id: MOCK_SESSION_ID,
+        voter_id: MOCK_USER_ID,
+        target_user_id: MOCK_TARGET_USER_ID,
+        vote_type: VoteType.KICK,
+      },
+      update: {},
+    })
+  })
+})
+
+// ── retractVote ──
+describe('retractVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.vote.delete as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      retractVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('calls prisma.vote.delete with correct compound key', async () => {
+    await retractVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    expect(prisma.vote.delete).toHaveBeenCalledWith({
+      where: {
+        session_id_voter_id_target_user_id_vote_type: {
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+          target_user_id: MOCK_TARGET_USER_ID,
+          vote_type: VoteType.KICK,
+        },
+      },
+    })
+  })
+})
+
+// ── getVoteCounts ──
+describe('getVoteCounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(prisma.vote.count as any).mockResolvedValue(5)
+  })
+
+  it('calls prisma.vote.count and returns {count}', async () => {
+    const result = await getVoteCounts(
+      MOCK_SESSION_ID,
+      MOCK_TARGET_USER_ID,
+      VoteType.KICK
+    )
+    expect(prisma.vote.count).toHaveBeenCalledWith({
+      where: {
+        session_id: MOCK_SESSION_ID,
+        target_user_id: MOCK_TARGET_USER_ID,
+        vote_type: VoteType.KICK,
+      },
+    })
+    expect(result).toEqual({ count: 5 })
+  })
+})

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -237,40 +237,454 @@ Update session status.
 
 ---
 
-# `lib/action/debate.ts` Documentation
+# `lib/action/utils.ts` Documentation
 
 ## Overview
-Manages the lifecycle and turn-based logic of a debate session:
-- Authorization (moderator/host)
-- Debate state retrieval
-- Turn control (start, advance, auto-advance)
-- Pause / resume
-- End debate
+Shared utility functions for authentication and authorization checks across server actions.
 
 ---
 
-## requireModerator(sessionId)
+## requireAuth()
 
-**Description**  
-Ensures the current user is authorized (HOST or MODERATOR).
+**Description**
+Require authenticated user. Returns the Supabase user object.
+
+**Logic**
+- Fetch current user from Supabase
+- Throw error if not authenticated
+
+**Returns**
+- Supabase `User` object
+
+**Errors**
+- Not authenticated
+
+---
+
+## requireHostOrModerator(sessionId)
+
+**Description**
+Require that the current user is the host or moderator of the given session.
 
 **Params**
 - `sessionId: string`
 
 **Logic**
-- Authenticate user (Supabase)
+- Authenticate user
 - Fetch session
-- अनुमति if:
-  - `user.id === session.host_id`
-  - OR `user.id === session.moderator_id`
+- Verify user is either host or moderator
 
 **Returns**
-- `{ user, session }`
+- `{ user, session }` - Both user and session objects
 
 **Errors**
 - Not authenticated
 - Session not found
 - Not authorized
+
+---
+
+## requireParticipant(sessionId)
+
+**Description**
+Verify that the authenticated user is an active participant in the session.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Authenticate user
+- Fetch participation record
+- Verify user is in session and `left_at` is null
+
+**Returns**
+- Supabase `User` object
+
+**Errors**
+- Not authenticated
+- Not a participant in this session
+- User has left the session
+
+---
+
+# `lib/action/transcript.ts` Documentation
+
+## Overview
+Manages transcript segments for live debate transcription (REQ-6).
+
+---
+
+## createTranscriptSegment(sessionId, content, timestamp, duration?, confidence?)
+
+**Description**
+Create a new transcript segment for a debate session.
+
+**Params**
+- `sessionId: string`
+- `content: string` - Transcribed text
+- `timestamp: number` - Seconds since debate start
+- `duration?: number` - Duration of speech segment (seconds)
+- `confidence?: number` - Confidence score (0.0 - 1.0)
+
+**Logic**
+- Verify user is an active participant
+- Create transcript record with speaker attribution
+
+**Returns**
+- `Transcript` object
+
+**Errors**
+- Not authenticated
+- Not a participant in this session
+
+---
+
+## getTranscriptBySession(sessionId)
+
+**Description**
+Fetch all transcript segments for a session in chronological order.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Verify user is an active participant
+- Fetch all segments ordered by timestamp
+- Include speaker details (id, username, realname)
+
+**Returns**
+- `Transcript[]` with speaker information
+
+**Errors**
+- Not authenticated
+- Not a participant in this session
+
+---
+
+# `lib/action/recording.ts` Documentation
+
+## Overview
+Manages video recordings of completed debate sessions (REQ-8).
+
+---
+
+## createRecording(sessionId, url, duration?, fileSize?, mimeType?)
+
+**Description**
+Create a recording entry for a debate session. Only host or moderator can create recordings.
+
+**Params**
+- `sessionId: string`
+- `url: string` - Recording file URL
+- `duration?: number` - Duration in seconds
+- `fileSize?: number` - File size in bytes
+- `mimeType?: string` - MIME type (e.g., "video/webm")
+
+**Logic**
+- Verify user is host or moderator
+- Create recording record
+
+**Returns**
+- `Recording` object
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
+
+---
+
+## getRecordingsBySession(sessionId)
+
+**Description**
+Fetch all recordings for a session, most recent first.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Verify user is an active participant
+- Fetch recordings ordered by creation date (desc)
+- Include recorder details
+
+**Returns**
+- `Recording[]` with recorder information
+
+**Errors**
+- Not authenticated
+- Not a participant in this session
+
+---
+
+## deleteRecording(recordingId)
+
+**Description**
+Delete a recording. Only the recording creator or session host can delete.
+
+**Params**
+- `recordingId: string`
+
+**Logic**
+- Authenticate user
+- Fetch recording with session host info
+- Verify user is either the recorder or the session host
+- Delete recording
+
+**Errors**
+- Not authenticated
+- Recording not found
+- Not authorized to delete this recording
+
+---
+
+# `lib/action/vote.ts` Documentation
+
+## Overview
+Manages audience voting for kick and promote actions (REQ-4).
+
+---
+
+## castVote(sessionId, targetUserId, voteType)
+
+**Description**
+Cast a vote to kick or promote a participant.
+
+**Params**
+- `sessionId: string`
+- `targetUserId: string`
+- `voteType: VoteType` - KICK or PROMOTE
+
+**Logic**
+- Authenticate user
+- Verify user is not voting for themselves
+- Verify session is LIVE
+- Verify voter is an active participant
+- Upsert vote (idempotent)
+
+**Returns**
+- `Vote` object
+
+**Errors**
+- Not authenticated
+- Cannot vote for yourself
+- Session not found
+- Session is not live
+- Not a participant in this session
+
+**Notes**
+- Uses `upsert` to prevent duplicate votes
+- Unique constraint: one vote of each type per voter-target pair per session
+
+---
+
+## retractVote(sessionId, targetUserId, voteType)
+
+**Description**
+Retract a previously cast vote.
+
+**Params**
+- `sessionId: string`
+- `targetUserId: string`
+- `voteType: VoteType`
+
+**Logic**
+- Authenticate user
+- Delete the vote record
+
+**Errors**
+- Not authenticated
+- Vote not found
+
+---
+
+## getVoteCounts(sessionId, targetUserId, voteType)
+
+**Description**
+Get the count of votes for a specific target and vote type.
+
+**Params**
+- `sessionId: string`
+- `targetUserId: string`
+- `voteType: VoteType`
+
+**Returns**
+- `{ count: number }`
+
+---
+
+# `lib/action/queue.ts` Documentation
+
+## Overview
+Manages the FIFO audience queue for promoting speakers (REQ-4).
+
+---
+
+## joinQueue(sessionId)
+
+**Description**
+Add the current user to the audience queue.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Authenticate user
+- Verify session is LIVE
+- Verify user is an active AUDIENCE member
+- Add to queue
+
+**Returns**
+- `AudienceQueue` object
+
+**Errors**
+- Not authenticated
+- Session not found
+- Session is not live
+- Not a participant in this session
+- Only audience members can join the queue
+
+---
+
+## leaveQueue(sessionId)
+
+**Description**
+Remove the current user from the audience queue.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Authenticate user
+- Delete queue entry
+
+**Errors**
+- Not authenticated
+- Queue entry not found
+
+---
+
+## getQueue(sessionId)
+
+**Description**
+Fetch the current audience queue in FIFO order.
+
+**Params**
+- `sessionId: string`
+
+**Returns**
+- `AudienceQueue[]` ordered by `joined_queue` (ascending)
+- Includes user details (id, username, realname)
+
+---
+
+## promoteFromQueue(sessionId, userId?)
+
+**Description**
+Promote a user from the audience queue to DEBATER. Only host or moderator can promote.
+
+**Params**
+- `sessionId: string`
+- `userId?: string` - Optional specific user; if omitted, promotes FIFO head
+
+**Logic**
+- Verify user is host or moderator
+- Transaction:
+  - Find queue entry (specific user or FIFO head)
+  - Update role to DEBATER
+  - Remove from queue
+  - Log role transition
+
+**Returns**
+- `{ promotedUserId: string }`
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
+- No one in the queue
+
+---
+
+# `lib/action/team.ts` Documentation
+
+## Overview
+Manages team assignments for TEAM format debates.
+
+---
+
+## assignTeam(sessionId, userId, team)
+
+**Description**
+Assign a user to a team. Only host or moderator can assign.
+
+**Params**
+- `sessionId: string`
+- `userId: string`
+- `team: string` - Must be "proponent" or "opponent"
+
+**Logic**
+- Verify user is host or moderator
+- Verify session type is TEAM
+- Verify team value is valid
+- Upsert team assignment
+
+**Returns**
+- `TeamAssignment` object
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
+- Team assignments are only for TEAM format sessions
+- Team must be 'proponent' or 'opponent'
+
+---
+
+## getTeamAssignments(sessionId)
+
+**Description**
+Fetch all team assignments for a session.
+
+**Params**
+- `sessionId: string`
+
+**Returns**
+- `TeamAssignment[]` ordered by `assigned_at` (ascending)
+- Includes user details (id, username, realname)
+
+---
+
+## removeFromTeam(sessionId, userId)
+
+**Description**
+Remove a user from their team. Only host or moderator can remove.
+
+**Params**
+- `sessionId: string`
+- `userId: string`
+
+**Logic**
+- Verify user is host or moderator
+- Delete team assignment
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
+- Team assignment not found
+
+---
+
+# `lib/action/debate.ts` Documentation
+
+## Overview
+Manages the lifecycle and turn-based logic of a debate session:
+- Debate state retrieval
+- Turn control (start, advance, auto-advance)
+- Pause / resume
+- End debate
+
+**Note:** This file now uses the shared `requireHostOrModerator` function from `utils.ts` for authorization checks.
 
 ---
 
@@ -297,7 +711,7 @@ Fetch current debate state.
 
 ## startDebate(sessionId, debaters, turnLength)
 
-**Description**  
+**Description**
 Initializes or resets a debate.
 
 **Params**
@@ -306,7 +720,7 @@ Initializes or resets a debate.
 - `turnLength: number` (seconds)
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Require exactly 2 debaters
 - Set:
   - `current_index = 0`
@@ -318,18 +732,20 @@ Initializes or resets a debate.
   - Reset if exists
 
 **Errors**
-- Unauthorized
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 - Invalid debater count
 
 ---
 
 ## advanceTurn(sessionId)
 
-**Description**  
+**Description**
 Manually advance to next speaker.
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Ensure state exists
 - Rotate:
   - `current_index = (index + 1) % 2`
@@ -339,7 +755,9 @@ Manually advance to next speaker.
   - `is_paused = false`
 
 **Errors**
-- Unauthorized
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 - No active debate
 
 ---
@@ -368,11 +786,11 @@ Auto-advances turn when timer expires (safe against race conditions).
 
 ## pauseDebate(sessionId)
 
-**Description**  
+**Description**
 Pauses the debate timer.
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Ensure:
   - state exists
   - not already paused
@@ -384,7 +802,9 @@ Pauses the debate timer.
   - `paused_time_remaining = remaining`
 
 **Errors**
-- Unauthorized
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 - No active debate
 - Already paused
 
@@ -392,11 +812,11 @@ Pauses the debate timer.
 
 ## resumeDebate(sessionId)
 
-**Description**  
+**Description**
 Resumes a paused debate.
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Ensure:
   - state exists
   - currently paused
@@ -405,7 +825,9 @@ Resumes a paused debate.
   - `is_paused = false`
 
 **Errors**
-- Unauthorized
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 - No active debate
 - Not paused
 
@@ -413,13 +835,18 @@ Resumes a paused debate.
 
 ## endDebate(sessionId)
 
-**Description**  
+**Description**
 Ends the debate and clears state.
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Delete `debateState`
 - Silently ignore if already deleted
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 
 ---
 
@@ -452,8 +879,8 @@ Handles user profile initialization and synchronization with the database.
 
 ## ensureUserProfile()
 
-**Description**  
-Ensures the currently authenticated user has a profile in the database.  
+**Description**
+Ensures the currently authenticated user has a profile in the database.
 Creates one if it does not exist.
 
 ---
@@ -512,3 +939,71 @@ Creates one if it does not exist.
 - Cache username availability checks
 - Move collision handling to DB-level unique constraints + retry
 - Allow user-defined usernames (with validation layer)
+
+---
+
+## getUserPreferences()
+
+**Description**
+Fetch user preferences for the currently authenticated user.
+
+**Logic**
+- Authenticate user (via `requireAuth`)
+- Fetch user record with all preference fields
+
+**Returns**
+- User object containing:
+  - `username, email, realname, bio`
+  - Notification preferences: `notify_invitations, notify_messages, notify_weekly_digest`
+  - Privacy preferences: `profile_visibility, show_online_status, allow_direct_messages`
+  - Appearance preferences: `theme, font_size, animations_enabled`
+  - Language & region: `language, timezone, date_format`
+
+**Errors**
+- Not authenticated
+
+---
+
+## updateUserPreferences(prefs)
+
+**Description**
+Update user preferences for the currently authenticated user.
+
+**Params**
+- `prefs: UserPreferences` - Object containing preferences to update
+
+**UserPreferences Type:**
+```typescript
+{
+  bio?: string | null
+  notify_invitations?: boolean
+  notify_messages?: boolean
+  notify_weekly_digest?: boolean
+  profile_visibility?: string
+  show_online_status?: boolean
+  allow_direct_messages?: boolean
+  theme?: string
+  font_size?: string
+  animations_enabled?: boolean
+  language?: string
+  timezone?: string
+  date_format?: string
+}
+```
+
+**Logic**
+- Authenticate user (via `requireAuth`)
+- Validate constraints:
+  - `theme`: must be "dark", "light", or "system"
+  - `font_size`: must be "small", "medium", or "large"
+  - `profile_visibility`: must be "public" or "private"
+- Update user record with provided preferences
+
+**Returns**
+- Updated `User` object
+
+**Errors**
+- Not authenticated
+- Theme must be 'dark', 'light', or 'system'
+- Font size must be 'small', 'medium', or 'large'
+- Profile visibility must be 'public' or 'private'

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -27,6 +27,10 @@ This document describes the database schema for Arguably.
 - `PAUSED` - Temporarily paused
 - `ENDED` - Debate concluded
 
+### VoteType
+- `KICK` - Vote to remove a participant
+- `PROMOTE` - Vote to promote an audience member to debater
+
 ## Models
 
 ### User
@@ -43,11 +47,31 @@ Represents a platform user account.
 | `realname` | String? | - | null | Display name |
 | `role` | UniversalRole | - | USER | System role |
 | `created_at` | DateTime | - | now() | Account creation |
+| `bio` | String? | - | null | User biography |
+| `notify_invitations` | Boolean | - | true | Email notification for invitations |
+| `notify_messages` | Boolean | - | true | Email notification for messages |
+| `notify_weekly_digest` | Boolean | - | false | Weekly digest emails |
+| `profile_visibility` | String | - | "public" | Profile visibility setting |
+| `show_online_status` | Boolean | - | true | Display online status |
+| `allow_direct_messages` | Boolean | - | true | Allow DMs from other users |
+| `theme` | String | - | "dark" | UI theme preference |
+| `font_size` | String | - | "medium" | Font size preference |
+| `animations_enabled` | Boolean | - | true | Enable UI animations |
+| `language` | String | - | "en" | Preferred language |
+| `timezone` | String | - | "UTC" | User timezone |
+| `date_format` | String | - | "MM/DD/YYYY" | Date format preference |
 
 **Relations:**
 - `hosted_sessions: Session[]` - Sessions created by this user
 - `moderated_sessions: Session[]` - Sessions moderated by this user
 - `participates_ins: ParticipatesIn[]` - All session participations
+- `transcripts: Transcript[]` - Transcript segments spoken by this user
+- `recordings: Recording[]` - Recordings created by this user
+- `votes_cast: Vote[]` - Votes cast by this user
+- `votes_received: Vote[]` - Votes received by this user
+- `audience_queues: AudienceQueue[]` - Queue entries for this user
+- `team_assignments: TeamAssignment[]` - Team assignments for this user
+- `role_history: RoleHistory[]` - Role change history for this user
 
 ---
 
@@ -72,6 +96,7 @@ Represents a debate session/room.
 | `debater_capacity_panel` | Int? | - | 5 | Max panel slots (PANEL only) |
 | `audience_capacity` | Int | - | 10 | Max audience slots |
 | `turn_length` | Int | - | 120 | Turn duration (seconds) |
+| `format_locked` | Boolean | - | false | Format locked after debate begins |
 | `created_at` | DateTime | - | now() | Creation timestamp |
 | `ended_at` | DateTime? | - | null | End timestamp |
 
@@ -79,6 +104,13 @@ Represents a debate session/room.
 - `host: User` - Session creator
 - `moderator: User?` - Session moderator (optional)
 - `participates_ins: ParticipatesIn[]` - All participants
+- `debate_state: DebateState?` - Current debate state (optional)
+- `transcripts: Transcript[]` - Transcript segments for this session
+- `recordings: Recording[]` - Recordings of this session
+- `votes: Vote[]` - All votes cast in this session
+- `audience_queue: AudienceQueue[]` - Audience members in queue
+- `team_assignments: TeamAssignment[]` - Team assignments for this session
+- `role_history: RoleHistory[]` - Role change history for this session
 
 **Notes:**
 - The term "proponent" refers to the debaters that agree with the host
@@ -108,13 +140,186 @@ Join table tracking user participation in sessions.
 
 ---
 
+### Transcript
+
+Speaker-attributed, timestamped transcript segment (REQ-6).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this segment belongs to |
+| `speaker_id` | UUID | FK → User | - | User who spoke this segment |
+| `content` | String | - | - | Transcribed text |
+| `timestamp` | Float | - | - | Seconds since debate start |
+| `duration` | Float? | - | null | Duration of speech segment (seconds) |
+| `confidence` | Float? | - | null | Confidence score (0.0 - 1.0) |
+| `created_at` | DateTime | - | now() | Creation timestamp |
+
+**Relations:**
+- `session: Session` - Session this transcript belongs to
+- `speaker: User` - User who spoke this segment
+
+**Indexes:**
+- Composite index on `(session_id, timestamp)` for efficient timeline queries
+
+---
+
+### Recording
+
+Video recording link for a completed session (REQ-8).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this recording is for |
+| `recorded_by` | UUID | FK → User | - | User who created the recording |
+| `url` | String | - | - | Recording file URL |
+| `duration` | Float? | - | null | Duration in seconds |
+| `file_size` | Int? | - | null | File size in bytes |
+| `mime_type` | String? | - | null | MIME type (e.g., "video/webm") |
+| `created_at` | DateTime | - | now() | Creation timestamp |
+
+**Relations:**
+- `session: Session` - Session this recording is for
+- `recorder: User` - User who created the recording
+
+**Indexes:**
+- Index on `session_id`
+
+---
+
+### Vote
+
+Audience vote to kick or promote a participant (REQ-4).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this vote is in |
+| `voter_id` | UUID | FK → User | - | User casting the vote |
+| `target_user_id` | UUID | FK → User | - | User being voted on |
+| `vote_type` | VoteType | - | - | Type of vote (KICK or PROMOTE) |
+| `created_at` | DateTime | - | now() | Vote timestamp |
+
+**Relations:**
+- `session: Session` - Session this vote belongs to
+- `voter: User` - User who cast the vote
+- `target: User` - User being voted on
+
+**Indexes:**
+- Index on `session_id`
+
+**Constraints:**
+- Unique constraint on `(session_id, voter_id, target_user_id, vote_type)` - each user can only cast one vote of each type against each target per session
+
+---
+
+### AudienceQueue
+
+FIFO queue for audience members waiting to speak (REQ-4).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this queue entry is for |
+| `user_id` | UUID | FK → User | - | User in queue |
+| `joined_queue` | DateTime | - | now() | When user joined the queue |
+
+**Relations:**
+- `session: Session` - Session this queue entry belongs to
+- `user: User` - User in the queue
+
+**Indexes:**
+- Index on `session_id`
+
+**Constraints:**
+- Unique constraint on `(session_id, user_id)` - a user can only be in the queue once per session
+
+---
+
+### TeamAssignment
+
+Team membership for team debates.
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this assignment is for |
+| `user_id` | UUID | FK → User | - | User on the team |
+| `team` | String | - | - | Team identifier: "proponent" or "opponent" |
+| `assigned_at` | DateTime | - | now() | Assignment timestamp |
+
+**Relations:**
+- `session: Session` - Session this assignment belongs to
+- `user: User` - User on the team
+
+**Indexes:**
+- Index on `session_id`
+
+**Constraints:**
+- Unique constraint on `(session_id, user_id)` - a user can only be on one team per session
+
+---
+
+### RoleHistory
+
+Tracks role transitions with timestamps for audit purposes (REQ-2.8).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session where role changed |
+| `user_id` | UUID | FK → User | - | User whose role changed |
+| `old_role` | SessionRole | - | - | Previous role |
+| `new_role` | SessionRole | - | - | New role |
+| `changed_at` | DateTime | - | now() | Timestamp of role change |
+| `reason` | String? | - | null | Optional reason for role change |
+
+**Relations:**
+- `session: Session` - Session this role change belongs to
+- `user: User` - User whose role changed
+
+**Indexes:**
+- Index on `session_id`
+- Index on `user_id`
+
+---
+
 ## Relationships
 
 ```
 User
 ├─ (1) ─ hosts ─ (Many) → Session ─ has ─ (Many) → ParticipatesIn
 ├─ (1) ─ moderates ─ (Many) → Session
-└─ (1) ─ participates ─ (Many) → ParticipatesIn
+├─ (1) ─ participates ─ (Many) → ParticipatesIn
+├─ (1) ─ speaks ─ (Many) → Transcript
+├─ (1) ─ records ─ (Many) → Recording
+├─ (1) ─ casts_votes ─ (Many) → Vote
+├─ (1) ─ receives_votes ─ (Many) → Vote
+├─ (1) ─ queues ─ (Many) → AudienceQueue
+├─ (1) ─ assigned_to ─ (Many) → TeamAssignment
+└─ (1) ─ role_changes ─ (Many) → RoleHistory
+
+Session
+├─ (1) ─ has ─ (1?) → DebateState
+├─ (1) ─ has ─ (Many) → Transcript
+├─ (1) ─ has ─ (Many) → Recording
+├─ (1) ─ has ─ (Many) → Vote
+├─ (1) ─ has ─ (Many) → AudienceQueue
+├─ (1) ─ has ─ (Many) → TeamAssignment
+└─ (1) ─ has ─ (Many) → RoleHistory
 ```
 
 ---
@@ -170,8 +375,15 @@ totalDebaterCapacity = debater_capacity_panel
 | `User.username` | Must be unique across all users |
 | `Session.code` | Must be unique across all sessions |
 | `Session.moderator_id` | Optional; can be null initially |
+| `Session.format_locked` | Set to true when session status changes to LIVE (REQ-1.8) |
 | `ParticipatesIn.left_at` | null = actively in session |
 | `Session.ended_at` | null until session ends |
+| `Vote unique constraint` | Each user can cast only one vote of each type against each target per session |
+| `AudienceQueue unique constraint` | A user can only be in the queue once per session |
+| `TeamAssignment unique constraint` | A user can only be on one team per session |
+| `Transcript.timestamp` | Seconds since debate start, used for replay synchronization |
+| `Vote.vote_type` | Must be KICK or PROMOTE |
+| `TeamAssignment.team` | Must be "proponent" or "opponent" for TEAM format sessions |
 
 ---
 
@@ -186,6 +398,19 @@ totalDebaterCapacity = debater_capacity_panel
 │ email (String?)                                             │
 │ realname (String?)                                          │
 │ role (UniversalRole)                                        │
+│ bio (String?)                                               │
+│ notify_invitations (Boolean)                                │
+│ notify_messages (Boolean)                                   │
+│ notify_weekly_digest (Boolean)                              │
+│ profile_visibility (String)                                 │
+│ show_online_status (Boolean)                                │
+│ allow_direct_messages (Boolean)                             │
+│ theme (String)                                              │
+│ font_size (String)                                          │
+│ animations_enabled (Boolean)                                │
+│ language (String)                                           │
+│ timezone (String)                                           │
+│ date_format (String)                                        │
 │ created_at (DateTime)                                       │
 └─────────────────────────────────────────────────────────────┘
         │                                        │
@@ -208,6 +433,7 @@ totalDebaterCapacity = debater_capacity_panel
 │ debater_capacity_panel (Int?)                               │
 │ audience_capacity (Int)                                     │
 │ turn_length (Int)                                           │
+│ format_locked (Boolean)                                     │
 │ created_at (DateTime)                                       │
 │ ended_at (DateTime?)                                        │
 └─────────────────────────────────────────────────────────────┘
@@ -224,4 +450,75 @@ totalDebaterCapacity = debater_capacity_panel
 │ joined_at (DateTime)                                        │
 │ left_at (DateTime?)                                         │
 │ session_role (SessionRole)                                  │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                     Transcript                              │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ speaker_id (UUID, FK → User)                                │
+│ content (String)                                            │
+│ timestamp (Float)                                           │
+│ duration (Float?)                                           │
+│ confidence (Float?)                                         │
+│ created_at (DateTime)                                       │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                     Recording                               │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ recorded_by (UUID, FK → User)                               │
+│ url (String)                                                │
+│ duration (Float?)                                           │
+│ file_size (Int?)                                            │
+│ mime_type (String?)                                         │
+│ created_at (DateTime)                                       │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                        Vote                                 │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ voter_id (UUID, FK → User)                                  │
+│ target_user_id (UUID, FK → User)                            │
+│ vote_type (VoteType)                                        │
+│ created_at (DateTime)                                       │
+│ UNIQUE (session_id, voter_id, target_user_id, vote_type)   │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                   AudienceQueue                             │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ user_id (UUID, FK → User)                                   │
+│ joined_queue (DateTime)                                     │
+│ UNIQUE (session_id, user_id)                                │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                  TeamAssignment                             │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ user_id (UUID, FK → User)                                   │
+│ team (String)                                               │
+│ assigned_at (DateTime)                                      │
+│ UNIQUE (session_id, user_id)                                │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                    RoleHistory                              │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ user_id (UUID, FK → User)                                   │
+│ old_role (SessionRole)                                      │
+│ new_role (SessionRole)                                      │
+│ changed_at (DateTime)                                       │
+│ reason (String?)                                            │
 └─────────────────────────────────────────────────────────────┘

--- a/lib/actions/debate.ts
+++ b/lib/actions/debate.ts
@@ -2,25 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
-
-async function requireModerator(sessionId: string) {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) throw new Error("Not authenticated")
-
-  const session = await prisma.session.findUnique({
-    where: { id: sessionId },
-  })
-  if (!session) throw new Error("Session not found")
-
-  const allowed =
-    session.moderator_id === user.id || session.host_id === user.id
-  if (!allowed) throw new Error("Not authorized")
-
-  return { user, session }
-}
+import { requireHostOrModerator } from "@/lib/actions/utils"
 
 export async function getDebateState(sessionId: string) {
   const state = await prisma.debateState.findUnique({
@@ -46,7 +28,7 @@ export async function startDebate(
   debaters: { userId: string; displayName: string }[],
   turnLength: number
 ) {
-  await requireModerator(sessionId)
+  await requireHostOrModerator(sessionId)
   if (debaters.length !== 2) throw new Error("Exactly 2 debaters required")
 
   const now = Date.now()
@@ -73,7 +55,7 @@ export async function startDebate(
 }
 
 export async function advanceTurn(sessionId: string) {
-  await requireModerator(sessionId)
+  await requireHostOrModerator(sessionId)
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
@@ -122,7 +104,7 @@ export async function advanceTurnIfExpired(sessionId: string) {
 }
 
 export async function pauseDebate(sessionId: string) {
-  await requireModerator(sessionId)
+  await requireHostOrModerator(sessionId)
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
@@ -145,7 +127,7 @@ export async function pauseDebate(sessionId: string) {
 }
 
 export async function resumeDebate(sessionId: string) {
-  await requireModerator(sessionId)
+  await requireHostOrModerator(sessionId)
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
@@ -164,7 +146,7 @@ export async function resumeDebate(sessionId: string) {
 }
 
 export async function endDebate(sessionId: string) {
-  await requireModerator(sessionId)
+  await requireHostOrModerator(sessionId)
   await prisma.debateState
     .delete({ where: { session_id: sessionId } })
     .catch(() => {})

--- a/lib/actions/queue.ts
+++ b/lib/actions/queue.ts
@@ -1,0 +1,113 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+import { requireAuth, requireHostOrModerator } from "@/lib/actions/utils"
+import { SessionRole, SessionStatus } from "@/lib/generated/prisma"
+
+export async function joinQueue(sessionId: string) {
+  const user = await requireAuth()
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { status: true },
+  })
+  if (!session) throw new Error("Session not found")
+  if (session.status !== SessionStatus.LIVE) throw new Error("Session is not live")
+
+  // Verify user is an audience member
+  const participation = await prisma.participatesIn.findUnique({
+    where: {
+      user_id_session_id: { user_id: user.id, session_id: sessionId },
+    },
+  })
+  if (!participation || participation.left_at) {
+    throw new Error("Not a participant in this session")
+  }
+  if (participation.session_role !== SessionRole.AUDIENCE) {
+    throw new Error("Only audience members can join the queue")
+  }
+
+  return await prisma.audienceQueue.create({
+    data: {
+      session_id: sessionId,
+      user_id: user.id,
+    },
+  })
+}
+
+export async function leaveQueue(sessionId: string) {
+  const user = await requireAuth()
+
+  await prisma.audienceQueue.delete({
+    where: {
+      session_id_user_id: {
+        session_id: sessionId,
+        user_id: user.id,
+      },
+    },
+  })
+}
+
+export async function getQueue(sessionId: string) {
+  return await prisma.audienceQueue.findMany({
+    where: { session_id: sessionId },
+    orderBy: { joined_queue: "asc" },
+    include: {
+      user: { select: { id: true, username: true, realname: true } },
+    },
+  })
+}
+
+export async function promoteFromQueue(sessionId: string, userId?: string) {
+  await requireHostOrModerator(sessionId)
+
+  return await prisma.$transaction(async (tx) => {
+    // Find the user to promote: specific user or FIFO head
+    const queueEntry = userId
+      ? await tx.audienceQueue.findUnique({
+          where: { session_id_user_id: { session_id: sessionId, user_id: userId } },
+        })
+      : await tx.audienceQueue.findFirst({
+          where: { session_id: sessionId },
+          orderBy: { joined_queue: "asc" },
+        })
+
+    if (!queueEntry) throw new Error("No one in the queue")
+
+    const targetUserId = queueEntry.user_id
+
+    // Update role to DEBATER
+    await tx.participatesIn.update({
+      where: {
+        user_id_session_id: {
+          user_id: targetUserId,
+          session_id: sessionId,
+        },
+      },
+      data: { session_role: SessionRole.DEBATER },
+    })
+
+    // Remove from queue
+    await tx.audienceQueue.delete({
+      where: {
+        session_id_user_id: {
+          session_id: sessionId,
+          user_id: targetUserId,
+        },
+      },
+    })
+
+    // Log role transition
+    await tx.roleHistory.create({
+      data: {
+        session_id: sessionId,
+        user_id: targetUserId,
+        old_role: SessionRole.AUDIENCE,
+        new_role: SessionRole.DEBATER,
+        reason: "Promoted from queue",
+      },
+    })
+
+    return { promotedUserId: targetUserId }
+  })
+}

--- a/lib/actions/recording.ts
+++ b/lib/actions/recording.ts
@@ -1,0 +1,53 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+import { requireAuth, requireHostOrModerator, requireParticipant } from "@/lib/actions/utils"
+
+export async function createRecording(
+  sessionId: string,
+  url: string,
+  duration?: number,
+  fileSize?: number,
+  mimeType?: string
+) {
+  const { user } = await requireHostOrModerator(sessionId)
+
+  return await prisma.recording.create({
+    data: {
+      session_id: sessionId,
+      recorded_by: user.id,
+      url,
+      duration: duration ?? null,
+      file_size: fileSize ?? null,
+      mime_type: mimeType ?? null,
+    },
+  })
+}
+
+export async function getRecordingsBySession(sessionId: string) {
+  await requireParticipant(sessionId)
+
+  return await prisma.recording.findMany({
+    where: { session_id: sessionId },
+    orderBy: { created_at: "desc" },
+    include: {
+      recorder: { select: { id: true, username: true, realname: true } },
+    },
+  })
+}
+
+export async function deleteRecording(recordingId: string) {
+  const user = await requireAuth()
+
+  const recording = await prisma.recording.findUnique({
+    where: { id: recordingId },
+    include: { session: { select: { host_id: true } } },
+  })
+  if (!recording) throw new Error("Recording not found")
+
+  if (recording.recorded_by !== user.id && recording.session.host_id !== user.id) {
+    throw new Error("Not authorized to delete this recording")
+  }
+
+  await prisma.recording.delete({ where: { id: recordingId } })
+}

--- a/lib/actions/session.ts
+++ b/lib/actions/session.ts
@@ -269,6 +269,8 @@ export async function joinSessionAsDebater(sessionId: string, isProponent: boole
         },
     })
 
+    const previousRole = existing?.session_role ?? SessionRole.AUDIENCE
+
     if (existing) {
         await prisma.participatesIn.update({
             where: {
@@ -288,6 +290,17 @@ export async function joinSessionAsDebater(sessionId: string, isProponent: boole
             },
         })
     }
+
+    // Log role transition
+    await prisma.roleHistory.create({
+        data: {
+            session_id: sessionId,
+            user_id: user.id,
+            old_role: previousRole,
+            new_role: SessionRole.DEBATER,
+            reason: "Joined as debater",
+        },
+    })
 }
 
 export async function leaveSession(sessionId: string) {
@@ -319,15 +332,35 @@ export async function assignModerator(sessionId: string, targetUserId: string) {
   if (session.host_id !== user.id) throw new Error("Only the host can assign a moderator")
   if (targetUserId === user.id) throw new Error("Host cannot assign themselves as moderator")
 
+  // Get current role of target user for history logging
+  const targetParticipation = await prisma.participatesIn.findUnique({
+    where: { user_id_session_id: { user_id: targetUserId, session_id: sessionId } },
+    select: { session_role: true },
+  })
+  if (!targetParticipation) throw new Error("Target user is not a participant")
+
+  const txOps = []
+
   // Demote previous moderator back to AUDIENCE (if any)
   if (session.moderator_id && session.moderator_id !== targetUserId) {
-    await prisma.participatesIn.updateMany({
-      where: { session_id: sessionId, user_id: session.moderator_id },
-      data: { session_role: SessionRole.AUDIENCE },
-    })
+    txOps.push(
+      prisma.participatesIn.updateMany({
+        where: { session_id: sessionId, user_id: session.moderator_id },
+        data: { session_role: SessionRole.AUDIENCE },
+      }),
+      prisma.roleHistory.create({
+        data: {
+          session_id: sessionId,
+          user_id: session.moderator_id,
+          old_role: SessionRole.MODERATOR,
+          new_role: SessionRole.AUDIENCE,
+          reason: "Demoted: new moderator assigned",
+        },
+      })
+    )
   }
 
-  await prisma.$transaction([
+  txOps.push(
     prisma.session.update({
       where: { id: sessionId },
       data: { moderator_id: targetUserId },
@@ -336,7 +369,18 @@ export async function assignModerator(sessionId: string, targetUserId: string) {
       where: { user_id_session_id: { user_id: targetUserId, session_id: sessionId } },
       data: { session_role: SessionRole.MODERATOR },
     }),
-  ])
+    prisma.roleHistory.create({
+      data: {
+        session_id: sessionId,
+        user_id: targetUserId,
+        old_role: targetParticipation.session_role,
+        new_role: SessionRole.MODERATOR,
+        reason: "Assigned as moderator by host",
+      },
+    })
+  )
+
+  await prisma.$transaction(txOps)
 }
 
 export async function kickParticipant(sessionId: string, targetUserId: string) {
@@ -356,6 +400,12 @@ export async function kickParticipant(sessionId: string, targetUserId: string) {
   // Cannot kick yourself
   if (targetUserId === user.id) throw new Error("Cannot kick yourself")
 
+  // Get current role for history logging
+  const participation = await prisma.participatesIn.findUnique({
+    where: { user_id_session_id: { user_id: targetUserId, session_id: sessionId } },
+    select: { session_role: true },
+  })
+
   await prisma.participatesIn.update({
     where: {
       user_id_session_id: {
@@ -365,6 +415,18 @@ export async function kickParticipant(sessionId: string, targetUserId: string) {
     },
     data: { left_at: new Date() },
   })
+
+  if (participation) {
+    await prisma.roleHistory.create({
+      data: {
+        session_id: sessionId,
+        user_id: targetUserId,
+        old_role: participation.session_role,
+        new_role: SessionRole.AUDIENCE,
+        reason: "Kicked by moderator/host",
+      },
+    })
+  }
 }
 
 export async function updateSessionStatus(sessionId: string, status: SessionStatus) {
@@ -390,6 +452,10 @@ export async function updateSessionStatus(sessionId: string, status: SessionStat
 
     const data : Prisma.SessionUpdateInput = { }
     data.status = status
+
+    if (status === SessionStatus.LIVE) {
+        data.format_locked = true
+    }
 
     if (status === SessionStatus.ENDED) {
         data.ended_at = new Date()

--- a/lib/actions/team.ts
+++ b/lib/actions/team.ts
@@ -1,0 +1,59 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+import { requireHostOrModerator } from "@/lib/actions/utils"
+import { SessionType } from "@/lib/generated/prisma"
+
+export async function assignTeam(
+  sessionId: string,
+  userId: string,
+  team: string
+) {
+  const { session } = await requireHostOrModerator(sessionId)
+
+  if (session.type !== SessionType.TEAM) {
+    throw new Error("Team assignments are only for TEAM format sessions")
+  }
+
+  if (team !== "proponent" && team !== "opponent") {
+    throw new Error("Team must be 'proponent' or 'opponent'")
+  }
+
+  return await prisma.teamAssignment.upsert({
+    where: {
+      session_id_user_id: {
+        session_id: sessionId,
+        user_id: userId,
+      },
+    },
+    create: {
+      session_id: sessionId,
+      user_id: userId,
+      team,
+    },
+    update: { team },
+  })
+}
+
+export async function getTeamAssignments(sessionId: string) {
+  return await prisma.teamAssignment.findMany({
+    where: { session_id: sessionId },
+    include: {
+      user: { select: { id: true, username: true, realname: true } },
+    },
+    orderBy: { assigned_at: "asc" },
+  })
+}
+
+export async function removeFromTeam(sessionId: string, userId: string) {
+  await requireHostOrModerator(sessionId)
+
+  await prisma.teamAssignment.delete({
+    where: {
+      session_id_user_id: {
+        session_id: sessionId,
+        user_id: userId,
+      },
+    },
+  })
+}

--- a/lib/actions/transcript.ts
+++ b/lib/actions/transcript.ts
@@ -1,0 +1,37 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+import { requireParticipant } from "@/lib/actions/utils"
+
+export async function createTranscriptSegment(
+  sessionId: string,
+  content: string,
+  timestamp: number,
+  duration?: number,
+  confidence?: number
+) {
+  const user = await requireParticipant(sessionId)
+
+  return await prisma.transcript.create({
+    data: {
+      session_id: sessionId,
+      speaker_id: user.id,
+      content,
+      timestamp,
+      duration: duration ?? null,
+      confidence: confidence ?? null,
+    },
+  })
+}
+
+export async function getTranscriptBySession(sessionId: string) {
+  await requireParticipant(sessionId)
+
+  return await prisma.transcript.findMany({
+    where: { session_id: sessionId },
+    orderBy: { timestamp: "asc" },
+    include: {
+      speaker: { select: { id: true, username: true, realname: true } },
+    },
+  })
+}

--- a/lib/actions/user.ts
+++ b/lib/actions/user.ts
@@ -2,6 +2,27 @@
 
 import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
+import { requireAuth } from "@/lib/actions/utils"
+
+const VALID_THEMES = ["dark", "light", "system"] as const
+const VALID_FONT_SIZES = ["small", "medium", "large"] as const
+const VALID_PROFILE_VISIBILITY = ["public", "private"] as const
+
+type UserPreferences = {
+    bio?: string | null
+    notify_invitations?: boolean
+    notify_messages?: boolean
+    notify_weekly_digest?: boolean
+    profile_visibility?: string
+    show_online_status?: boolean
+    allow_direct_messages?: boolean
+    theme?: string
+    font_size?: string
+    animations_enabled?: boolean
+    language?: string
+    timezone?: string
+    date_format?: string
+}
 
 export async function ensureUserProfile() {
     const supabase = await createClient()
@@ -35,4 +56,50 @@ export async function ensureUserProfile() {
     })
 
     return result
+}
+
+export async function getUserPreferences() {
+    const user = await requireAuth()
+
+    return await prisma.user.findUnique({
+        where: { id: user.id },
+        select: {
+            username: true,
+            email: true,
+            realname: true,
+            bio: true,
+            notify_invitations: true,
+            notify_messages: true,
+            notify_weekly_digest: true,
+            profile_visibility: true,
+            show_online_status: true,
+            allow_direct_messages: true,
+            theme: true,
+            font_size: true,
+            animations_enabled: true,
+            language: true,
+            timezone: true,
+            date_format: true,
+        },
+    })
+}
+
+export async function updateUserPreferences(prefs: UserPreferences) {
+    const user = await requireAuth()
+
+    // Validate allowed values
+    if (prefs.theme !== undefined && !VALID_THEMES.includes(prefs.theme as typeof VALID_THEMES[number])) {
+        throw new Error("Theme must be 'dark', 'light', or 'system'")
+    }
+    if (prefs.font_size !== undefined && !VALID_FONT_SIZES.includes(prefs.font_size as typeof VALID_FONT_SIZES[number])) {
+        throw new Error("Font size must be 'small', 'medium', or 'large'")
+    }
+    if (prefs.profile_visibility !== undefined && !VALID_PROFILE_VISIBILITY.includes(prefs.profile_visibility as typeof VALID_PROFILE_VISIBILITY[number])) {
+        throw new Error("Profile visibility must be 'public' or 'private'")
+    }
+
+    return await prisma.user.update({
+        where: { id: user.id },
+        data: prefs,
+    })
 }

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -1,0 +1,57 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+import { prisma } from "@/lib/prisma"
+
+/**
+ * Require authenticated user. Returns the Supabase user object.
+ * Throws if not authenticated.
+ */
+export async function requireAuth() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+  return user
+}
+
+/**
+ * Require that the current user is the host or moderator of the given session.
+ * Returns both the user and session objects.
+ */
+export async function requireHostOrModerator(sessionId: string) {
+  const user = await requireAuth()
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+  })
+  if (!session) throw new Error("Session not found")
+
+  if (session.host_id !== user.id && session.moderator_id !== user.id) {
+    throw new Error("Not authorized")
+  }
+
+  return { user, session }
+}
+
+/**
+ * Verify that the authenticated user is an active participant in the session.
+ * Returns the user object.
+ */
+export async function requireParticipant(sessionId: string) {
+  const user = await requireAuth()
+
+  const participation = await prisma.participatesIn.findUnique({
+    where: {
+      user_id_session_id: {
+        user_id: user.id,
+        session_id: sessionId,
+      },
+    },
+  })
+
+  if (!participation || participation.left_at) {
+    throw new Error("Not a participant in this session")
+  }
+
+  return user
+}

--- a/lib/actions/vote.ts
+++ b/lib/actions/vote.ts
@@ -1,0 +1,85 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+import { requireAuth } from "@/lib/actions/utils"
+import { SessionStatus, VoteType } from "@/lib/generated/prisma"
+
+export async function castVote(
+  sessionId: string,
+  targetUserId: string,
+  voteType: VoteType
+) {
+  const user = await requireAuth()
+
+  if (user.id === targetUserId) throw new Error("Cannot vote for yourself")
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { status: true },
+  })
+  if (!session) throw new Error("Session not found")
+  if (session.status !== SessionStatus.LIVE) throw new Error("Session is not live")
+
+  // Verify voter is an active participant
+  const participation = await prisma.participatesIn.findUnique({
+    where: {
+      user_id_session_id: { user_id: user.id, session_id: sessionId },
+    },
+  })
+  if (!participation || participation.left_at) {
+    throw new Error("Not a participant in this session")
+  }
+
+  return await prisma.vote.upsert({
+    where: {
+      session_id_voter_id_target_user_id_vote_type: {
+        session_id: sessionId,
+        voter_id: user.id,
+        target_user_id: targetUserId,
+        vote_type: voteType,
+      },
+    },
+    create: {
+      session_id: sessionId,
+      voter_id: user.id,
+      target_user_id: targetUserId,
+      vote_type: voteType,
+    },
+    update: {},
+  })
+}
+
+export async function retractVote(
+  sessionId: string,
+  targetUserId: string,
+  voteType: VoteType
+) {
+  const user = await requireAuth()
+
+  await prisma.vote.delete({
+    where: {
+      session_id_voter_id_target_user_id_vote_type: {
+        session_id: sessionId,
+        voter_id: user.id,
+        target_user_id: targetUserId,
+        vote_type: voteType,
+      },
+    },
+  })
+}
+
+export async function getVoteCounts(
+  sessionId: string,
+  targetUserId: string,
+  voteType: VoteType
+) {
+  const count = await prisma.vote.count({
+    where: {
+      session_id: sessionId,
+      target_user_id: targetUserId,
+      vote_type: voteType,
+    },
+  })
+
+  return { count }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,8 @@ datasource db {
   provider = "postgresql"
 }
 
+// ── Enums ──
+
 enum UniversalRole {
   ADMIN
   USER
@@ -33,6 +35,14 @@ enum SessionStatus {
   ENDED
 }
 
+/// Type of vote cast by audience members
+enum VoteType {
+  KICK
+  PROMOTE
+}
+
+// ── Models ──
+
 model User {
   id         String        @id @db.Uuid
   username   String        @unique
@@ -41,9 +51,40 @@ model User {
   role       UniversalRole @default(USER)
   created_at DateTime      @default(now())
 
+  // Profile
+  bio String?
+
+  // Notification preferences
+  notify_invitations   Boolean @default(true)
+  notify_messages      Boolean @default(true)
+  notify_weekly_digest Boolean @default(false)
+
+  // Privacy preferences
+  profile_visibility    String  @default("public")
+  show_online_status    Boolean @default(true)
+  allow_direct_messages Boolean @default(true)
+
+  // Appearance preferences
+  theme              String  @default("dark")
+  font_size          String  @default("medium")
+  animations_enabled Boolean @default(true)
+
+  // Language & region preferences
+  language    String @default("en")
+  timezone    String @default("UTC")
+  date_format String @default("MM/DD/YYYY")
+
+  // Relations
   hosted_sessions    Session[]        @relation("HostToSession")
   moderated_sessions Session[]        @relation("ModeratorToSession")
   participates_ins   ParticipatesIn[]
+  transcripts        Transcript[]
+  recordings         Recording[]
+  votes_cast         Vote[]           @relation("VoterToVote")
+  votes_received     Vote[]           @relation("TargetToVote")
+  audience_queues    AudienceQueue[]
+  team_assignments   TeamAssignment[]
+  role_history       RoleHistory[]
 }
 
 model ParticipatesIn {
@@ -73,6 +114,8 @@ model Session {
   debater_capacity_panel     Int?          @default(5)
   audience_capacity          Int           @default(10)
   turn_length                Int           @default(120)
+  /// Whether the debate format is locked (true after debate begins, per REQ-1.8)
+  format_locked              Boolean       @default(false)
   created_at                 DateTime      @default(now())
   ended_at                   DateTime?
 
@@ -80,6 +123,12 @@ model Session {
   moderator        User?            @relation("ModeratorToSession", fields: [moderator_id], references: [id])
   participates_ins ParticipatesIn[]
   debate_state     DebateState?
+  transcripts      Transcript[]
+  recordings       Recording[]
+  votes            Vote[]
+  audience_queue   AudienceQueue[]
+  team_assignments TeamAssignment[]
+  role_history     RoleHistory[]
 }
 
 model DebateState {
@@ -93,4 +142,110 @@ model DebateState {
   paused_time_remaining Float   @default(0)
 
   session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+}
+
+/// Speaker-attributed, timestamped transcript segment (REQ-6)
+model Transcript {
+  id         String   @id @default(cuid())
+  session_id String
+  speaker_id String   @db.Uuid
+  content    String
+  /// Seconds since debate start
+  timestamp  Float
+  /// Duration of this speech segment in seconds
+  duration   Float?
+  /// Confidence score from the transcription engine (0.0 - 1.0)
+  confidence Float?
+  created_at DateTime @default(now())
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  speaker User    @relation(fields: [speaker_id], references: [id])
+
+  @@index([session_id, timestamp])
+}
+
+/// Video recording link for a completed session (REQ-8)
+model Recording {
+  id          String   @id @default(cuid())
+  session_id  String
+  recorded_by String   @db.Uuid
+  url         String
+  /// Duration in seconds
+  duration    Float?
+  /// File size in bytes
+  file_size   Int?
+  mime_type   String?
+  created_at  DateTime @default(now())
+
+  session  Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  recorder User    @relation(fields: [recorded_by], references: [id])
+
+  @@index([session_id])
+}
+
+/// Audience vote to kick or promote a participant (REQ-4)
+model Vote {
+  id             String   @id @default(cuid())
+  session_id     String
+  voter_id       String   @db.Uuid
+  target_user_id String   @db.Uuid
+  vote_type      VoteType
+  created_at     DateTime @default(now())
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  voter   User    @relation("VoterToVote", fields: [voter_id], references: [id])
+  target  User    @relation("TargetToVote", fields: [target_user_id], references: [id])
+
+  /// Each user can only cast one vote of each type against each target per session
+  @@unique([session_id, voter_id, target_user_id, vote_type])
+  @@index([session_id])
+}
+
+/// FIFO queue for audience members waiting to speak (REQ-4)
+model AudienceQueue {
+  id           String   @id @default(cuid())
+  session_id   String
+  user_id      String   @db.Uuid
+  joined_queue DateTime @default(now())
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [user_id], references: [id])
+
+  /// A user can only be in the queue once per session
+  @@unique([session_id, user_id])
+  @@index([session_id])
+}
+
+/// Team membership for team debates
+model TeamAssignment {
+  id          String   @id @default(cuid())
+  session_id  String
+  user_id     String   @db.Uuid
+  /// Team identifier: "proponent" or "opponent"
+  team        String
+  assigned_at DateTime @default(now())
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [user_id], references: [id])
+
+  /// A user can only be on one team per session
+  @@unique([session_id, user_id])
+  @@index([session_id])
+}
+
+/// Tracks role transitions with timestamps for audit purposes (REQ-2.8)
+model RoleHistory {
+  id         String      @id @default(cuid())
+  session_id String
+  user_id    String      @db.Uuid
+  old_role   SessionRole
+  new_role   SessionRole
+  changed_at DateTime    @default(now())
+  reason     String?
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [user_id], references: [id])
+
+  @@index([session_id])
+  @@index([user_id])
 }


### PR DESCRIPTION
## Summary
Closes #16

- Add 6 new Prisma models: **Transcript**, **Recording**, **Vote**, **AudienceQueue**, **TeamAssignment**, **RoleHistory**
- Add `VoteType` enum (KICK, PROMOTE)
- Add 12 user preference fields to User model (notifications, privacy, appearance, language/region)
- Add `format_locked` Boolean to Session model (REQ-1.8)
- Create 5 new server action files with shared auth helpers (`utils.ts`, `transcript.ts`, `recording.ts`, `vote.ts`, `queue.ts`, `team.ts`)
- Extend existing actions: `updateUserPreferences`/`getUserPreferences` in user.ts, `format_locked` in session.ts, RoleHistory audit logging in `assignModerator`/`kickParticipant`/`joinSessionAsDebater`
- Refactor debate.ts to use shared `requireHostOrModerator` from utils.ts
- Update DATABASE.md and ACTIONS.md documentation

## Test plan
- [x] 176 unit tests pass (80 new tests added)
- [x] 100% coverage on all new action files (queue, recording, team, transcript, user, utils, vote)
- [x] `npm run build` passes cleanly
- [x] Existing tests unbroken (updated session.test.ts mock for new roleHistory model)