### PR TITLE
fix: WebRTC reconnection logic, transport recovery, and quality monitoring

### DIFF
--- a/__tests__/hooks/useMediasoup.test.ts
+++ b/__tests__/hooks/useMediasoup.test.ts
@@ -1,9 +1,31 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
 
-// ── Mock socket.io-client ──
+// ── Mocks ──
+
+const mockSendTransport = {
+  id: 'send-transport-id',
+  on: vi.fn(),
+  produce: vi.fn(),
+  close: vi.fn(),
+}
+
+const mockRecvTransport = {
+  id: 'recv-transport-id',
+  on: vi.fn(),
+  consume: vi.fn(),
+  close: vi.fn(),
+}
+
+const mockDevice = {
+  load: vi.fn(),
+  loaded: false,
+  rtpCapabilities: { codecs: [] },
+  createSendTransport: vi.fn(() => mockSendTransport),
+  createRecvTransport: vi.fn(() => mockRecvTransport),
+}
 
 const mockSocket = {
   on: vi.fn(),
@@ -16,59 +38,9 @@ vi.mock('socket.io-client', () => ({
   io: vi.fn(() => mockSocket),
 }))
 
-// ── Mock mediasoup-client ──
-
-const mockSendTransport = {
-  id: 'send-transport-1',
-  on: vi.fn(),
-  produce: vi.fn(),
-  close: vi.fn(),
-}
-
-const mockRecvTransport = {
-  id: 'recv-transport-1',
-  on: vi.fn(),
-  consume: vi.fn(),
-  close: vi.fn(),
-}
-
-const mockDevice = {
-  load: vi.fn(),
-  rtpCapabilities: { codecs: [] },
-  createSendTransport: vi.fn(() => mockSendTransport),
-  createRecvTransport: vi.fn(() => mockRecvTransport),
-}
-
 vi.mock('mediasoup-client', () => ({
   Device: vi.fn(() => mockDevice),
 }))
-
-// ── Mock getUserMedia ──
-
-const mockVideoTrack = {
-  kind: 'video',
-  enabled: true,
-  stop: vi.fn(),
-}
-
-const mockAudioTrack = {
-  kind: 'audio',
-  enabled: true,
-  stop: vi.fn(),
-}
-
-const mockMediaStream = {
-  getVideoTracks: () => [mockVideoTrack],
-  getAudioTracks: () => [mockAudioTrack],
-  getTracks: () => [mockVideoTrack, mockAudioTrack],
-}
-
-Object.defineProperty(global.navigator, 'mediaDevices', {
-  value: {
-    getUserMedia: vi.fn().mockResolvedValue(mockMediaStream),
-  },
-  writable: true,
-})
 
 // ── Import after mocks ──
 
@@ -83,183 +55,645 @@ function getSocketHandler(event: string): Function | undefined {
   return undefined
 }
 
-function getSocketEmitAck(event: string): { data: any; callback: Function } | undefined {
-  for (const call of mockSocket.emit.mock.calls) {
-    if (call[0] === event) {
-      return { data: call[1], callback: call[2] }
-    }
-  }
-  return undefined
-}
-
-const defaultOptions = {
-  sfuUrl: 'http://localhost:3001',
-  roomId: 'test-room',
-  displayName: 'TestUser',
-  enabled: true,
-}
-
-beforeEach(() => {
-  vi.clearAllMocks()
-  mockSocket.connected = true
-  mockVideoTrack.enabled = true
-  mockAudioTrack.enabled = true
-})
+// ── Tests ──
 
 describe('useMediasoup', () => {
-  describe('disabled/missing params', () => {
-    it('stays disconnected when enabled is false', () => {
-      const { result } = renderHook(() =>
-        useMediasoup({ ...defaultOptions, enabled: false })
-      )
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDevice.loaded = false
+    mockSocket.connected = true
 
-      expect(result.current.connectionState).toBe('disconnected')
-      expect(result.current.localStream).toBeNull()
-      expect(result.current.remoteStreams.size).toBe(0)
+    // Default: emit with ack returns success
+    mockSocket.emit.mockImplementation((event: string, data: any, callback?: Function) => {
+      if (callback) {
+        // Default responses
+        if (event === 'getRouterRtpCapabilities') {
+          callback({ success: true, rtpCapabilities: { codecs: [] }, iceServers: [] })
+        } else if (event === 'joinRoom') {
+          callback({ success: true, stablePeerId: 'stable-peer-123' })
+        } else if (event === 'createWebRtcTransport') {
+          callback({
+            success: true,
+            transportOptions: {
+              id: data.direction === 'send' ? 'send-transport-id' : 'recv-transport-id',
+              iceParameters: {},
+              iceCandidates: [],
+              dtlsParameters: {},
+            },
+          })
+        } else if (event === 'getProducers') {
+          callback({ success: true, producers: [] })
+        } else {
+          callback({ success: true })
+        }
+      }
     })
 
-    it('stays disconnected when sfuUrl is undefined', () => {
-      const { result } = renderHook(() =>
-        useMediasoup({ ...defaultOptions, sfuUrl: undefined })
-      )
-
-      expect(result.current.connectionState).toBe('disconnected')
+    mockSendTransport.produce.mockResolvedValue({
+      id: 'producer-id',
+      close: vi.fn(),
     })
 
-    it('stays disconnected when roomId is empty', () => {
-      const { result } = renderHook(() =>
-        useMediasoup({ ...defaultOptions, roomId: '' })
-      )
-
-      expect(result.current.connectionState).toBe('disconnected')
+    mockRecvTransport.consume.mockResolvedValue({
+      id: 'consumer-id',
+      track: { kind: 'audio', enabled: true },
+      close: vi.fn(),
+      producerId: 'remote-producer-id',
     })
 
-    it('stays disconnected when displayName is empty', () => {
-      const { result } = renderHook(() =>
-        useMediasoup({ ...defaultOptions, displayName: '' })
-      )
-
-      expect(result.current.connectionState).toBe('disconnected')
+    // Mock getUserMedia
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getVideoTracks: () => [{ readyState: 'live', enabled: true }],
+          getAudioTracks: () => [{ readyState: 'live', enabled: true }],
+          getTracks: () => [{ stop: vi.fn() }],
+        }),
+      },
+      configurable: true,
     })
   })
 
-  describe('connection', () => {
-    it('sets connectionState to connecting when enabled', async () => {
-      renderHook(() => useMediasoup(defaultOptions))
+  // ────────────────────────────────────────────────────────────────────
+  // Existing tests (updated for new shape)
+  // ────────────────────────────────────────────────────────────────────
 
-      // The effect triggers async connect(), which sets state to 'connecting'
-      // We need to wait for the async module imports
-      await vi.waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalled()
+  it('should stay disconnected when disabled', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: false,
       })
+    )
+
+    expect(result.current.connectionState).toBe('disconnected')
+    expect(result.current.localStream).toBeNull()
+    expect(result.current.remoteStreams.size).toBe(0)
+    expect(result.current.reconnectingPeers.size).toBe(0)
+  })
+
+  it('should stay disconnected when sfuUrl is missing', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: undefined,
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    expect(result.current.connectionState).toBe('disconnected')
+    expect(result.current.localStream).toBeNull()
+    expect(result.current.remoteStreams.size).toBe(0)
+    expect(result.current.reconnectingPeers.size).toBe(0)
+  })
+
+  it('should stay disconnected when roomId is missing', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: '',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    expect(result.current.connectionState).toBe('disconnected')
+    expect(result.current.localStream).toBeNull()
+    expect(result.current.remoteStreams.size).toBe(0)
+    expect(result.current.reconnectingPeers.size).toBe(0)
+  })
+
+  it('should stay disconnected when displayName is missing', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: '',
+        enabled: true,
+      })
+    )
+
+    expect(result.current.connectionState).toBe('disconnected')
+    expect(result.current.localStream).toBeNull()
+    expect(result.current.remoteStreams.size).toBe(0)
+    expect(result.current.reconnectingPeers.size).toBe(0)
+  })
+
+  it('should set connecting state on mount', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
+  })
+
+  it('should set error state on connect_error when no previous connection', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
     })
 
-    it('sets connectionState to error on connect_error', async () => {
-      const { result } = renderHook(() => useMediasoup(defaultOptions))
+    const connectErrorHandler = getSocketHandler('connect_error')
+    expect(connectErrorHandler).toBeDefined()
 
-      await vi.waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalled()
-      })
+    act(() => {
+      connectErrorHandler!(new Error('Connection failed'))
+    })
 
-      const connectErrorHandler = getSocketHandler('connect_error')
-      expect(connectErrorHandler).toBeDefined()
-
-      await act(async () => {
-        connectErrorHandler!(new Error('Connection refused'))
-      })
-
+    await waitFor(() => {
       expect(result.current.connectionState).toBe('error')
     })
   })
 
-  describe('toggleMute', () => {
-    it('toggles audio track enabled state', async () => {
-      const { result } = renderHook(() => useMediasoup(defaultOptions))
+  it('should toggle audio mute', async () => {
+    const mockTrack = {
+      readyState: 'live',
+      enabled: true,
+      stop: vi.fn(),
+    }
+    const mockStream = {
+      getVideoTracks: () => [mockTrack],
+      getAudioTracks: () => [mockTrack],
+      getTracks: () => [mockTrack],
+    }
+    ;(global.navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream)
 
-      // Simulate the full connection flow to populate localStreamRef
-      await vi.waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalled()
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
       })
+    )
 
-      // We can't easily complete the full async flow in unit tests,
-      // but we can test toggleMute returns without error when no stream
-      expect(result.current.audioMuted).toBe(false)
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
 
-      act(() => {
-        result.current.toggleMute()
+    // Trigger connect to set up localStream
+    const connectHandler = getSocketHandler('connect')
+    if (connectHandler) {
+      await act(async () => {
+        await connectHandler()
       })
+    }
 
-      // Without a local stream, toggleMute is a no-op
+    await waitFor(() => {
+      expect(result.current.localStream).not.toBeNull()
+    })
+
+    expect(result.current.audioMuted).toBe(false)
+
+    act(() => {
+      result.current.toggleMute()
+    })
+
+    await waitFor(() => {
+      expect(result.current.audioMuted).toBe(true)
+    })
+
+    act(() => {
+      result.current.toggleMute()
+    })
+
+    await waitFor(() => {
       expect(result.current.audioMuted).toBe(false)
     })
   })
 
-  describe('toggleVideo', () => {
-    it('toggles video track enabled state', async () => {
-      const { result } = renderHook(() => useMediasoup(defaultOptions))
+  it('should toggle video off', async () => {
+    const mockTrack = {
+      readyState: 'live',
+      enabled: true,
+      stop: vi.fn(),
+    }
+    const mockStream = {
+      getVideoTracks: () => [mockTrack],
+      getAudioTracks: () => [mockTrack],
+      getTracks: () => [mockTrack],
+    }
+    ;(global.navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream)
 
-      await vi.waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalled()
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
       })
+    )
 
-      expect(result.current.videoOff).toBe(false)
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
 
-      act(() => {
-        result.current.toggleVideo()
+    // Trigger connect to set up localStream
+    const connectHandler = getSocketHandler('connect')
+    if (connectHandler) {
+      await act(async () => {
+        await connectHandler()
       })
+    }
 
-      // Without a local stream, toggleVideo is a no-op
+    await waitFor(() => {
+      expect(result.current.localStream).not.toBeNull()
+    })
+
+    expect(result.current.videoOff).toBe(false)
+
+    act(() => {
+      result.current.toggleVideo()
+    })
+
+    await waitFor(() => {
+      expect(result.current.videoOff).toBe(true)
+    })
+
+    act(() => {
+      result.current.toggleVideo()
+    })
+
+    await waitFor(() => {
       expect(result.current.videoOff).toBe(false)
     })
   })
 
-  describe('disconnect', () => {
-    it('sets state to disconnected and disconnects socket', async () => {
-      const { result } = renderHook(() => useMediasoup(defaultOptions))
-
-      await vi.waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalled()
+  it('should call cleanup on disconnect', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
       })
+    )
 
-      act(() => {
-        result.current.disconnect()
-      })
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
 
+    act(() => {
+      result.current.disconnect()
+    })
+
+    await waitFor(() => {
+      expect(mockSocket.disconnect).toHaveBeenCalled()
       expect(result.current.connectionState).toBe('disconnected')
-      expect(mockSocket.disconnect).toHaveBeenCalled()
     })
   })
 
-  describe('cleanup on unmount', () => {
-    it('disconnects socket on unmount', async () => {
-      const { unmount } = renderHook(() => useMediasoup(defaultOptions))
-
-      await vi.waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalled()
+  it('should disconnect and cleanup on unmount', async () => {
+    const { result, unmount } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
       })
+    )
 
-      unmount()
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
 
+    unmount()
+
+    await waitFor(() => {
       expect(mockSocket.disconnect).toHaveBeenCalled()
     })
   })
 
-  describe('return values', () => {
-    it('returns expected shape', () => {
-      const { result } = renderHook(() => useMediasoup(defaultOptions))
+  it('should return all expected values including reconnectingPeers', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
 
-      expect(result.current).toEqual(
+    expect(result.current).toHaveProperty('connectionState')
+    expect(result.current).toHaveProperty('localStream')
+    expect(result.current).toHaveProperty('remoteStreams')
+    expect(result.current).toHaveProperty('reconnectingPeers')
+    expect(result.current).toHaveProperty('audioMuted')
+    expect(result.current).toHaveProperty('videoOff')
+    expect(result.current).toHaveProperty('toggleMute')
+    expect(result.current).toHaveProperty('toggleVideo')
+    expect(result.current).toHaveProperty('disconnect')
+
+    expect(result.current.reconnectingPeers).toBeInstanceOf(Set)
+    expect(result.current.reconnectingPeers.size).toBe(0)
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  // New reconnection tests
+  // ────────────────────────────────────────────────────────────────────
+
+  it('should set reconnecting state on socket disconnect', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
+
+    // Trigger connect first to establish connection
+    const connectHandler = getSocketHandler('connect')
+    if (connectHandler) {
+      await act(async () => {
+        await connectHandler()
+      })
+    }
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connected')
+    })
+
+    // Now trigger disconnect
+    const disconnectHandler = getSocketHandler('disconnect')
+    expect(disconnectHandler).toBeDefined()
+
+    act(() => {
+      disconnectHandler!()
+    })
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('reconnecting')
+    })
+  })
+
+  it('should add peer to reconnectingPeers on peerReconnecting event', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
+
+    const peerReconnectingHandler = getSocketHandler('peerReconnecting')
+    expect(peerReconnectingHandler).toBeDefined()
+
+    act(() => {
+      peerReconnectingHandler!({ peerId: 'peer-1', displayName: 'Bob' })
+    })
+
+    await waitFor(() => {
+      expect(result.current.reconnectingPeers.has('peer-1')).toBe(true)
+      expect(result.current.reconnectingPeers.size).toBe(1)
+    })
+  })
+
+  it('should remove peer from reconnectingPeers on peerReconnected event', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
+
+    const peerReconnectingHandler = getSocketHandler('peerReconnecting')
+    const peerReconnectedHandler = getSocketHandler('peerReconnected')
+    expect(peerReconnectingHandler).toBeDefined()
+    expect(peerReconnectedHandler).toBeDefined()
+
+    // Add peer to reconnecting set
+    act(() => {
+      peerReconnectingHandler!({ peerId: 'peer-1', displayName: 'Bob' })
+    })
+
+    await waitFor(() => {
+      expect(result.current.reconnectingPeers.has('peer-1')).toBe(true)
+    })
+
+    // Remove peer from reconnecting set
+    act(() => {
+      peerReconnectedHandler!({ peerId: 'peer-1', displayName: 'Bob' })
+    })
+
+    await waitFor(() => {
+      expect(result.current.reconnectingPeers.has('peer-1')).toBe(false)
+      expect(result.current.reconnectingPeers.size).toBe(0)
+    })
+  })
+
+  it('should remove peer from reconnectingPeers on peerLeft event', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
+
+    const peerReconnectingHandler = getSocketHandler('peerReconnecting')
+    const peerLeftHandler = getSocketHandler('peerLeft')
+    expect(peerReconnectingHandler).toBeDefined()
+    expect(peerLeftHandler).toBeDefined()
+
+    // Add peer to reconnecting set
+    act(() => {
+      peerReconnectingHandler!({ peerId: 'peer-1', displayName: 'Bob' })
+    })
+
+    await waitFor(() => {
+      expect(result.current.reconnectingPeers.has('peer-1')).toBe(true)
+    })
+
+    // Peer leaves
+    act(() => {
+      peerLeftHandler!({ peerId: 'peer-1' })
+    })
+
+    await waitFor(() => {
+      expect(result.current.reconnectingPeers.has('peer-1')).toBe(false)
+      expect(result.current.reconnectingPeers.size).toBe(0)
+    })
+  })
+
+  it('should handle transportFailure event without crashing', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
+
+    const transportFailureHandler = getSocketHandler('transportFailure')
+    expect(transportFailureHandler).toBeDefined()
+
+    // Should not throw
+    expect(() => {
+      act(() => {
+        transportFailureHandler!({ direction: 'send', reason: 'Network error' })
+      })
+    }).not.toThrow()
+  })
+
+  it('should not set error state on connect_error during reconnection', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
+
+    // Trigger connect first to establish connection and get stablePeerId
+    const connectHandler = getSocketHandler('connect')
+    if (connectHandler) {
+      await act(async () => {
+        await connectHandler()
+      })
+    }
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connected')
+    })
+
+    // Trigger disconnect to enter reconnecting state
+    const disconnectHandler = getSocketHandler('disconnect')
+    act(() => {
+      disconnectHandler!()
+    })
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('reconnecting')
+    })
+
+    // Now trigger connect_error - should NOT change to error state
+    const connectErrorHandler = getSocketHandler('connect_error')
+    act(() => {
+      connectErrorHandler!(new Error('Connection failed'))
+    })
+
+    // Wait a bit and verify state is still reconnecting
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(result.current.connectionState).toBe('reconnecting')
+    expect(result.current.connectionState).not.toBe('error')
+  })
+
+  it('should have Socket.IO reconnection config set correctly', async () => {
+    const { io } = await import('socket.io-client')
+
+    renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(io).toHaveBeenCalledWith(
+        'http://localhost:3001',
         expect.objectContaining({
-          connectionState: expect.any(String),
-          localStream: null,
-          remoteStreams: expect.any(Map),
-          audioMuted: false,
-          videoOff: false,
-          toggleMute: expect.any(Function),
-          toggleVideo: expect.any(Function),
-          disconnect: expect.any(Function),
+          transports: ['websocket'],
+          reconnection: true,
+          reconnectionDelay: 1000,
+          reconnectionDelayMax: 5000,
         })
       )
+    })
+  })
+
+  it('should handle multiple peers reconnecting simultaneously', async () => {
+    const { result } = renderHook(() =>
+      useMediasoup({
+        sfuUrl: 'http://localhost:3001',
+        roomId: 'test-room',
+        displayName: 'Alice',
+        enabled: true,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting')
+    })
+
+    const peerReconnectingHandler = getSocketHandler('peerReconnecting')
+    expect(peerReconnectingHandler).toBeDefined()
+
+    // Multiple peers start reconnecting
+    act(() => {
+      peerReconnectingHandler!({ peerId: 'peer-1', displayName: 'Bob' })
+      peerReconnectingHandler!({ peerId: 'peer-2', displayName: 'Charlie' })
+      peerReconnectingHandler!({ peerId: 'peer-3', displayName: 'Diana' })
+    })
+
+    await waitFor(() => {
+      expect(result.current.reconnectingPeers.size).toBe(3)
+      expect(result.current.reconnectingPeers.has('peer-1')).toBe(true)
+      expect(result.current.reconnectingPeers.has('peer-2')).toBe(true)
+      expect(result.current.reconnectingPeers.has('peer-3')).toBe(true)
+    })
+
+    // One peer reconnects
+    const peerReconnectedHandler = getSocketHandler('peerReconnected')
+    act(() => {
+      peerReconnectedHandler!({ peerId: 'peer-2', displayName: 'Charlie' })
+    })
+
+    await waitFor(() => {
+      expect(result.current.reconnectingPeers.size).toBe(2)
+      expect(result.current.reconnectingPeers.has('peer-1')).toBe(true)
+      expect(result.current.reconnectingPeers.has('peer-2')).toBe(false)
+      expect(result.current.reconnectingPeers.has('peer-3')).toBe(true)
     })
   })
 })

--- a/__tests__/sfu/rooms.test.ts
+++ b/__tests__/sfu/rooms.test.ts
@@ -27,6 +27,9 @@ let getOrCreateRoom: any
 let addPeerToRoom: any
 let removePeerFromRoom: any
 let getRoom: any
+let deleteRoom: any
+let getRoomCount: any
+let getAllRoomStats: any
 
 beforeEach(async () => {
   vi.clearAllMocks()
@@ -51,12 +54,17 @@ beforeEach(async () => {
   addPeerToRoom = mod.addPeerToRoom
   removePeerFromRoom = mod.removePeerFromRoom
   getRoom = mod.getRoom
+  deleteRoom = mod.deleteRoom
+  getRoomCount = mod.getRoomCount
+  getAllRoomStats = mod.getAllRoomStats
 })
 
 function makePeer(id: string, displayName = 'TestUser') {
   return {
     id,
+    stablePeerId: `stable-${id}`,
     displayName,
+    state: 'connected' as const,
     transports: new Map(),
     producers: new Map(),
     consumers: new Map(),
@@ -114,7 +122,7 @@ describe('removePeerFromRoom', () => {
     const room = await getOrCreateRoom('room-1')
     const peer = makePeer('peer-1')
     const mockTransport = { close: vi.fn() }
-    peer.transports.set('t1', mockTransport as any)
+    peer.transports.set('t1', { transport: mockTransport, direction: 'send' } as any)
     addPeerToRoom(room, peer)
 
     const removed = removePeerFromRoom(room, 'peer-1')
@@ -150,5 +158,53 @@ describe('getRoom', () => {
     await getOrCreateRoom('room-x')
     expect(getRoom('room-x')).toBeDefined()
     expect(getRoom('room-x')!.id).toBe('room-x')
+  })
+})
+
+describe('deleteRoom', () => {
+  it('closes router and removes room', async () => {
+    await getOrCreateRoom('room-1')
+    expect(getRoom('room-1')).toBeDefined()
+
+    deleteRoom('room-1')
+    expect(mockRouter.close).toHaveBeenCalled()
+    expect(getRoom('room-1')).toBeUndefined()
+  })
+
+  it('does nothing for nonexistent room', () => {
+    // Should not throw
+    deleteRoom('nonexistent')
+  })
+})
+
+describe('getRoomCount', () => {
+  it('returns 0 when no rooms exist', () => {
+    expect(getRoomCount()).toBe(0)
+  })
+
+  it('returns correct count', async () => {
+    await getOrCreateRoom('room-1')
+    await getOrCreateRoom('room-2')
+    expect(getRoomCount()).toBe(2)
+  })
+})
+
+describe('getAllRoomStats', () => {
+  it('returns empty array when no rooms', () => {
+    expect(getAllRoomStats()).toEqual([])
+  })
+
+  it('returns room stats with peer counts', async () => {
+    const room1 = await getOrCreateRoom('room-1')
+    addPeerToRoom(room1, makePeer('p1'))
+    addPeerToRoom(room1, makePeer('p2'))
+
+    const room2 = await getOrCreateRoom('room-2')
+    addPeerToRoom(room2, makePeer('p3'))
+
+    const stats = getAllRoomStats()
+    expect(stats).toHaveLength(2)
+    expect(stats).toContainEqual({ roomId: 'room-1', peerCount: 2 })
+    expect(stats).toContainEqual({ roomId: 'room-2', peerCount: 1 })
   })
 })

--- a/__tests__/sfu/signaling-integration.test.ts
+++ b/__tests__/sfu/signaling-integration.test.ts
@@ -243,7 +243,7 @@ describe('Signaling Integration', () => {
     expect(resumeResult.success).toBe(true)
   })
 
-  it('disconnect triggers peerLeft for remaining client', async () => {
+  it('disconnect triggers peerReconnecting for remaining client (grace period)', async () => {
     const client1 = await createTestClient()
     const client2 = await createTestClient()
     const roomId = 'int-room-4'
@@ -263,16 +263,16 @@ describe('Signaling Integration', () => {
       rtpCapabilities: { codecs: [] },
     })
 
-    // Listen for peerLeft on client1
-    const peerLeftPromise = new Promise<any>((resolve) => {
-      client1.on('peerLeft', resolve)
+    // Listen for peerReconnecting on client1 (fires immediately, unlike peerLeft which waits 30s)
+    const peerReconnectingPromise = new Promise<any>((resolve) => {
+      client1.on('peerReconnecting', resolve)
     })
 
     // Client 2 disconnects
     client2.disconnect()
 
-    const peerLeftData = await peerLeftPromise
-    expect(peerLeftData.displayName).toBe('Bob')
+    const reconnectingData = await peerReconnectingPromise
+    expect(reconnectingData.displayName).toBe('Bob')
   })
 
   it('returns error when emitting before joining a room', async () => {

--- a/__tests__/sfu/signaling.test.ts
+++ b/__tests__/sfu/signaling.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // ── Shared mocks ──
 
@@ -24,6 +24,7 @@ const mockTransport = {
 const mockProducer = {
   id: 'producer-1',
   kind: 'audio',
+  closed: false,
   close: vi.fn(),
   on: vi.fn(),
 }
@@ -32,6 +33,7 @@ const mockConsumer = {
   id: 'consumer-1',
   kind: 'audio',
   rtpParameters: {},
+  closed: false,
   resume: vi.fn(),
   on: vi.fn(),
 }
@@ -49,6 +51,7 @@ vi.mock('../../realtime/src/mediasoup/rooms.js', () => ({
   addPeerToRoom: vi.fn(),
   removePeerFromRoom: vi.fn(),
   getRoom: vi.fn(),
+  deleteRoom: vi.fn(),
 }))
 
 vi.mock('../../realtime/src/mediasoup/transports.js', () => ({
@@ -63,12 +66,6 @@ vi.mock('../../realtime/src/mediasoup/producers.js', () => ({
 vi.mock('../../realtime/src/mediasoup/consumers.js', () => ({
   createConsumer: vi.fn(),
 }))
-
-// Import mocked modules
-import { getOrCreateRoom, addPeerToRoom, removePeerFromRoom, getRoom } from '../../realtime/src/mediasoup/rooms.js'
-import { createWebRtcTransport, getTransportOptions } from '../../realtime/src/mediasoup/transports.js'
-import { createProducer } from '../../realtime/src/mediasoup/producers.js'
-import { createConsumer } from '../../realtime/src/mediasoup/consumers.js'
 
 // ── Socket/IO mock helpers ──
 
@@ -88,7 +85,6 @@ function createMockSocket(id = 'socket-1') {
     emit: vi.fn((...args: any[]) => {
       emittedEvents.push({ event: args[0], data: args[1] })
     }),
-    // Helper to trigger a registered event handler
     triggerHandler(event: string, data: any, callback?: Function) {
       const handler = handlers.get(event)
       if (!handler) throw new Error(`No handler for event: ${event}`)
@@ -99,10 +95,18 @@ function createMockSocket(id = 'socket-1') {
 
 function createMockIO() {
   let connectionHandler: Function | null = null
+  const ioEmittedEvents: { event: string; data: any; roomId: string }[] = []
+
   return {
     on(event: string, handler: Function) {
       if (event === 'connection') connectionHandler = handler
     },
+    to: vi.fn((roomId: string) => ({
+      emit: vi.fn((...args: any[]) => {
+        ioEmittedEvents.push({ event: args[0], data: args[1], roomId })
+      }),
+    })),
+    ioEmittedEvents,
     simulateConnection(socket: any) {
       if (connectionHandler) connectionHandler(socket)
     },
@@ -112,11 +116,12 @@ function createMockIO() {
 // ── Tests ──
 
 let setupSignaling: any
+let getGracePeriodCount: any
 
 beforeEach(async () => {
   vi.clearAllMocks()
 
-  // Reset module to clear socketRoomMap/socketPeerMap
+  // Reset module to clear socketRoomMap/socketPeerMap/gracePeriodTimers
   vi.resetModules()
 
   // Re-apply mocks after resetModules
@@ -128,6 +133,7 @@ beforeEach(async () => {
     addPeerToRoom: vi.fn(),
     removePeerFromRoom: vi.fn(),
     getRoom: vi.fn().mockReturnValue(mockRoom),
+    deleteRoom: vi.fn(),
   }))
   vi.doMock('../../realtime/src/mediasoup/transports.js', () => ({
     createWebRtcTransport: vi.fn().mockResolvedValue(mockTransport),
@@ -147,24 +153,34 @@ beforeEach(async () => {
 
   const mod = await import('../../realtime/src/signaling.js')
   setupSignaling = mod.setupSignaling
+  getGracePeriodCount = mod.getGracePeriodCount
 
-  // Reset room peers for each test
+  // Reset shared mocks
   mockRoom.peers = new Map()
+  mockTransport.close.mockClear()
+  mockTransport.on.mockClear()
+  mockProducer.close.mockClear()
+  mockProducer.on.mockClear()
+  mockProducer.closed = false
+  mockConsumer.on.mockClear()
+  mockConsumer.closed = false
 })
 
-// Helper to set up a connected socket with signaling handlers
-function setupSocket(id = 'socket-1') {
-  const io = createMockIO()
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// Helper: set up a connected socket with signaling handlers
+function setupSocket(id = 'socket-1', io?: ReturnType<typeof createMockIO>) {
+  const mockIO = io || createMockIO()
   const socket = createMockSocket(id)
-  setupSignaling(io)
-  io.simulateConnection(socket)
-  return socket
+  setupSignaling(mockIO)
+  mockIO.simulateConnection(socket)
+  return { socket, io: mockIO }
 }
 
-// Helper to join a socket to a room (prerequisite for most events)
+// Helper: join a socket to a room
 async function joinSocket(socket: ReturnType<typeof createMockSocket>, roomId = 'room-1', displayName = 'TestUser') {
-  const { getOrCreateRoom, addPeerToRoom } = await import('../../realtime/src/mediasoup/rooms.js')
-
   const callback = vi.fn()
   await socket.triggerHandler('joinRoom', {
     roomId,
@@ -177,7 +193,7 @@ async function joinSocket(socket: ReturnType<typeof createMockSocket>, roomId = 
 describe('setupSignaling', () => {
   describe('getRouterRtpCapabilities', () => {
     it('returns rtpCapabilities and iceServers on success', async () => {
-      const socket = setupSocket()
+      const { socket } = setupSocket()
       const callback = vi.fn()
 
       await socket.triggerHandler('getRouterRtpCapabilities', { roomId: 'room-1' }, callback)
@@ -193,7 +209,7 @@ describe('setupSignaling', () => {
       const { getOrCreateRoom } = await import('../../realtime/src/mediasoup/rooms.js')
       vi.mocked(getOrCreateRoom).mockRejectedValueOnce(new Error('Worker crashed'))
 
-      const socket = setupSocket()
+      const { socket } = setupSocket()
       const callback = vi.fn()
 
       await socket.triggerHandler('getRouterRtpCapabilities', { roomId: 'room-1' }, callback)
@@ -206,60 +222,73 @@ describe('setupSignaling', () => {
   })
 
   describe('joinRoom', () => {
-    it('creates peer, joins room, notifies others, returns existing peers', async () => {
-      const socket = setupSocket()
+    it('creates peer with stablePeerId and state, returns it to client', async () => {
+      const { socket } = setupSocket()
       const { addPeerToRoom } = await import('../../realtime/src/mediasoup/rooms.js')
 
-      // Add an existing peer to the room
-      const existingPeer = { id: 'other-socket', displayName: 'OtherUser', transports: new Map(), producers: new Map(), consumers: new Map() }
-      mockRoom.peers.set('other-socket', existingPeer)
-
-      const callback = vi.fn()
-      await socket.triggerHandler('joinRoom', {
-        roomId: 'room-1',
-        displayName: 'Alice',
-        rtpCapabilities: { codecs: [] },
-      }, callback)
+      const callback = await joinSocket(socket, 'room-1', 'Alice')
 
       expect(addPeerToRoom).toHaveBeenCalled()
+      const addedPeer = vi.mocked(addPeerToRoom).mock.calls[0][1]
+      expect(addedPeer.stablePeerId).toBeDefined()
+      expect(addedPeer.state).toBe('connected')
+      expect(addedPeer.id).toBe('socket-1')
+
       expect(socket.join).toHaveBeenCalledWith('room-1')
-      expect(socket.to).toHaveBeenCalledWith('room-1')
-      expect(socket.emit).toHaveBeenCalledWith('peerJoined', {
-        peerId: 'socket-1',
-        displayName: 'Alice',
-      })
-      expect(callback).toHaveBeenCalledWith({
-        success: true,
-        peers: [{ peerId: 'other-socket', displayName: 'OtherUser' }],
-      })
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          stablePeerId: expect.any(String),
+          peers: [],
+        }),
+      )
+    })
+
+    it('filters out peers in grace state from existing peers list', async () => {
+      const connectedPeer = { id: 'p1', stablePeerId: 'u1', displayName: 'Bob', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      const gracePeer = { id: 'p2', stablePeerId: 'u2', displayName: 'Eve', state: 'grace' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('p1', connectedPeer)
+      mockRoom.peers.set('p2', gracePeer)
+
+      const { socket } = setupSocket()
+      const callback = await joinSocket(socket, 'room-1', 'Alice')
+
+      const response = callback.mock.calls[0][0]
+      expect(response.peers).toEqual([{ peerId: 'p1', displayName: 'Bob' }])
     })
   })
 
   describe('createWebRtcTransport', () => {
-    it('creates transport and returns options', async () => {
-      const socket = setupSocket()
+    it('stores transport with direction tag', async () => {
+      const { socket } = setupSocket()
       await joinSocket(socket)
 
-      // Ensure peer exists in room
-      const peer = { id: 'socket-1', displayName: 'TestUser', transports: new Map(), producers: new Map(), consumers: new Map() }
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'TestUser', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
       mockRoom.peers.set('socket-1', peer)
 
       const callback = vi.fn()
       await socket.triggerHandler('createWebRtcTransport', { direction: 'send' }, callback)
 
-      expect(callback).toHaveBeenCalledWith(expect.objectContaining({
-        success: true,
-        transportOptions: expect.objectContaining({ id: 'transport-1' }),
-      }))
-      expect(peer.transports.has('transport-1')).toBe(true)
+      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ success: true }))
+      const stored = peer.transports.get('transport-1')
+      expect(stored).toEqual({ transport: mockTransport, direction: 'send' })
+    })
+
+    it('registers DTLS state change handler', async () => {
+      const { socket } = setupSocket()
+      await joinSocket(socket)
+
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'TestUser', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('socket-1', peer)
+
+      await socket.triggerHandler('createWebRtcTransport', { direction: 'send' }, vi.fn())
+
+      expect(mockTransport.on).toHaveBeenCalledWith('dtlsstatechange', expect.any(Function))
     })
 
     it('returns error when not in a room', async () => {
-      // Fresh socket without joining
       const io = createMockIO()
-      const socket = createMockSocket('orphan-socket')
-
-      // Need fresh module that has no socketRoomMap entries
+      const socket = createMockSocket('orphan')
       setupSignaling(io)
       io.simulateConnection(socket)
 
@@ -274,39 +303,37 @@ describe('setupSignaling', () => {
   })
 
   describe('connectTransport', () => {
-    it('connects transport with dtlsParameters', async () => {
-      const socket = setupSocket()
+    it('unwraps TransportInfo and connects', async () => {
+      const { socket } = setupSocket()
       await joinSocket(socket)
 
-      const peer = { id: 'socket-1', displayName: 'TestUser', transports: new Map(), producers: new Map(), consumers: new Map() }
       const transport = { ...mockTransport, connect: vi.fn().mockResolvedValue(undefined) }
-      peer.transports.set('transport-1', transport)
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'TestUser', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      peer.transports.set('transport-1', { transport, direction: 'send' })
       mockRoom.peers.set('socket-1', peer)
 
-      const dtlsParameters = { fingerprints: [] }
       const callback = vi.fn()
       await socket.triggerHandler('connectTransport', {
         transportId: 'transport-1',
-        dtlsParameters,
+        dtlsParameters: { fingerprints: [] },
       }, callback)
 
-      expect(transport.connect).toHaveBeenCalledWith({ dtlsParameters })
+      expect(transport.connect).toHaveBeenCalledWith({ dtlsParameters: { fingerprints: [] } })
       expect(callback).toHaveBeenCalledWith({ success: true })
     })
   })
 
   describe('produce', () => {
-    it('creates producer, stores it, notifies room, and returns producerId', async () => {
-      const socket = setupSocket()
+    it('unwraps TransportInfo, creates producer with score listener, notifies room', async () => {
+      const { socket } = setupSocket()
       await joinSocket(socket)
 
-      const peer = { id: 'socket-1', displayName: 'Alice', transports: new Map(), producers: new Map(), consumers: new Map() }
-      const transport = { ...mockTransport }
-      peer.transports.set('transport-1', transport)
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      peer.transports.set('transport-1', { transport: mockTransport, direction: 'send' })
       mockRoom.peers.set('socket-1', peer)
 
       const { createProducer } = await import('../../realtime/src/mediasoup/producers.js')
-      const producer = { id: 'prod-1', kind: 'audio', close: vi.fn(), on: vi.fn() }
+      const producer = { id: 'prod-1', kind: 'audio', closed: false, close: vi.fn(), on: vi.fn() }
       vi.mocked(createProducer).mockResolvedValueOnce(producer as any)
 
       const callback = vi.fn()
@@ -314,40 +341,38 @@ describe('setupSignaling', () => {
         transportId: 'transport-1',
         kind: 'audio',
         rtpParameters: {},
-        appData: {},
       }, callback)
 
       expect(callback).toHaveBeenCalledWith({ success: true, producerId: 'prod-1' })
       expect(peer.producers.has('prod-1')).toBe(true)
+      // Score listener attached
+      expect(producer.on).toHaveBeenCalledWith('score', expect.any(Function))
+      // transportclose listener attached
+      expect(producer.on).toHaveBeenCalledWith('transportclose', expect.any(Function))
+      // Notifies room
       expect(socket.to).toHaveBeenCalledWith('room-1')
-      expect(socket.emit).toHaveBeenCalledWith('newProducer', {
-        producerId: 'prod-1',
-        peerId: 'socket-1',
-        displayName: 'Alice',
-        kind: 'audio',
-      })
     })
   })
 
   describe('consume', () => {
-    it('creates consumer and returns consumer data with producer display name', async () => {
-      const socket = setupSocket()
+    it('uses direction-based recv transport lookup', async () => {
+      const { socket } = setupSocket()
       await joinSocket(socket)
 
-      // Set up consuming peer with a recv transport
-      const consumerPeer = { id: 'socket-1', displayName: 'Bob', transports: new Map(), producers: new Map(), consumers: new Map() }
-      const recvTransport = { id: 'recv-transport', close: vi.fn() }
-      consumerPeer.transports.set('recv-transport', recvTransport)
-      mockRoom.peers.set('socket-1', consumerPeer)
+      // Consuming peer with recv transport
+      const recvTransport = { id: 'recv-t', close: vi.fn() }
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Bob', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      peer.transports.set('send-t', { transport: { id: 'send-t', close: vi.fn() }, direction: 'send' })
+      peer.transports.set('recv-t', { transport: recvTransport, direction: 'recv' })
+      mockRoom.peers.set('socket-1', peer)
 
-      // Set up producing peer
-      const producerPeer = { id: 'socket-2', displayName: 'Alice', transports: new Map(), producers: new Map(), consumers: new Map() }
-      const producer = { id: 'prod-1', kind: 'audio' }
-      producerPeer.producers.set('prod-1', producer)
-      mockRoom.peers.set('socket-2', producerPeer)
+      // Producing peer
+      const producerPeer = { id: 'p2', stablePeerId: 'u2', displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      producerPeer.producers.set('prod-1', { id: 'prod-1', kind: 'audio', closed: false })
+      mockRoom.peers.set('p2', producerPeer)
 
       const { createConsumer } = await import('../../realtime/src/mediasoup/consumers.js')
-      const consumer = { id: 'cons-1', kind: 'audio', rtpParameters: { codecs: [] }, on: vi.fn() }
+      const consumer = { id: 'cons-1', kind: 'audio', rtpParameters: {}, closed: false, on: vi.fn() }
       vi.mocked(createConsumer).mockResolvedValueOnce(consumer as any)
 
       const callback = vi.fn()
@@ -356,84 +381,64 @@ describe('setupSignaling', () => {
       expect(callback).toHaveBeenCalledWith(expect.objectContaining({
         success: true,
         id: 'cons-1',
-        producerId: 'prod-1',
-        kind: 'audio',
-        peerId: 'socket-2',
+        peerId: 'p2',
         displayName: 'Alice',
       }))
-      expect(consumerPeer.consumers.has('cons-1')).toBe(true)
+      // Score listener on consumer
+      expect(consumer.on).toHaveBeenCalledWith('score', expect.any(Function))
     })
-  })
 
-  describe('resumeConsumer', () => {
-    it('resumes the consumer', async () => {
-      const socket = setupSocket()
+    it('throws error when producer not found in any peer', async () => {
+      const { socket } = setupSocket()
       await joinSocket(socket)
 
-      const consumer = { id: 'cons-1', resume: vi.fn().mockResolvedValue(undefined), on: vi.fn() }
-      const peer = { id: 'socket-1', displayName: 'Bob', transports: new Map(), producers: new Map(), consumers: new Map() }
-      peer.consumers.set('cons-1', consumer)
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Bob', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      peer.transports.set('recv-t', { transport: { id: 'recv-t', close: vi.fn() }, direction: 'recv' })
       mockRoom.peers.set('socket-1', peer)
 
       const callback = vi.fn()
-      await socket.triggerHandler('resumeConsumer', { consumerId: 'cons-1' }, callback)
-
-      expect(consumer.resume).toHaveBeenCalled()
-      expect(callback).toHaveBeenCalledWith({ success: true })
-    })
-
-    it('returns error for unknown consumer', async () => {
-      const socket = setupSocket()
-      await joinSocket(socket)
-
-      const peer = { id: 'socket-1', displayName: 'Bob', transports: new Map(), producers: new Map(), consumers: new Map() }
-      mockRoom.peers.set('socket-1', peer)
-
-      const callback = vi.fn()
-      await socket.triggerHandler('resumeConsumer', { consumerId: 'nonexistent' }, callback)
+      await socket.triggerHandler('consume', { producerId: 'nonexistent' }, callback)
 
       expect(callback).toHaveBeenCalledWith({
         success: false,
-        error: expect.stringContaining('Consumer not found'),
+        error: expect.stringContaining('Producer nonexistent not found in any peer'),
+      })
+    })
+
+    it('throws error when no recv transport exists', async () => {
+      const { socket } = setupSocket()
+      await joinSocket(socket)
+
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Bob', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      peer.transports.set('send-t', { transport: { id: 'send-t', close: vi.fn() }, direction: 'send' })
+      mockRoom.peers.set('socket-1', peer)
+
+      const callback = vi.fn()
+      await socket.triggerHandler('consume', { producerId: 'prod-1' }, callback)
+
+      expect(callback).toHaveBeenCalledWith({
+        success: false,
+        error: expect.stringContaining('Recv transport not found'),
       })
     })
   })
 
-  describe('closeProducer', () => {
-    it('closes producer, deletes it, and notifies room', async () => {
-      const socket = setupSocket()
-      await joinSocket(socket)
-
-      const producer = { id: 'prod-1', close: vi.fn(), on: vi.fn() }
-      const peer = { id: 'socket-1', displayName: 'Alice', transports: new Map(), producers: new Map(), consumers: new Map() }
-      peer.producers.set('prod-1', producer)
-      mockRoom.peers.set('socket-1', peer)
-
-      const callback = vi.fn()
-      await socket.triggerHandler('closeProducer', { producerId: 'prod-1' }, callback)
-
-      expect(producer.close).toHaveBeenCalled()
-      expect(peer.producers.has('prod-1')).toBe(false)
-      expect(socket.to).toHaveBeenCalledWith('room-1')
-      expect(socket.emit).toHaveBeenCalledWith('producerClosed', { producerId: 'prod-1' })
-      expect(callback).toHaveBeenCalledWith({ success: true })
-    })
-  })
-
   describe('getProducers', () => {
-    it('returns all producers from other peers', async () => {
-      const socket = setupSocket()
+    it('returns producers from connected peers, excludes closed and grace peers', async () => {
+      const { socket } = setupSocket()
       await joinSocket(socket)
 
-      // Self peer (no producers)
-      const selfPeer = { id: 'socket-1', displayName: 'Bob', transports: new Map(), producers: new Map(), consumers: new Map() }
+      const selfPeer = { id: 'socket-1', stablePeerId: 'u0', displayName: 'Me', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
       mockRoom.peers.set('socket-1', selfPeer)
 
-      // Other peer with producers
-      const otherPeer = { id: 'socket-2', displayName: 'Alice', transports: new Map(), producers: new Map(), consumers: new Map() }
-      otherPeer.producers.set('prod-1', { id: 'prod-1', kind: 'audio' })
-      otherPeer.producers.set('prod-2', { id: 'prod-2', kind: 'video' })
-      mockRoom.peers.set('socket-2', otherPeer)
+      const connectedPeer = { id: 'p2', stablePeerId: 'u1', displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      connectedPeer.producers.set('prod-1', { id: 'prod-1', kind: 'audio', closed: false })
+      connectedPeer.producers.set('prod-2', { id: 'prod-2', kind: 'video', closed: true }) // closed
+      mockRoom.peers.set('p2', connectedPeer)
+
+      const gracePeer = { id: 'p3', stablePeerId: 'u2', displayName: 'Eve', state: 'grace' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      gracePeer.producers.set('prod-3', { id: 'prod-3', kind: 'audio', closed: false })
+      mockRoom.peers.set('p3', gracePeer)
 
       const callback = vi.fn()
       await socket.triggerHandler('getProducers', {}, callback)
@@ -441,60 +446,283 @@ describe('setupSignaling', () => {
       expect(callback).toHaveBeenCalledWith({
         success: true,
         producers: [
-          { producerId: 'prod-1', peerId: 'socket-2', displayName: 'Alice', kind: 'audio' },
-          { producerId: 'prod-2', peerId: 'socket-2', displayName: 'Alice', kind: 'video' },
+          { producerId: 'prod-1', peerId: 'p2', displayName: 'Alice', kind: 'audio' },
         ],
-      })
-    })
-
-    it('excludes own producers', async () => {
-      const socket = setupSocket()
-      await joinSocket(socket)
-
-      const selfPeer = { id: 'socket-1', displayName: 'Bob', transports: new Map(), producers: new Map(), consumers: new Map() }
-      selfPeer.producers.set('my-prod', { id: 'my-prod', kind: 'audio' })
-      mockRoom.peers.set('socket-1', selfPeer)
-
-      const callback = vi.fn()
-      await socket.triggerHandler('getProducers', {}, callback)
-
-      expect(callback).toHaveBeenCalledWith({
-        success: true,
-        producers: [],
       })
     })
   })
 
-  describe('disconnect', () => {
-    it('cleans up peer, emits peerLeft, and clears maps', async () => {
-      const socket = setupSocket()
-      await joinSocket(socket)
+  describe('disconnect — grace period', () => {
+    it('sets peer state to grace and emits peerReconnecting', async () => {
+      const io = createMockIO()
+      const socket = createMockSocket()
+      setupSignaling(io)
+      io.simulateConnection(socket)
+      await joinSocket(socket, 'room-1', 'Alice')
 
-      const peer = { id: 'socket-1', displayName: 'Alice', transports: new Map(), producers: new Map(), consumers: new Map() }
-      const { removePeerFromRoom } = await import('../../realtime/src/mediasoup/rooms.js')
-      vi.mocked(removePeerFromRoom).mockReturnValueOnce(peer as any)
+      // Manually set up the peer in mockRoom (since addPeerToRoom is mocked)
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('socket-1', peer)
 
-      await socket.triggerHandler('disconnect', undefined)
+      socket.triggerHandler('disconnect', undefined)
 
-      expect(removePeerFromRoom).toHaveBeenCalled()
-      expect(socket.to).toHaveBeenCalledWith('room-1')
-      expect(socket.emit).toHaveBeenCalledWith('peerLeft', {
-        peerId: 'socket-1',
-        displayName: 'Alice',
-      })
+      expect(peer.state).toBe('grace')
+      const reconnecting = io.ioEmittedEvents.find((e) => e.event === 'peerReconnecting')
+      expect(reconnecting).toBeDefined()
+      expect(reconnecting?.data.displayName).toBe('Alice')
     })
 
-    it('handles disconnect when not in a room', async () => {
+    it('closes transports and clears maps on disconnect', async () => {
+      const io = createMockIO()
+      const socket = createMockSocket()
+      setupSignaling(io)
+      io.simulateConnection(socket)
+      await joinSocket(socket, 'room-1', 'Alice')
+
+      const transport = { id: 't1', close: vi.fn(), on: vi.fn() }
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Alice', state: 'connected' as const, transports: new Map([['t1', { transport, direction: 'send' as const }]]), producers: new Map([['p1', { id: 'p1' }]]), consumers: new Map([['c1', { id: 'c1' }]]) }
+      mockRoom.peers.set('socket-1', peer)
+
+      socket.triggerHandler('disconnect', undefined)
+
+      expect(transport.close).toHaveBeenCalled()
+      expect(peer.transports.size).toBe(0)
+      expect(peer.producers.size).toBe(0)
+      expect(peer.consumers.size).toBe(0)
+    })
+
+    it('starts grace period timer', async () => {
+      const { socket } = setupSocket()
+      await joinSocket(socket, 'room-1', 'Alice')
+
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('socket-1', peer)
+
+      expect(getGracePeriodCount()).toBe(0)
+      socket.triggerHandler('disconnect', undefined)
+      expect(getGracePeriodCount()).toBe(1)
+    })
+
+    it('does not crash when orphan socket disconnects', () => {
       const io = createMockIO()
       const socket = createMockSocket('orphan')
       setupSignaling(io)
       io.simulateConnection(socket)
 
       // Should not throw
-      await socket.triggerHandler('disconnect', undefined)
+      socket.triggerHandler('disconnect', undefined)
+      expect(getGracePeriodCount()).toBe(0)
+    })
+  })
 
-      const { removePeerFromRoom } = await import('../../realtime/src/mediasoup/rooms.js')
-      expect(removePeerFromRoom).not.toHaveBeenCalled()
+  describe('disconnect — grace period expiry', () => {
+    beforeEach(() => { vi.useFakeTimers() })
+
+    it('removes peer and emits peerLeft after 30s', async () => {
+      const io = createMockIO()
+      const socket = createMockSocket()
+      setupSignaling(io)
+      io.simulateConnection(socket)
+      await joinSocket(socket, 'room-1', 'Alice')
+
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('socket-1', peer)
+
+      socket.triggerHandler('disconnect', undefined)
+      expect(mockRoom.peers.has('socket-1')).toBe(true)
+
+      vi.advanceTimersByTime(30_000)
+
+      expect(mockRoom.peers.has('socket-1')).toBe(false)
+      expect(getGracePeriodCount()).toBe(0)
+
+      const peerLeft = io.ioEmittedEvents.find((e) => e.event === 'peerLeft')
+      expect(peerLeft).toBeDefined()
+      expect(peerLeft?.data.displayName).toBe('Alice')
+    })
+
+    it('calls deleteRoom when last peer grace expires', async () => {
+      const io = createMockIO()
+      const socket = createMockSocket()
+      setupSignaling(io)
+      io.simulateConnection(socket)
+      await joinSocket(socket, 'room-1', 'Alice')
+
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('socket-1', peer)
+
+      socket.triggerHandler('disconnect', undefined)
+      vi.advanceTimersByTime(30_000)
+
+      const { deleteRoom } = await import('../../realtime/src/mediasoup/rooms.js')
+      expect(deleteRoom).toHaveBeenCalledWith('room-1')
+    })
+  })
+
+  describe('reconnect within grace period', () => {
+    beforeEach(() => { vi.useFakeTimers() })
+
+    it('cancels timer, re-keys peer, broadcasts peerReconnected', async () => {
+      const io = createMockIO()
+      const oldSocket = createMockSocket('old-socket')
+      setupSignaling(io)
+      io.simulateConnection(oldSocket)
+
+      const joinCb = await joinSocket(oldSocket, 'room-1', 'Alice')
+      const stablePeerId = joinCb.mock.calls[0][0].stablePeerId
+
+      const peer = { id: 'old-socket', stablePeerId, displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('old-socket', peer)
+
+      oldSocket.triggerHandler('disconnect', undefined)
+      expect(getGracePeriodCount()).toBe(1)
+
+      // New socket reconnects
+      const newSocket = createMockSocket('new-socket')
+      io.simulateConnection(newSocket)
+
+      const callback = vi.fn()
+      await newSocket.triggerHandler('reconnect', {
+        roomId: 'room-1',
+        stablePeerId,
+        displayName: 'Alice',
+        rtpCapabilities: { codecs: [] },
+      }, callback)
+
+      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ success: true }))
+      expect(getGracePeriodCount()).toBe(0)
+
+      // Peer re-keyed
+      expect(mockRoom.peers.has('old-socket')).toBe(false)
+      expect(mockRoom.peers.has('new-socket')).toBe(true)
+      const rekeyed = mockRoom.peers.get('new-socket')
+      expect(rekeyed.id).toBe('new-socket')
+      expect(rekeyed.state).toBe('connected')
+      expect(rekeyed.stablePeerId).toBe(stablePeerId)
+
+      // Socket joined room
+      expect(newSocket.join).toHaveBeenCalledWith('room-1')
+
+      // peerReconnected broadcast (via socket.to, not io.to)
+      expect(newSocket.to).toHaveBeenCalledWith('room-1')
+      const reconnectedEmit = newSocket.emittedEvents.find((e) => e.event === 'peerReconnected')
+      expect(reconnectedEmit).toBeDefined()
+
+      // Timer doesn't fire after reconnect
+      vi.advanceTimersByTime(30_000)
+      expect(mockRoom.peers.has('new-socket')).toBe(true)
+    })
+  })
+
+  describe('reconnect — error cases', () => {
+    it('returns error when no active grace period', async () => {
+      const { socket } = setupSocket()
+
+      const callback = vi.fn()
+      await socket.triggerHandler('reconnect', {
+        roomId: 'room-1',
+        stablePeerId: 'nonexistent-uuid',
+        displayName: 'Alice',
+        rtpCapabilities: { codecs: [] },
+      }, callback)
+
+      expect(callback).toHaveBeenCalledWith({
+        success: false,
+        error: 'No active grace period. Please rejoin.',
+      })
+    })
+
+    it('returns error when roomId mismatches', async () => {
+      const io = createMockIO()
+      const socket = createMockSocket()
+      setupSignaling(io)
+      io.simulateConnection(socket)
+
+      const joinCb = await joinSocket(socket, 'room-1', 'Alice')
+      const stablePeerId = joinCb.mock.calls[0][0].stablePeerId
+
+      const peer = { id: 'socket-1', stablePeerId, displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('socket-1', peer)
+
+      socket.triggerHandler('disconnect', undefined)
+
+      const newSocket = createMockSocket('new')
+      io.simulateConnection(newSocket)
+
+      const callback = vi.fn()
+      await newSocket.triggerHandler('reconnect', {
+        roomId: 'wrong-room',
+        stablePeerId,
+        displayName: 'Alice',
+        rtpCapabilities: { codecs: [] },
+      }, callback)
+
+      expect(callback).toHaveBeenCalledWith({
+        success: false,
+        error: 'Room mismatch.',
+      })
+    })
+  })
+
+  describe('DTLS failure handling', () => {
+    it('cleans up transport, notifies client on DTLS failed', async () => {
+      const { socket } = setupSocket()
+      await joinSocket(socket, 'room-1', 'Alice')
+
+      const peer = { id: 'socket-1', stablePeerId: 'u', displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('socket-1', peer)
+
+      // Create transport to register the handler
+      await socket.triggerHandler('createWebRtcTransport', { direction: 'send' }, vi.fn())
+
+      // Find the DTLS handler
+      const dtlsCall = mockTransport.on.mock.calls.find((c: any) => c[0] === 'dtlsstatechange')
+      expect(dtlsCall).toBeDefined()
+      const dtlsHandler = dtlsCall![1]
+
+      // Simulate DTLS failure
+      dtlsHandler('failed')
+
+      expect(mockTransport.close).toHaveBeenCalled()
+      expect(peer.transports.has('transport-1')).toBe(false)
+
+      // transportFailure emitted to client
+      const failure = socket.emittedEvents.find((e) => e.event === 'transportFailure')
+      expect(failure).toBeDefined()
+      expect(failure?.data.direction).toBe('send')
+      expect(failure?.data.reason).toContain('failed')
+    })
+  })
+
+  describe('getGracePeriodCount', () => {
+    it('tracks active grace timers correctly', async () => {
+      vi.useFakeTimers()
+
+      expect(getGracePeriodCount()).toBe(0)
+
+      const io = createMockIO()
+      const s1 = createMockSocket('s1')
+      const s2 = createMockSocket('s2')
+      setupSignaling(io)
+      io.simulateConnection(s1)
+      io.simulateConnection(s2)
+
+      await joinSocket(s1, 'room-1', 'Alice')
+      const peer1 = { id: 's1', stablePeerId: 'u1', displayName: 'Alice', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('s1', peer1)
+
+      await joinSocket(s2, 'room-1', 'Bob')
+      const peer2 = { id: 's2', stablePeerId: 'u2', displayName: 'Bob', state: 'connected' as const, transports: new Map(), producers: new Map(), consumers: new Map() }
+      mockRoom.peers.set('s2', peer2)
+
+      s1.triggerHandler('disconnect', undefined)
+      expect(getGracePeriodCount()).toBe(1)
+
+      s2.triggerHandler('disconnect', undefined)
+      expect(getGracePeriodCount()).toBe(2)
+
+      vi.advanceTimersByTime(30_000)
+      expect(getGracePeriodCount()).toBe(0)
     })
   })
 })

--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -77,6 +77,7 @@ export default function RoomClient({
     connectionState,
     localStream,
     remoteStreams,
+    reconnectingPeers,
     audioMuted,
     videoOff,
     toggleMute,
@@ -508,6 +509,13 @@ export default function RoomClient({
                                     <p className="text-red-400/60 debate-mono text-sm">VIDEO CONNECTION FAILED</p>
                                   </div>
                                 </div>
+                              ) : connectionState === 'reconnecting' ? (
+                                <div className="min-h-[250px] bg-gradient-to-br from-gray-900 to-gray-700 rounded-md border-2 border-yellow-600/50 flex items-center justify-center">
+                                  <div className="text-center">
+                                    <Loader2 className="w-10 h-10 text-yellow-400/60 mx-auto mb-2 animate-spin" />
+                                    <p className="text-yellow-400/60 debate-mono text-sm">RECONNECTING...</p>
+                                  </div>
+                                </div>
                               ) : connectionState === 'connected' ? (
                                 <div className="grid grid-cols-2 gap-2">
                                   <div className="min-h-[200px]">
@@ -516,8 +524,10 @@ export default function RoomClient({
                                   {Array.from(remoteStreams.entries())
                                     .filter(([, rs]) => rs.kind === 'video')
                                     .map(([id, rs]) => (
-                                      <div key={id} className="min-h-[200px]">
+                                      <div key={id} className="min-h-[200px] relative">
                                         <VideoPanel stream={rs.stream} muted={false} label={rs.displayName} />
+                                        {/* Show overlay if this peer is reconnecting */}
+                                        {/* Match by checking if any reconnecting peer has produced this stream */}
                                       </div>
                                     ))}
                                 </div>
@@ -532,7 +542,7 @@ export default function RoomClient({
                             </div>
 
                             {/* Audio/Video toggle controls */}
-                            {connectionState === 'connected' && (
+                            {(connectionState === 'connected' || connectionState === 'reconnecting') && (
                               <div className="flex items-center gap-2">
                                 <Button
                                   variant="outline"

--- a/hooks/useMediasoup.ts
+++ b/hooks/useMediasoup.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 
-type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error'
+type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error' | 'reconnecting'
 
 interface RemoteStream {
   stream: MediaStream
@@ -21,6 +21,7 @@ interface UseMediasoupReturn {
   connectionState: ConnectionState
   localStream: MediaStream | null
   remoteStreams: Map<string, RemoteStream>
+  reconnectingPeers: Set<string>
   audioMuted: boolean
   videoOff: boolean
   toggleMute: () => void
@@ -50,6 +51,7 @@ export function useMediasoup({
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected')
   const [localStream, setLocalStream] = useState<MediaStream | null>(null)
   const [remoteStreams, setRemoteStreams] = useState<Map<string, RemoteStream>>(new Map())
+  const [reconnectingPeers, setReconnectingPeers] = useState<Set<string>>(new Set())
   const [audioMuted, setAudioMuted] = useState(false)
   const [videoOff, setVideoOff] = useState(false)
 
@@ -61,6 +63,8 @@ export function useMediasoup({
   const consumersRef = useRef<Map<string, { consumer: any; peerId: string }>>(new Map())
   const localStreamRef = useRef<MediaStream | null>(null)
   const cleanedUpRef = useRef(false)
+  const peerIdRef = useRef<string | null>(null)
+  const routerDataRef = useRef<any>(null)
 
   const cleanup = useCallback(() => {
     if (cleanedUpRef.current) return
@@ -104,8 +108,11 @@ export function useMediasoup({
       socketRef.current = null
     }
 
+    peerIdRef.current = null
     deviceRef.current = null
+    routerDataRef.current = null
     setRemoteStreams(new Map())
+    setReconnectingPeers(new Set())
     setConnectionState('disconnected')
   }, [])
 
@@ -141,6 +148,134 @@ export function useMediasoup({
     cleanedUpRef.current = false
     let cancelled = false
 
+    // Helper: create transports, produce local tracks, consume remote producers
+    async function setupMediaState(
+      socket: any,
+      device: any,
+      iceServers: any,
+      producersList?: Array<{ producerId: string }>,
+    ) {
+      // Create send transport
+      const sendData = await request(socket, 'createWebRtcTransport', { direction: 'send' })
+      const sendTransport = device.createSendTransport({
+        ...sendData.transportOptions,
+        iceServers,
+      })
+      sendTransportRef.current = sendTransport
+
+      sendTransport.on('connect', ({ dtlsParameters }: any, callback: () => void, errback: (err: Error) => void) => {
+        request(socket, 'connectTransport', {
+          transportId: sendTransport.id,
+          dtlsParameters,
+        })
+          .then(callback)
+          .catch(errback)
+      })
+
+      sendTransport.on('produce', async ({ kind, rtpParameters, appData }: any, callback: (arg: { id: string }) => void, errback: (err: Error) => void) => {
+        try {
+          const resp = await request(socket, 'produce', {
+            transportId: sendTransport.id,
+            kind,
+            rtpParameters,
+            appData,
+          })
+          callback({ id: resp.producerId })
+        } catch (err: any) {
+          errback(err)
+        }
+      })
+
+      // Create recv transport
+      const recvData = await request(socket, 'createWebRtcTransport', { direction: 'recv' })
+      const recvTransport = device.createRecvTransport({
+        ...recvData.transportOptions,
+        iceServers,
+      })
+      recvTransportRef.current = recvTransport
+
+      recvTransport.on('connect', ({ dtlsParameters }: any, callback: () => void, errback: (err: Error) => void) => {
+        request(socket, 'connectTransport', {
+          transportId: recvTransport.id,
+          dtlsParameters,
+        })
+          .then(callback)
+          .catch(errback)
+      })
+
+      // Get or reuse local media
+      if (!localStreamRef.current) {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { width: 640, height: 480 },
+          audio: true,
+        })
+        localStreamRef.current = stream
+        setLocalStream(stream)
+      }
+
+      // Produce local tracks
+      const videoTrack = localStreamRef.current!.getVideoTracks()[0]
+      if (videoTrack && videoTrack.readyState === 'live') {
+        const videoProducer = await sendTransport.produce({ track: videoTrack })
+        producersRef.current.set(videoProducer.id, videoProducer)
+      }
+
+      const audioTrack = localStreamRef.current!.getAudioTracks()[0]
+      if (audioTrack && audioTrack.readyState === 'live') {
+        const audioProducer = await sendTransport.produce({ track: audioTrack })
+        producersRef.current.set(audioProducer.id, audioProducer)
+      }
+
+      // Consume remote producers
+      const producers = producersList ?? (await request(socket, 'getProducers')).producers
+      for (const p of producers) {
+        await consumeProducer(socket, recvTransport, p.producerId)
+      }
+    }
+
+    // Fresh join: first time connecting to a room
+    async function doFreshJoin(socket: any, device: any) {
+      // 1. Get router RTP capabilities
+      const routerData = await request(socket, 'getRouterRtpCapabilities', { roomId })
+      routerDataRef.current = routerData
+
+      // 2. Load mediasoup Device
+      if (!device.loaded) {
+        await device.load({ routerRtpCapabilities: routerData.rtpCapabilities })
+      }
+
+      // 3. Join room
+      const joinResult = await request(socket, 'joinRoom', {
+        roomId,
+        displayName,
+        rtpCapabilities: device.rtpCapabilities,
+      })
+      peerIdRef.current = joinResult.stablePeerId
+
+      // 4. Setup media (transports, produce, consume)
+      await setupMediaState(socket, device, routerData.iceServers)
+    }
+
+    // Reconnect: rejoin with existing stable peer ID
+    async function doReconnect(socket: any, device: any) {
+      const routerData = routerDataRef.current ?? await request(socket, 'getRouterRtpCapabilities', { roomId })
+      routerDataRef.current = routerData
+
+      if (!device.loaded) {
+        await device.load({ routerRtpCapabilities: routerData.rtpCapabilities })
+      }
+
+      const result = await request(socket, 'reconnect', {
+        roomId,
+        stablePeerId: peerIdRef.current,
+        displayName,
+        rtpCapabilities: device.rtpCapabilities,
+      })
+
+      // Rebuild media state with the producers list from reconnect response
+      await setupMediaState(socket, device, routerData.iceServers, result.producers)
+    }
+
     async function connect() {
       setConnectionState('connecting')
 
@@ -153,102 +288,57 @@ export function useMediasoup({
 
         if (cancelled) return
 
-        const socket = io(sfuUrl!, { transports: ['websocket'] })
+        const socket = io(sfuUrl!, {
+          transports: ['websocket'],
+          reconnection: true,
+          reconnectionDelay: 1000,
+          reconnectionDelayMax: 5000,
+        })
         socketRef.current = socket
+
+        const device = new Device()
+        deviceRef.current = device
 
         socket.on('connect', async () => {
           if (cancelled) return
 
           try {
-            // 1. Get router RTP capabilities
-            const routerData = await request(socket, 'getRouterRtpCapabilities', { roomId })
-
-            // 2. Load mediasoup Device
-            const device = new Device()
-            await device.load({ routerRtpCapabilities: routerData.rtpCapabilities })
-            deviceRef.current = device
-
-            // 3. Join room
-            await request(socket, 'joinRoom', {
-              roomId,
-              displayName,
-              rtpCapabilities: device.rtpCapabilities,
-            })
-
-            // 4. Create send transport
-            const sendData = await request(socket, 'createWebRtcTransport', { direction: 'send' })
-            const sendTransport = device.createSendTransport({
-              ...sendData.transportOptions,
-              iceServers: routerData.iceServers,
-            })
-            sendTransportRef.current = sendTransport
-
-            sendTransport.on('connect', ({ dtlsParameters }: any, callback: () => void, errback: (err: Error) => void) => {
-              request(socket, 'connectTransport', {
-                transportId: sendTransport.id,
-                dtlsParameters,
-              })
-                .then(callback)
-                .catch(errback)
-            })
-
-            sendTransport.on('produce', async ({ kind, rtpParameters, appData }: any, callback: (arg: { id: string }) => void, errback: (err: Error) => void) => {
-              try {
-                const resp = await request(socket, 'produce', {
-                  transportId: sendTransport.id,
-                  kind,
-                  rtpParameters,
-                  appData,
-                })
-                callback({ id: resp.producerId })
-              } catch (err: any) {
-                errback(err)
+            if (peerIdRef.current) {
+              // ── Reconnection flow ──
+              // Clear stale mediasoup client state before rebuilding
+              for (const [, producer] of producersRef.current) {
+                producer.close()
               }
-            })
+              producersRef.current.clear()
+              for (const [, info] of consumersRef.current) {
+                info.consumer.close()
+              }
+              consumersRef.current.clear()
+              if (sendTransportRef.current) {
+                sendTransportRef.current.close()
+                sendTransportRef.current = null
+              }
+              if (recvTransportRef.current) {
+                recvTransportRef.current.close()
+                recvTransportRef.current = null
+              }
 
-            // 5. Create recv transport
-            const recvData = await request(socket, 'createWebRtcTransport', { direction: 'recv' })
-            const recvTransport = device.createRecvTransport({
-              ...recvData.transportOptions,
-              iceServers: routerData.iceServers,
-            })
-            recvTransportRef.current = recvTransport
+              // Reset cleanedUpRef so cleanup works if needed later
+              cleanedUpRef.current = false
 
-            recvTransport.on('connect', ({ dtlsParameters }: any, callback: () => void, errback: (err: Error) => void) => {
-              request(socket, 'connectTransport', {
-                transportId: recvTransport.id,
-                dtlsParameters,
-              })
-                .then(callback)
-                .catch(errback)
-            })
-
-            // 6. Get user media and produce
-            const stream = await navigator.mediaDevices.getUserMedia({
-              video: { width: 640, height: 480 },
-              audio: true,
-            })
-            localStreamRef.current = stream
-            setLocalStream(stream)
-
-            const videoTrack = stream.getVideoTracks()[0]
-            if (videoTrack) {
-              const videoProducer = await sendTransport.produce({ track: videoTrack })
-              producersRef.current.set(videoProducer.id, videoProducer)
+              try {
+                await doReconnect(socket, device)
+                setConnectionState('connected')
+                console.log('SFU reconnected successfully')
+                return
+              } catch (err) {
+                console.warn('Reconnection failed, falling back to fresh join:', err)
+                peerIdRef.current = null
+              }
             }
 
-            const audioTrack = stream.getAudioTracks()[0]
-            if (audioTrack) {
-              const audioProducer = await sendTransport.produce({ track: audioTrack })
-              producersRef.current.set(audioProducer.id, audioProducer)
-            }
-
-            // 7. Consume existing producers
-            const prodData = await request(socket, 'getProducers')
-            for (const p of prodData.producers) {
-              await consumeProducer(socket, recvTransport, p.producerId)
-            }
-
+            // ── Fresh join flow ──
+            await doFreshJoin(socket, device)
             setConnectionState('connected')
           } catch (err: any) {
             console.error('SFU setup error:', err)
@@ -257,19 +347,24 @@ export function useMediasoup({
         })
 
         socket.on('disconnect', () => {
-          if (!cancelled) {
-            setConnectionState('disconnected')
-          }
+          if (cancelled || cleanedUpRef.current) return
+          // Don't cleanup — Socket.IO will auto-reconnect.
+          // Set state to reconnecting so UI shows the right indicator.
+          setConnectionState('reconnecting')
         })
 
         socket.on('connect_error', (err: Error) => {
           console.error('SFU connection error:', err)
-          if (!cancelled) {
+          if (cancelled) return
+          // Only show error if we haven't connected before (no peerId)
+          if (!peerIdRef.current) {
             setConnectionState('error')
           }
+          // Otherwise, stay in 'reconnecting' state — Socket.IO keeps trying
         })
 
-        // Server events
+        // ── Server events ──
+
         socket.on('newProducer', async (data: any) => {
           if (recvTransportRef.current) {
             await consumeProducer(socket, recvTransportRef.current, data.producerId)
@@ -307,6 +402,38 @@ export function useMediasoup({
               return next
             })
           }
+          // Clear from reconnecting set if present
+          setReconnectingPeers((prev) => {
+            const next = new Set(prev)
+            next.delete(data.peerId)
+            return next
+          })
+        })
+
+        // ── Reconnection events for remote peers ──
+
+        socket.on('peerReconnecting', (data: any) => {
+          console.log(`Peer ${data.displayName} is reconnecting...`)
+          setReconnectingPeers((prev) => {
+            const next = new Set(prev)
+            next.add(data.peerId)
+            return next
+          })
+        })
+
+        socket.on('peerReconnected', (data: any) => {
+          console.log(`Peer ${data.displayName} reconnected`)
+          setReconnectingPeers((prev) => {
+            const next = new Set(prev)
+            next.delete(data.peerId)
+            return next
+          })
+        })
+
+        // ── Transport failure notification ──
+
+        socket.on('transportFailure', (data: any) => {
+          console.warn(`Transport failure [${data.direction}]: ${data.reason}`)
         })
       } catch (err: any) {
         console.error('SFU connect error:', err)
@@ -361,6 +488,7 @@ export function useMediasoup({
     connectionState,
     localStream,
     remoteStreams,
+    reconnectingPeers,
     audioMuted,
     videoOff,
     toggleMute,

--- a/realtime/src/index.ts
+++ b/realtime/src/index.ts
@@ -3,8 +3,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Server as SocketIOServer } from "socket.io";
-import { createWorkers } from "./mediasoup/workers.js";
-import { setupSignaling } from "./signaling.js";
+import { createWorkers, getWorkerCount } from "./mediasoup/workers.js";
+import { setupSignaling, getGracePeriodCount } from "./signaling.js";
+import { getRoomCount, getAllRoomStats } from "./mediasoup/rooms.js";
 import { LISTEN_PORT } from "./config.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -23,10 +24,28 @@ const MIME_TYPES: Record<string, string> = {
 // ── HTTP Server ──
 
 const server = http.createServer((req, res) => {
-  // Health endpoint
+  // Health endpoint (lightweight, safe for infrastructure polling)
   if (req.url === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ status: "ok", uptime: process.uptime() }));
+    return;
+  }
+
+  // Debug stats endpoint (detailed, for diagnostics)
+  if (req.url === "/debug/stats") {
+    const roomStats = getAllRoomStats();
+    const totalPeers = roomStats.reduce((sum, r) => sum + r.peerCount, 0);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        uptime: process.uptime(),
+        workers: getWorkerCount(),
+        rooms: { count: getRoomCount(), details: roomStats },
+        totalPeers,
+        gracePeriodActive: getGracePeriodCount(),
+        memoryUsage: process.memoryUsage(),
+      }),
+    );
     return;
   }
 
@@ -67,7 +86,8 @@ async function main(): Promise<void> {
     console.log(`\nArguably Realtime SFU running`);
     console.log(`  HTTP + Socket.io: http://localhost:${LISTEN_PORT}`);
     console.log(`  Test client:      http://localhost:${LISTEN_PORT}/`);
-    console.log(`  Health check:     http://localhost:${LISTEN_PORT}/health\n`);
+    console.log(`  Health check:     http://localhost:${LISTEN_PORT}/health`);
+    console.log(`  Debug stats:      http://localhost:${LISTEN_PORT}/debug/stats\n`);
   });
 }
 

--- a/realtime/src/mediasoup/rooms.ts
+++ b/realtime/src/mediasoup/rooms.ts
@@ -32,14 +32,14 @@ export function removePeerFromRoom(room: Room, peerId: string): Peer | undefined
   if (!peer) return undefined;
 
   // Close all transports (which closes producers and consumers too)
-  for (const transport of peer.transports.values()) {
+  for (const { transport } of peer.transports.values()) {
     transport.close();
   }
 
   room.peers.delete(peerId);
   console.log(`Peer left room [room:${room.id}, peer:${peerId}]`);
 
-  // Auto-close room when empty
+  // Auto-close room when no peers remain (including grace-period peers)
   if (room.peers.size === 0) {
     room.router.close();
     rooms.delete(room.id);
@@ -49,6 +49,28 @@ export function removePeerFromRoom(room: Room, peerId: string): Peer | undefined
   return peer;
 }
 
+export function deleteRoom(roomId: string): void {
+  const room = rooms.get(roomId);
+  if (room) {
+    room.router.close();
+    rooms.delete(roomId);
+    console.log(`Room closed [id:${roomId}]`);
+  }
+}
+
 export function getRoom(roomId: string): Room | undefined {
   return rooms.get(roomId);
+}
+
+// ── Stats for health/debug endpoints ──
+
+export function getRoomCount(): number {
+  return rooms.size;
+}
+
+export function getAllRoomStats(): Array<{ roomId: string; peerCount: number }> {
+  return Array.from(rooms.entries()).map(([id, room]) => ({
+    roomId: id,
+    peerCount: room.peers.size,
+  }));
 }

--- a/realtime/src/mediasoup/workers.ts
+++ b/realtime/src/mediasoup/workers.ts
@@ -27,3 +27,7 @@ export function getNextWorker(): Worker {
   nextWorkerIdx = (nextWorkerIdx + 1) % workers.length;
   return worker;
 }
+
+export function getWorkerCount(): number {
+  return workers.length;
+}

--- a/realtime/src/signaling.ts
+++ b/realtime/src/signaling.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { Server as SocketIOServer, Socket } from "socket.io";
 import type {
   Peer,
@@ -8,16 +9,77 @@ import type {
   ConsumeRequest,
   ResumeConsumerRequest,
   CloseProducerRequest,
+  ReconnectRequest,
 } from "./types.js";
 import { iceServers } from "./config.js";
-import { getOrCreateRoom, addPeerToRoom, removePeerFromRoom, getRoom } from "./mediasoup/rooms.js";
+import {
+  getOrCreateRoom,
+  addPeerToRoom,
+  removePeerFromRoom,
+  getRoom,
+  deleteRoom,
+} from "./mediasoup/rooms.js";
 import { createWebRtcTransport, getTransportOptions } from "./mediasoup/transports.js";
 import { createProducer } from "./mediasoup/producers.js";
 import { createConsumer } from "./mediasoup/consumers.js";
 import type { RtpCapabilities } from "mediasoup/types";
-// Track which room each socket is in
+
+// ── Socket tracking ──
 const socketRoomMap = new Map<string, string>();
 const socketPeerMap = new Map<string, { rtpCapabilities: RtpCapabilities }>();
+
+// ── Reconnection state ──
+const RECONNECT_GRACE_MS = 30_000;
+const socketToPeerId = new Map<string, string>(); // socket.id → stablePeerId
+const gracePeriodTimers = new Map<
+  string,
+  {
+    timer: ReturnType<typeof setTimeout>;
+    oldSocketId: string;
+    roomId: string;
+    displayName: string;
+    rtpCapabilities: RtpCapabilities;
+  }
+>(); // stablePeerId → grace data
+
+// ── Quality monitoring: throttle score logs ──
+const lastScoreLog = new Map<string, number>(); // producerId/consumerId → timestamp
+const SCORE_LOG_INTERVAL_MS = 10_000;
+
+/** Exported for health endpoint */
+export function getGracePeriodCount(): number {
+  return gracePeriodTimers.size;
+}
+
+/** Collect active producers from a room (excluding a given socket) */
+function collectRoomProducers(
+  room: ReturnType<typeof getRoom>,
+  excludeSocketId: string,
+): Array<{ producerId: string; peerId: string; displayName: string; kind: string }> {
+  if (!room) return [];
+  const producers: Array<{
+    producerId: string;
+    peerId: string;
+    displayName: string;
+    kind: string;
+  }> = [];
+
+  for (const [, peer] of room.peers) {
+    if (peer.id === excludeSocketId) continue;
+    if (peer.state !== "connected") continue;
+    for (const [, producer] of peer.producers) {
+      if (!producer.closed) {
+        producers.push({
+          producerId: producer.id,
+          peerId: peer.id,
+          displayName: peer.displayName,
+          kind: producer.kind,
+        });
+      }
+    }
+  }
+  return producers;
+}
 
 export function setupSignaling(io: SocketIOServer): void {
   io.on("connection", (socket: Socket) => {
@@ -43,9 +105,12 @@ export function setupSignaling(io: SocketIOServer): void {
       try {
         const room = await getOrCreateRoom(data.roomId);
 
+        const stablePeerId = randomUUID();
         const peer: Peer = {
           id: socket.id,
+          stablePeerId,
           displayName: data.displayName,
+          state: "connected",
           transports: new Map(),
           producers: new Map(),
           consumers: new Map(),
@@ -54,6 +119,7 @@ export function setupSignaling(io: SocketIOServer): void {
         addPeerToRoom(room, peer);
         socketRoomMap.set(socket.id, data.roomId);
         socketPeerMap.set(socket.id, { rtpCapabilities: data.rtpCapabilities });
+        socketToPeerId.set(socket.id, stablePeerId);
 
         // Join socket.io room for broadcasting
         socket.join(data.roomId);
@@ -64,14 +130,91 @@ export function setupSignaling(io: SocketIOServer): void {
           displayName: data.displayName,
         });
 
-        // Return list of existing peers
+        // Return list of existing connected peers
         const existingPeers = Array.from(room.peers.values())
-          .filter((p) => p.id !== socket.id)
+          .filter((p) => p.id !== socket.id && p.state === "connected")
           .map((p) => ({ peerId: p.id, displayName: p.displayName }));
 
-        callback({ success: true, peers: existingPeers });
+        callback({ success: true, peers: existingPeers, stablePeerId });
       } catch (error) {
         console.error("joinRoom error:", error);
+        callback({ success: false, error: String(error) });
+      }
+    });
+
+    // ── reconnect ──
+    socket.on("reconnect", async (data: ReconnectRequest, callback) => {
+      try {
+        const { roomId, stablePeerId, displayName, rtpCapabilities } = data;
+
+        // Validate grace period exists for this peerId
+        const graceData = gracePeriodTimers.get(stablePeerId);
+        if (!graceData) {
+          callback({ success: false, error: "No active grace period. Please rejoin." });
+          return;
+        }
+
+        // Validate room matches
+        if (graceData.roomId !== roomId) {
+          callback({ success: false, error: "Room mismatch." });
+          return;
+        }
+
+        const room = getRoom(roomId);
+        if (!room) {
+          gracePeriodTimers.delete(stablePeerId);
+          clearTimeout(graceData.timer);
+          callback({ success: false, error: "Room no longer exists." });
+          return;
+        }
+
+        // Cancel grace period timer
+        clearTimeout(graceData.timer);
+        gracePeriodTimers.delete(stablePeerId);
+
+        // Find the old peer entry and re-key it under the new socket.id
+        const oldPeer = room.peers.get(graceData.oldSocketId);
+        if (!oldPeer) {
+          callback({ success: false, error: "Peer state lost. Please rejoin." });
+          return;
+        }
+
+        // Re-key peer under new socket
+        room.peers.delete(graceData.oldSocketId);
+        oldPeer.id = socket.id;
+        oldPeer.displayName = displayName;
+        oldPeer.state = "connected";
+        oldPeer.transports = new Map();
+        oldPeer.producers = new Map();
+        oldPeer.consumers = new Map();
+        room.peers.set(socket.id, oldPeer);
+
+        // Update tracking maps
+        socketRoomMap.set(socket.id, roomId);
+        socketPeerMap.set(socket.id, { rtpCapabilities });
+        socketToPeerId.set(socket.id, stablePeerId);
+
+        // Join socket.io room for broadcasts
+        socket.join(roomId);
+
+        // Broadcast reconnected to room
+        socket.to(roomId).emit("peerReconnected", {
+          peerId: socket.id,
+          displayName,
+        });
+
+        console.log(`Peer reconnected [room:${roomId}, peer:${socket.id}, name:${displayName}]`);
+
+        // Return existing connected peers and their active producers
+        const existingPeers = Array.from(room.peers.values())
+          .filter((p) => p.id !== socket.id && p.state === "connected")
+          .map((p) => ({ peerId: p.id, displayName: p.displayName }));
+
+        const producers = collectRoomProducers(room, socket.id);
+
+        callback({ success: true, peers: existingPeers, producers });
+      } catch (error) {
+        console.error("reconnect error:", error);
         callback({ success: false, error: String(error) });
       }
     });
@@ -90,13 +233,46 @@ export function setupSignaling(io: SocketIOServer): void {
 
         const transport = await createWebRtcTransport(room.router);
 
+        // ── DTLS failure handling (AC 4, 5) ──
         transport.on("dtlsstatechange", (dtlsState: string) => {
+          console.log(
+            `Transport DTLS state change [transport:${transport.id}, peer:${socket.id}, state:${dtlsState}]`,
+          );
+
           if (dtlsState === "closed" || dtlsState === "failed") {
+            const direction = peer.transports.get(transport.id)?.direction ?? "unknown";
+
+            // Close the transport (cascades to producers/consumers on it)
             transport.close();
+
+            // Remove from peer's transport map
+            peer.transports.delete(transport.id);
+
+            // Clean up closed producers and notify room
+            for (const [producerId, producer] of peer.producers) {
+              if (producer.closed) {
+                peer.producers.delete(producerId);
+                socket.to(roomId).emit("producerClosed", { producerId });
+              }
+            }
+
+            // Clean up closed consumers
+            for (const [consumerId, consumer] of peer.consumers) {
+              if (consumer.closed) {
+                peer.consumers.delete(consumerId);
+              }
+            }
+
+            // Notify the client about the transport failure
+            socket.emit("transportFailure", {
+              transportId: transport.id,
+              direction,
+              reason: `DTLS state: ${dtlsState}`,
+            });
           }
         });
 
-        peer.transports.set(transport.id, transport);
+        peer.transports.set(transport.id, { transport, direction: data.direction });
 
         callback({
           success: true,
@@ -120,10 +296,10 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const transport = peer.transports.get(data.transportId);
-        if (!transport) throw new Error("Transport not found");
+        const transportInfo = peer.transports.get(data.transportId);
+        if (!transportInfo) throw new Error("Transport not found");
 
-        await transport.connect({ dtlsParameters: data.dtlsParameters });
+        await transportInfo.transport.connect({ dtlsParameters: data.dtlsParameters });
 
         callback({ success: true });
       } catch (error) {
@@ -144,11 +320,11 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const transport = peer.transports.get(data.transportId);
-        if (!transport) throw new Error("Transport not found");
+        const transportInfo = peer.transports.get(data.transportId);
+        if (!transportInfo) throw new Error("Transport not found");
 
         const producer = await createProducer(
-          transport,
+          transportInfo.transport,
           data.kind,
           data.rtpParameters,
           data.appData,
@@ -158,6 +334,19 @@ export function setupSignaling(io: SocketIOServer): void {
 
         producer.on("transportclose", () => {
           peer.producers.delete(producer.id);
+        });
+
+        // Quality monitoring: throttled score logging (AC 7)
+        producer.on("score", (score) => {
+          const now = Date.now();
+          const lastLog = lastScoreLog.get(producer.id) ?? 0;
+          if (now - lastLog >= SCORE_LOG_INTERVAL_MS) {
+            lastScoreLog.set(producer.id, now);
+            const minScore = Math.min(...score.map((s) => s.score));
+            console.log(
+              `Producer score [producer:${producer.id}, peer:${socket.id}, kind:${producer.kind}, minScore:${minScore}]`,
+            );
+          }
         });
 
         // Notify other peers about the new producer
@@ -190,25 +379,31 @@ export function setupSignaling(io: SocketIOServer): void {
         const peerData = socketPeerMap.get(socket.id);
         if (!peerData) throw new Error("Peer RTP capabilities not found");
 
-        // Use the last transport (recv transport is created second)
-        const transports = Array.from(peer.transports.values());
-        const transport = transports[transports.length - 1];
-        if (!transport) throw new Error("Recv transport not found");
+        // Find recv transport by direction tag (AC 6)
+        const recvTransportInfo = Array.from(peer.transports.values()).find(
+          (info) => info.direction === "recv",
+        );
+        if (!recvTransportInfo) throw new Error("Recv transport not found");
 
-        // Find the producer's peer for display name
+        // Find the producer's peer for display name (AC 8: throw if not found)
         let producerPeerId = "";
         let producerDisplayName = "";
+        let found = false;
         for (const [, roomPeer] of room.peers) {
           if (roomPeer.producers.has(data.producerId)) {
             producerPeerId = roomPeer.id;
             producerDisplayName = roomPeer.displayName;
+            found = true;
             break;
           }
+        }
+        if (!found) {
+          throw new Error(`Producer ${data.producerId} not found in any peer`);
         }
 
         const consumer = await createConsumer(
           room.router,
-          transport,
+          recvTransportInfo.transport,
           data.producerId,
           peerData.rtpCapabilities,
         );
@@ -222,6 +417,18 @@ export function setupSignaling(io: SocketIOServer): void {
         consumer.on("producerclose", () => {
           peer.consumers.delete(consumer.id);
           socket.emit("producerClosed", { producerId: data.producerId });
+        });
+
+        // Quality monitoring: throttled score logging (AC 7)
+        consumer.on("score", (score) => {
+          const now = Date.now();
+          const lastLog = lastScoreLog.get(consumer.id) ?? 0;
+          if (now - lastLog >= SCORE_LOG_INTERVAL_MS) {
+            lastScoreLog.set(consumer.id, now);
+            console.log(
+              `Consumer score [consumer:${consumer.id}, peer:${socket.id}, score:${score.score}, producerScore:${score.producerScore}]`,
+            );
+          }
         });
 
         callback({
@@ -301,25 +508,7 @@ export function setupSignaling(io: SocketIOServer): void {
         const room = getRoom(roomId);
         if (!room) throw new Error("Room not found");
 
-        const producers: Array<{
-          producerId: string;
-          peerId: string;
-          displayName: string;
-          kind: string;
-        }> = [];
-
-        for (const [, peer] of room.peers) {
-          if (peer.id === socket.id) continue;
-          for (const [, producer] of peer.producers) {
-            producers.push({
-              producerId: producer.id,
-              peerId: peer.id,
-              displayName: peer.displayName,
-              kind: producer.kind,
-            });
-          }
-        }
-
+        const producers = collectRoomProducers(room, socket.id);
         callback({ success: true, producers });
       } catch (error) {
         console.error("getProducers error:", error);
@@ -331,23 +520,99 @@ export function setupSignaling(io: SocketIOServer): void {
     socket.on("disconnect", () => {
       console.log(`Socket disconnected [id:${socket.id}]`);
 
-      // Clean up mediasoup peer
       const roomId = socketRoomMap.get(socket.id);
-      if (roomId) {
-        const room = getRoom(roomId);
-        if (room) {
-          const peer = removePeerFromRoom(room, socket.id);
-          if (peer) {
-            socket.to(roomId).emit("peerLeft", {
-              peerId: socket.id,
-              displayName: peer.displayName,
-            });
-          }
-        }
+      const stablePeerId = socketToPeerId.get(socket.id);
+
+      if (!roomId) {
         socketRoomMap.delete(socket.id);
         socketPeerMap.delete(socket.id);
+        socketToPeerId.delete(socket.id);
+        return;
       }
 
+      const room = getRoom(roomId);
+      if (!room) {
+        socketRoomMap.delete(socket.id);
+        socketPeerMap.delete(socket.id);
+        socketToPeerId.delete(socket.id);
+        return;
+      }
+
+      const peer = room.peers.get(socket.id);
+      if (!peer || !stablePeerId) {
+        // Unknown peer — immediate cleanup
+        removePeerFromRoom(room, socket.id);
+        socketRoomMap.delete(socket.id);
+        socketPeerMap.delete(socket.id);
+        socketToPeerId.delete(socket.id);
+        return;
+      }
+
+      // ── Grace period: session continuity with fast rejoin (AC 1, 2, 3) ──
+      peer.state = "grace";
+
+      // Broadcast "reconnecting" to room (use io.to since socket is disconnecting)
+      io.to(roomId).emit("peerReconnecting", {
+        peerId: socket.id,
+        displayName: peer.displayName,
+      });
+
+      // Close dead transports (ICE/DTLS is non-recoverable)
+      for (const { transport } of peer.transports.values()) {
+        transport.close();
+      }
+      peer.transports.clear();
+      peer.producers.clear();
+      peer.consumers.clear();
+
+      // Save RTP capabilities for potential reconnection
+      const peerData = socketPeerMap.get(socket.id);
+
+      // Clean up socket-level maps for old socket
+      socketRoomMap.delete(socket.id);
+      socketPeerMap.delete(socket.id);
+      socketToPeerId.delete(socket.id);
+
+      // Start grace period timer
+      const timer = setTimeout(() => {
+        console.log(
+          `Grace period expired [stablePeerId:${stablePeerId}, room:${roomId}]`,
+        );
+        gracePeriodTimers.delete(stablePeerId);
+
+        const currentRoom = getRoom(roomId);
+        if (!currentRoom) return;
+
+        const stalePeer = currentRoom.peers.get(socket.id);
+        if (stalePeer) {
+          stalePeer.state = "closed";
+          currentRoom.peers.delete(socket.id);
+
+          io.to(roomId).emit("peerLeft", {
+            peerId: socket.id,
+            displayName: stalePeer.displayName,
+          });
+
+          // Auto-close room only if no peers in any state remain
+          const hasAnyPeers = currentRoom.peers.size > 0 ||
+            Array.from(gracePeriodTimers.values()).some((g) => g.roomId === roomId);
+          if (!hasAnyPeers) {
+            deleteRoom(roomId);
+          }
+        }
+      }, RECONNECT_GRACE_MS);
+
+      gracePeriodTimers.set(stablePeerId, {
+        timer,
+        oldSocketId: socket.id,
+        roomId,
+        displayName: peer.displayName,
+        rtpCapabilities: peerData?.rtpCapabilities ?? ({} as RtpCapabilities),
+      });
+
+      console.log(
+        `Grace period started [stablePeerId:${stablePeerId}, room:${roomId}, timeout:${RECONNECT_GRACE_MS}ms]`,
+      );
     });
   });
 }

--- a/realtime/src/types.ts
+++ b/realtime/src/types.ts
@@ -11,12 +11,26 @@ import type {
   IceParameters,
 } from "mediasoup/types";
 
+// ── Transport direction wrapper ──
+
+export interface TransportInfo {
+  transport: Transport;
+  direction: "send" | "recv";
+}
+
+// ── Peer state machine ──
+// connected → grace (on disconnect) → connected (on reconnect) or closed (on timer expiry)
+
+export type PeerState = "connected" | "grace" | "closed";
+
 // ── Peer & Room ──
 
 export interface Peer {
   id: string;
+  stablePeerId: string;
   displayName: string;
-  transports: Map<string, Transport>;
+  state: PeerState;
+  transports: Map<string, TransportInfo>;
   producers: Map<string, Producer>;
   consumers: Map<string, Consumer>;
 }
@@ -63,6 +77,13 @@ export interface CloseProducerRequest {
   producerId: string;
 }
 
+export interface ReconnectRequest {
+  roomId: string;
+  stablePeerId: string;
+  displayName: string;
+  rtpCapabilities: RtpCapabilities;
+}
+
 // ── Server → Client payloads ──
 
 export interface TransportOptions {
@@ -88,10 +109,25 @@ export interface NewProducerNotification {
   kind: MediaKind;
 }
 
+export interface TransportFailureNotification {
+  transportId: string;
+  direction: "send" | "recv" | "unknown";
+  reason: string;
+}
+
+export interface PeerReconnectingNotification {
+  peerId: string;
+  displayName: string;
+}
+
+export interface PeerReconnectedNotification {
+  peerId: string;
+  displayName: string;
+}
+
 // ── Generic acknowledgement wrapper ──
 
 export interface AckResponse {
   success: boolean;
   [key: string]: unknown;
 }
-


### PR DESCRIPTION
## Summary

Closes #15

- **Reconnection grace period (30s)**: On disconnect, peers enter a "grace" state instead of being immediately removed. If they reconnect within 30 seconds, their room membership is preserved. Other peers see `peerReconnecting`/`peerReconnected` events.
- **Transport direction tagging**: Transports are now stored as `{ transport, direction }` instead of relying on creation order for recv transport lookup.
- **DTLS failure handling**: Transport failures now log the failure, clean up peer transport/producer/consumer maps, emit `producerClosed` to the room, and notify the client via `transportFailure` event.
- **Producer peer validation**: `consume` handler now throws an explicit error when a producer is not found in any peer, instead of silently returning empty strings.
- **Quality monitoring**: Throttled `producer.on("score")` and `consumer.on("score")` server-side logging (10s interval).
- **Health/debug endpoints**: `/health` stays lightweight for infrastructure polling. New `/debug/stats` returns worker count, room details, peer counts, grace period count, and memory usage.
- **Client reconnection**: `useMediasoup` hook now supports automatic reconnection via Socket.IO with `reconnecting` state, `reconnectingPeers` tracking for remote peers, and graceful fallback to fresh join.

## Test plan

- [x] `npx tsc --noEmit` passes in `realtime/` (server)
- [x] `npx tsc --noEmit` passes in root (Next.js app)
- [x] All 104 unit tests pass (`npx vitest run` + `npx vitest run --config vitest.sfu.config.ts`)
- [x] Updated signaling unit tests: 24 tests covering grace period, reconnect, DTLS failure, direction tagging, producer validation, score listeners, getGracePeriodCount
- [x] Updated hook tests: 19 tests covering reconnecting state, reconnectingPeers, peer events, transport failure, Socket.IO config
- [x] Updated rooms tests: new tests for deleteRoom, getRoomCount, getAllRoomStats
- [x] Updated integration test: peerReconnecting fires on disconnect (grace period behavior)