### PR TITLE
feat: audience queue, kick-voting, Expert vs Crowd rotation

### DIFF
--- a/__tests__/action-utils.test.ts
+++ b/__tests__/action-utils.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+    },
+    participatesIn: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import { requireAuth, requireHostOrModerator, requireParticipant } from '@/lib/actions/utils'
+
+function mockAuth(user: { id: string } | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+      }),
+    },
+  })
+}
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+
+describe('requireAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws "Not authenticated" when no user', async () => {
+    mockAuth(null)
+    await expect(requireAuth()).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns user when authenticated', async () => {
+    const mockUser = { id: MOCK_USER_ID }
+    mockAuth(mockUser)
+    const result = await requireAuth()
+    expect(result).toEqual(mockUser)
+  })
+})
+
+describe('requireHostOrModerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(requireHostOrModerator(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Session not found" when session does not exist', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(requireHostOrModerator(MOCK_SESSION_ID)).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Not authorized" when user is neither host nor moderator', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user-1',
+      moderator_id: 'other-user-2',
+    })
+    await expect(requireHostOrModerator(MOCK_SESSION_ID)).rejects.toThrow('Not authorized')
+  })
+
+  it('returns {user, session} when user is host', async () => {
+    const mockUser = { id: MOCK_USER_ID }
+    const mockSession = {
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    }
+    mockAuth(mockUser)
+    ;(prisma.session.findUnique as any).mockResolvedValue(mockSession)
+
+    const result = await requireHostOrModerator(MOCK_SESSION_ID)
+
+    expect(result).toEqual({
+      user: mockUser,
+      session: mockSession,
+    })
+  })
+
+  it('returns {user, session} when user is moderator', async () => {
+    const mockUser = { id: MOCK_USER_ID }
+    const mockSession = {
+      id: MOCK_SESSION_ID,
+      host_id: 'some-other-user',
+      moderator_id: MOCK_USER_ID,
+    }
+    mockAuth(mockUser)
+    ;(prisma.session.findUnique as any).mockResolvedValue(mockSession)
+
+    const result = await requireHostOrModerator(MOCK_SESSION_ID)
+
+    expect(result).toEqual({
+      user: mockUser,
+      session: mockSession,
+    })
+  })
+})
+
+describe('requireParticipant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(requireParticipant(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Not a participant" when no participation record', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(requireParticipant(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('throws "Not a participant" when participation has left_at set', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(requireParticipant(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('returns user when active participant', async () => {
+    const mockUser = { id: MOCK_USER_ID }
+    mockAuth(mockUser)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+
+    const result = await requireParticipant(MOCK_SESSION_ID)
+
+    expect(result).toEqual(mockUser)
+  })
+})

--- a/__tests__/components/confirm-dialog.test.tsx
+++ b/__tests__/components/confirm-dialog.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    title: 'Test Title',
+    description: 'Test description text',
+    onConfirm: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders title and description when open', () => {
+    render(<ConfirmDialog {...defaultProps} />)
+    expect(screen.getByText('Test Title')).toBeDefined()
+    expect(screen.getByText('Test description text')).toBeDefined()
+  })
+
+  it('does not render content when closed', () => {
+    render(<ConfirmDialog {...defaultProps} open={false} />)
+    expect(screen.queryByText('Test Title')).toBeNull()
+  })
+
+  it('renders default button labels', () => {
+    render(<ConfirmDialog {...defaultProps} />)
+    expect(screen.getByText('CANCEL')).toBeDefined()
+    expect(screen.getByText('CONFIRM')).toBeDefined()
+  })
+
+  it('renders custom button labels', () => {
+    render(<ConfirmDialog {...defaultProps} confirmLabel="KICK" cancelLabel="NEVERMIND" />)
+    expect(screen.getByText('KICK')).toBeDefined()
+    expect(screen.getByText('NEVERMIND')).toBeDefined()
+  })
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    render(<ConfirmDialog {...defaultProps} />)
+    fireEvent.click(screen.getByText('CONFIRM'))
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables buttons when loading', () => {
+    render(<ConfirmDialog {...defaultProps} loading={true} />)
+    const confirmBtn = screen.getByText('CONFIRM').closest('button')
+    const cancelBtn = screen.getByText('CANCEL').closest('button')
+    expect(confirmBtn?.disabled).toBe(true)
+    expect(cancelBtn?.disabled).toBe(true)
+  })
+
+  it('shows spinner when loading', () => {
+    render(<ConfirmDialog {...defaultProps} loading={true} />)
+    // Radix portals render outside container, query the document body
+    const spinner = document.body.querySelector('.animate-spin')
+    expect(spinner).not.toBeNull()
+  })
+
+  it('uses destructive variant styling on confirm button', () => {
+    render(<ConfirmDialog {...defaultProps} variant="destructive" confirmLabel="DELETE" />)
+    const deleteBtn = screen.getByText('DELETE').closest('button')
+    expect(deleteBtn).toBeDefined()
+  })
+})

--- a/__tests__/debate.test.ts
+++ b/__tests__/debate.test.ts
@@ -14,7 +14,16 @@ vi.mock('@/lib/prisma', () => ({
       updateMany: vi.fn(),
       delete: vi.fn(),
     },
+    // Needed for doPromoteFromQueue called inside debate actions
+    audienceQueue: { findFirst: vi.fn(), delete: vi.fn() },
+    participatesIn: { update: vi.fn() },
+    $transaction: vi.fn(),
   },
+}))
+
+vi.mock('@/lib/actions/queue', () => ({
+  doPromoteFromQueue: vi.fn().mockResolvedValue(null),
+  cleanupUserVotes: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { createClient } from '@/lib/supabase/server'
@@ -107,8 +116,18 @@ describe('startDebate', () => {
     await expect(startDebate(MOCK_SESSION_ID, debaters, 120)).rejects.toThrow('Not authorized')
   })
 
-  it('throws if not exactly 2 debaters', async () => {
-    await expect(startDebate(MOCK_SESSION_ID, [debaters[0]], 120)).rejects.toThrow('Exactly 2 debaters')
+  it('throws if fewer than 2 debaters for non-Expert format', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, [debaters[0]], 120)).rejects.toThrow('At least 2 debaters')
+  })
+
+  it('accepts >= 2 debaters for non-Expert formats', async () => {
+    const threeDebaters = [
+      { userId: 'u1', displayName: 'Alice' },
+      { userId: 'u2', displayName: 'Bob' },
+      { userId: 'u3', displayName: 'Charlie' },
+    ]
+    await startDebate(MOCK_SESSION_ID, threeDebaters, 120)
+    expect(prisma.debateState.upsert).toHaveBeenCalled()
   })
 
   it('upserts debate state with correct initial values', async () => {
@@ -146,6 +165,7 @@ describe('advanceTurn', () => {
   it('advances current_index from 0 to 1', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       current_index: 0, turn_length: 60, is_paused: false,
+      debater_order: debaters,
     })
     await advanceTurn(MOCK_SESSION_ID)
     const update = (prisma.debateState.update as any).mock.calls[0][0]
@@ -156,6 +176,7 @@ describe('advanceTurn', () => {
   it('wraps current_index from 1 back to 0', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       current_index: 1, turn_length: 60, is_paused: false,
+      debater_order: debaters,
     })
     await advanceTurn(MOCK_SESSION_ID)
     const update = (prisma.debateState.update as any).mock.calls[0][0]
@@ -165,11 +186,27 @@ describe('advanceTurn', () => {
   it('sets new turn_ends_at from now + turn_length', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       current_index: 0, turn_length: 90, is_paused: false,
+      debater_order: debaters,
     })
     const before = Date.now()
     await advanceTurn(MOCK_SESSION_ID)
     const update = (prisma.debateState.update as any).mock.calls[0][0]
     expect(update.data.turn_ends_at).toBeGreaterThanOrEqual(before + 90_000)
+  })
+
+  it('wraps correctly with 3 debaters', async () => {
+    const threeDebaters = [
+      { userId: 'u1', displayName: 'Alice' },
+      { userId: 'u2', displayName: 'Bob' },
+      { userId: 'u3', displayName: 'Charlie' },
+    ]
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      current_index: 2, turn_length: 60, is_paused: false,
+      debater_order: threeDebaters,
+    })
+    await advanceTurn(MOCK_SESSION_ID)
+    const update = (prisma.debateState.update as any).mock.calls[0][0]
+    expect(update.data.current_index).toBe(0)
   })
 })
 
@@ -178,6 +215,7 @@ describe('advanceTurnIfExpired', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAuth('any-user')
+    mockSession({ type: 'ONE_ON_ONE' })
     ;(prisma.debateState.updateMany as any).mockResolvedValue({ count: 1 })
   })
 
@@ -196,6 +234,7 @@ describe('advanceTurnIfExpired', () => {
   it('does nothing if paused', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       is_paused: true, turn_ends_at: Date.now() - 5000, current_index: 0, turn_length: 60,
+      debater_order: debaters,
     })
     await advanceTurnIfExpired(MOCK_SESSION_ID)
     expect(prisma.debateState.updateMany).not.toHaveBeenCalled()
@@ -204,6 +243,7 @@ describe('advanceTurnIfExpired', () => {
   it('does nothing if turn has not expired yet', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       is_paused: false, turn_ends_at: Date.now() + 30_000, current_index: 0, turn_length: 60,
+      debater_order: debaters,
     })
     await advanceTurnIfExpired(MOCK_SESSION_ID)
     expect(prisma.debateState.updateMany).not.toHaveBeenCalled()
@@ -212,6 +252,7 @@ describe('advanceTurnIfExpired', () => {
   it('calls updateMany with atomic guard when turn expired', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       is_paused: false, turn_ends_at: Date.now() - 2000, current_index: 0, turn_length: 60,
+      debater_order: debaters,
     })
     await advanceTurnIfExpired(MOCK_SESSION_ID)
     expect(prisma.debateState.updateMany).toHaveBeenCalledWith(

--- a/__tests__/debate.test.ts
+++ b/__tests__/debate.test.ts
@@ -16,7 +16,11 @@ vi.mock('@/lib/prisma', () => ({
     },
     // Needed for doPromoteFromQueue called inside debate actions
     audienceQueue: { findFirst: vi.fn(), delete: vi.fn() },
-    participatesIn: { update: vi.fn() },
+    participatesIn: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }))
@@ -36,6 +40,7 @@ import {
   pauseDebate,
   resumeDebate,
   endDebate,
+  extendTurn,
 } from '@/lib/actions/debate'
 
 const MOCK_HOST_ID = 'host-uuid'
@@ -67,7 +72,10 @@ const debaters = [
 
 // ── getDebateState ──
 describe('getDebateState', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth('any-user')
+  })
 
   it('returns null when no state exists', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue(null)
@@ -99,6 +107,11 @@ describe('startDebate', () => {
     mockAuth(MOCK_HOST_ID)
     mockSession()
     ;(prisma.debateState.upsert as any).mockResolvedValue({})
+    // Mock: both debaters are active participants
+    ;(prisma.participatesIn.findMany as any).mockResolvedValue([
+      { user_id: 'u1' },
+      { user_id: 'u2' },
+    ])
   })
 
   it('throws if not authenticated', async () => {
@@ -126,6 +139,11 @@ describe('startDebate', () => {
       { userId: 'u2', displayName: 'Bob' },
       { userId: 'u3', displayName: 'Charlie' },
     ]
+    ;(prisma.participatesIn.findMany as any).mockResolvedValue([
+      { user_id: 'u1' },
+      { user_id: 'u2' },
+      { user_id: 'u3' },
+    ])
     await startDebate(MOCK_SESSION_ID, threeDebaters, 120)
     expect(prisma.debateState.upsert).toHaveBeenCalled()
   })
@@ -217,6 +235,12 @@ describe('advanceTurnIfExpired', () => {
     mockAuth('any-user')
     mockSession({ type: 'ONE_ON_ONE' })
     ;(prisma.debateState.updateMany as any).mockResolvedValue({ count: 1 })
+    // Mock: user is an active participant
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: 'any-user',
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
   })
 
   it('does nothing if unauthenticated', async () => {
@@ -355,5 +379,194 @@ describe('endDebate', () => {
   it('does not throw if debate state already gone', async () => {
     ;(prisma.debateState.delete as any).mockRejectedValue(new Error('not found'))
     await expect(endDebate(MOCK_SESSION_ID)).resolves.not.toThrow()
+  })
+})
+
+// ── Security: getDebateState auth check ──
+describe('getDebateState — security', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(getDebateState(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns state when authenticated', async () => {
+    mockAuth('any-user')
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      session_id: MOCK_SESSION_ID,
+      debater_order: debaters,
+      current_index: 0,
+      turn_length: 120,
+      turn_ends_at: 9999999,
+      is_paused: false,
+      paused_time_remaining: 0,
+    })
+    const result = await getDebateState(MOCK_SESSION_ID)
+    expect(result).not.toBeNull()
+    expect(result?.session_id).toBe(MOCK_SESSION_ID)
+  })
+})
+
+// ── Security: startDebate input validation ──
+describe('startDebate — security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_HOST_ID)
+    mockSession()
+    ;(prisma.debateState.upsert as any).mockResolvedValue({})
+    ;(prisma.participatesIn.findMany as any).mockResolvedValue([
+      { user_id: 'u1' },
+      { user_id: 'u2' },
+    ])
+  })
+
+  it('throws if turnLength is less than 1', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 0)).rejects.toThrow(
+      'Turn length must be at least 1 second'
+    )
+  })
+
+  it('throws if turnLength exceeds 1800', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 1801)).rejects.toThrow(
+      'Turn length cannot exceed 30 minutes'
+    )
+  })
+
+  it('allows turnLength of exactly 1', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 1)).resolves.not.toThrow()
+  })
+
+  it('allows turnLength of exactly 1800', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 1800)).resolves.not.toThrow()
+  })
+
+  it('throws if debater IDs are not active participants', async () => {
+    ;(prisma.participatesIn.findMany as any).mockResolvedValue([
+      { user_id: 'u1' },
+    ])
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 120)).rejects.toThrow(
+      'is not an active participant'
+    )
+  })
+
+  it('succeeds when both debaters are active participants', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, debaters, 120)).resolves.not.toThrow()
+    expect(prisma.debateState.upsert).toHaveBeenCalled()
+  })
+})
+
+// ── Security: advanceTurnIfExpired participant check ──
+describe('advanceTurnIfExpired — security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth('any-user')
+    ;(prisma.debateState.updateMany as any).mockResolvedValue({ count: 1 })
+  })
+
+  it('does nothing if user is not a participant', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await advanceTurnIfExpired(MOCK_SESSION_ID)
+    expect(prisma.debateState.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('does nothing if user has left the session', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: 'any-user',
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await advanceTurnIfExpired(MOCK_SESSION_ID)
+    expect(prisma.debateState.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('advances turn when user is active participant and turn expired', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: 'any-user',
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false, turn_ends_at: Date.now() - 2000, current_index: 0, turn_length: 60,
+      debater_order: debaters,
+    })
+    // advanceTurnIfExpired fetches session.type to check Expert vs Crowd
+    ;(prisma.session.findUnique as any).mockResolvedValue({ type: 'ONE_ON_ONE' })
+    await advanceTurnIfExpired(MOCK_SESSION_ID)
+    expect(prisma.debateState.updateMany).toHaveBeenCalled()
+  })
+})
+
+// ── extendTurn ──
+describe('extendTurn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_HOST_ID)
+    mockSession()
+    ;(prisma.debateState.update as any).mockResolvedValue({})
+  })
+
+  it('throws if not authorized', async () => {
+    mockSession({ host_id: 'other', moderator_id: null })
+    await expect(extendTurn(MOCK_SESSION_ID, 30)).rejects.toThrow('Not authorized')
+  })
+
+  it('throws if no active debate', async () => {
+    ;(prisma.debateState.findUnique as any).mockResolvedValue(null)
+    await expect(extendTurn(MOCK_SESSION_ID, 30)).rejects.toThrow('No active debate')
+  })
+
+  it('adds extra seconds to turn_ends_at when debate is live', async () => {
+    const currentTurnEndsAt = Date.now() + 30_000
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false,
+      turn_ends_at: currentTurnEndsAt,
+      paused_time_remaining: 0,
+    })
+    await extendTurn(MOCK_SESSION_ID, 30)
+    const update = (prisma.debateState.update as any).mock.calls[0][0]
+    expect(update.data.turn_ends_at).toBe(currentTurnEndsAt + 30_000)
+  })
+
+  it('adds extra seconds to paused_time_remaining when debate is paused', async () => {
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: true,
+      turn_ends_at: null,
+      paused_time_remaining: 45,
+    })
+    await extendTurn(MOCK_SESSION_ID, 30)
+    const update = (prisma.debateState.update as any).mock.calls[0][0]
+    expect(update.data.paused_time_remaining).toBe(75)
+  })
+
+  it('throws if live but turn_ends_at is null', async () => {
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false,
+      turn_ends_at: null,
+      paused_time_remaining: 0,
+    })
+    await expect(extendTurn(MOCK_SESSION_ID, 30)).rejects.toThrow('No active turn')
+  })
+
+  it('allows moderator to extend turn', async () => {
+    mockSession({ host_id: 'other', moderator_id: MOCK_HOST_ID })
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: false,
+      turn_ends_at: Date.now() + 20_000,
+      paused_time_remaining: 0,
+    })
+    await extendTurn(MOCK_SESSION_ID, 60)
+    expect(prisma.debateState.update).toHaveBeenCalled()
+  })
+
+  it('handles extending by different amounts', async () => {
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      is_paused: true,
+      turn_ends_at: null,
+      paused_time_remaining: 10,
+    })
+    await extendTurn(MOCK_SESSION_ID, 120)
+    const update = (prisma.debateState.update as any).mock.calls[0][0]
+    expect(update.data.paused_time_remaining).toBe(130)
   })
 })

--- a/__tests__/hooks/useMediasoup.test.ts
+++ b/__tests__/hooks/useMediasoup.test.ts
@@ -43,6 +43,18 @@ vi.mock('mediasoup-client', () => ({
   Device: vi.fn(() => mockDevice),
 }))
 
+// ── Mock Supabase client (for auth token) ──
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: { access_token: 'mock-jwt-token' } },
+      }),
+    },
+  })),
+}))
+
 // ── Mock getUserMedia ──
 
 const mockVideoTrack = {

--- a/__tests__/queue.test.ts
+++ b/__tests__/queue.test.ts
@@ -1,0 +1,670 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SessionRole, SessionStatus, VoteType } from '@/lib/generated/prisma'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    participatesIn: { findUnique: vi.fn(), update: vi.fn(), count: vi.fn() },
+    session: { findUnique: vi.fn() },
+    audienceQueue: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    vote: {
+      create: vi.fn(),
+      count: vi.fn(),
+      findFirst: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    debateState: { findUnique: vi.fn(), update: vi.fn() },
+    $transaction: vi.fn((fn) => fn({
+      participatesIn: { findUnique: vi.fn(), update: vi.fn(), count: vi.fn() },
+      session: { findUnique: vi.fn() },
+      audienceQueue: {
+        create: vi.fn(),
+        delete: vi.fn(),
+        deleteMany: vi.fn(),
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+      },
+      vote: {
+        create: vi.fn(),
+        count: vi.fn(),
+        findFirst: vi.fn(),
+        deleteMany: vi.fn(),
+      },
+      debateState: { findUnique: vi.fn(), update: vi.fn() },
+    })),
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import {
+  joinQueue,
+  leaveQueue,
+  getQueue,
+  promoteFromQueue,
+  castKickVote,
+  removeKickVote,
+  getKickVotes,
+} from '@/lib/actions/queue'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+const MOCK_TARGET_USER_ID = 'target-user-uuid'
+
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── joinQueue ──
+describe('joinQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws if not a participant (findUnique returns null)', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('throws if left session (left_at is set)', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.AUDIENCE,
+      left_at: new Date(),
+    })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('throws if not AUDIENCE role (HOST)', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.HOST,
+      left_at: null,
+    })
+    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.WAITING })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Only audience members can join the queue')
+  })
+
+  it('throws if not AUDIENCE role (MODERATOR)', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.MODERATOR,
+      left_at: null,
+    })
+    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.WAITING })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Only audience members can join the queue')
+  })
+
+  it('throws if not AUDIENCE role (DEBATER)', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.DEBATER,
+      left_at: null,
+    })
+    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.WAITING })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Only audience members can join the queue')
+  })
+
+  it('throws if session ended', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.AUDIENCE,
+      left_at: null,
+    })
+    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.ENDED })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Session has ended')
+  })
+
+  it('creates AudienceQueue entry on success', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.AUDIENCE,
+      left_at: null,
+    })
+    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.WAITING })
+    ;(prisma.audienceQueue.create as any).mockResolvedValue({})
+
+    await joinQueue(MOCK_SESSION_ID)
+
+    expect(prisma.audienceQueue.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          session_id: MOCK_SESSION_ID,
+          user_id: MOCK_USER_ID,
+        }),
+      })
+    )
+  })
+})
+
+// ── leaveQueue ──
+describe('leaveQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(leaveQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('deletes queue entry and voters votes in a transaction', async () => {
+    const mockTx = {
+      audienceQueue: { deleteMany: vi.fn().mockResolvedValue({}) },
+      vote: { deleteMany: vi.fn().mockResolvedValue({}) },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+
+    await leaveQueue(MOCK_SESSION_ID)
+
+    expect(mockTx.audienceQueue.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          session_id: MOCK_SESSION_ID,
+          user_id: MOCK_USER_ID,
+        }),
+      })
+    )
+    expect(mockTx.vote.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+        }),
+      })
+    )
+  })
+})
+
+// ── getQueue ──
+describe('getQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(getQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns entries with computed rank (1-indexed)', async () => {
+    ;(prisma.audienceQueue.findMany as any).mockResolvedValue([
+      {
+        id: 'entry-1',
+        user_id: 'user-1',
+        session_id: MOCK_SESSION_ID,
+        added_at: new Date('2026-04-14T10:00:00Z'),
+        user: { id: 'user-1', username: 'alice', realname: 'Alice Smith' },
+      },
+      {
+        id: 'entry-2',
+        user_id: 'user-2',
+        session_id: MOCK_SESSION_ID,
+        added_at: new Date('2026-04-14T10:05:00Z'),
+        user: { id: 'user-2', username: 'bob', realname: null },
+      },
+      {
+        id: 'entry-3',
+        user_id: 'user-3',
+        session_id: MOCK_SESSION_ID,
+        added_at: new Date('2026-04-14T10:10:00Z'),
+        user: { id: 'user-3', username: 'charlie', realname: 'Charlie Brown' },
+      },
+    ])
+
+    const result = await getQueue(MOCK_SESSION_ID)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({
+      id: 'entry-1',
+      userId: 'user-1',
+      rank: 1,
+      displayName: 'Alice Smith',
+      addedAt: '2026-04-14T10:00:00.000Z',
+    })
+    expect(result[1]).toEqual({
+      id: 'entry-2',
+      userId: 'user-2',
+      rank: 2,
+      displayName: 'bob',
+      addedAt: '2026-04-14T10:05:00.000Z',
+    })
+    expect(result[2]).toEqual({
+      id: 'entry-3',
+      userId: 'user-3',
+      rank: 3,
+      displayName: 'Charlie Brown',
+      addedAt: '2026-04-14T10:10:00.000Z',
+    })
+  })
+
+  it('returns empty array when no entries', async () => {
+    ;(prisma.audienceQueue.findMany as any).mockResolvedValue([])
+
+    const result = await getQueue(MOCK_SESSION_ID)
+
+    expect(result).toEqual([])
+  })
+})
+
+// ── promoteFromQueue ──
+describe('promoteFromQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws if not host or moderator', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user',
+      moderator_id: 'another-user',
+    })
+    await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('Only moderator or host can promote from queue')
+  })
+
+  it('calls $transaction and returns promoted user', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    })
+
+    const mockTx = {
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'queue-entry-1',
+          session_id: MOCK_SESSION_ID,
+          user_id: 'promoted-user',
+          added_at: new Date(),
+          user: { id: 'promoted-user', username: 'promoted', realname: 'Promoted User' },
+        }),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      participatesIn: { update: vi.fn().mockResolvedValue({}) },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+
+    const result = await promoteFromQueue(MOCK_SESSION_ID)
+
+    expect(result).toEqual({
+      userId: 'promoted-user',
+      displayName: 'Promoted User',
+    })
+    expect(mockTx.audienceQueue.delete).toHaveBeenCalled()
+    expect(mockTx.participatesIn.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id_session_id: {
+            user_id: 'promoted-user',
+            session_id: MOCK_SESSION_ID,
+          },
+        }),
+        data: expect.objectContaining({ session_role: SessionRole.DEBATER }),
+      })
+    )
+  })
+})
+
+// ── castKickVote ──
+describe('castKickVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws if voting to kick yourself', async () => {
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_USER_ID)).rejects.toThrow('Cannot vote to kick yourself')
+  })
+
+  it('throws if voter is not AUDIENCE', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Only audience members can vote to kick')
+  })
+
+  it('throws if target is not DEBATER', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          }),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Target must be an active debater')
+  })
+
+  it('throws if target is HOST', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+      },
+      session: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: MOCK_SESSION_ID,
+          kick_threshold: 50,
+          host_id: MOCK_TARGET_USER_ID,
+        }),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Cannot vote to kick the host')
+  })
+
+  it('creates vote on success', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+        update: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(5),
+      },
+      session: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: MOCK_SESSION_ID,
+          kick_threshold: 50,
+          host_id: 'host-user',
+        }),
+      },
+      vote: {
+        create: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(2),
+        deleteMany: vi.fn().mockResolvedValue({}),
+      },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+
+    const result = await castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    expect(mockTx.vote.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+          target_user_id: MOCK_TARGET_USER_ID,
+          vote_type: VoteType.KICK,
+        }),
+      })
+    )
+    expect(result).toEqual({ kicked: false, voteCount: 2, requiredVotes: 3 })
+  })
+
+  it('returns kicked=true when threshold met (with correct math: ceil(audienceCount * threshold / 100))', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+        update: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(5),
+      },
+      session: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: MOCK_SESSION_ID,
+          kick_threshold: 50,
+          host_id: 'host-user',
+        }),
+      },
+      vote: {
+        create: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(3),
+        deleteMany: vi.fn().mockResolvedValue({}),
+      },
+      debateState: {
+        findUnique: vi.fn().mockResolvedValue({
+          session_id: MOCK_SESSION_ID,
+          debater_order: [
+            { userId: 'other-debater', displayName: 'Other' },
+            { userId: MOCK_TARGET_USER_ID, displayName: 'Target' },
+          ],
+          current_index: 0,
+        }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+
+    // audienceCount=5, threshold=50 → requiredVotes = ceil(5 * 50 / 100) = ceil(2.5) = 3
+    // voteCount=3 → kicked=true
+    const result = await castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    expect(result).toEqual({ kicked: true, voteCount: 3, requiredVotes: 3 })
+    expect(mockTx.participatesIn.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id_session_id: {
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+          },
+        }),
+        data: expect.objectContaining({ left_at: expect.any(Date) }),
+      })
+    )
+  })
+
+  it('returns kicked=false when threshold not met', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+        update: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(10),
+      },
+      session: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: MOCK_SESSION_ID,
+          kick_threshold: 60,
+          host_id: 'host-user',
+        }),
+      },
+      vote: {
+        create: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(5),
+        deleteMany: vi.fn().mockResolvedValue({}),
+      },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+
+    // audienceCount=10, threshold=60 → requiredVotes = ceil(10 * 60 / 100) = ceil(6) = 6
+    // voteCount=5 → kicked=false
+    const result = await castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    expect(result).toEqual({ kicked: false, voteCount: 5, requiredVotes: 6 })
+    expect(mockTx.participatesIn.update).not.toHaveBeenCalled()
+  })
+})
+
+// ── removeKickVote ──
+describe('removeKickVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(removeKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('deletes the vote', async () => {
+    ;(prisma.vote.deleteMany as any).mockResolvedValue({})
+
+    await removeKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    expect(prisma.vote.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+          target_user_id: MOCK_TARGET_USER_ID,
+          vote_type: VoteType.KICK,
+        }),
+      })
+    )
+  })
+})
+
+// ── getKickVotes ──
+describe('getKickVotes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(getKickVotes(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns correct voteCount, requiredVotes, userHasVoted', async () => {
+    ;(prisma.vote.count as any).mockResolvedValue(3)
+    ;(prisma.participatesIn.count as any).mockResolvedValue(8)
+    ;(prisma.vote.findFirst as any).mockResolvedValue({ id: 'vote-1' })
+    ;(prisma.session.findUnique as any).mockResolvedValue({ kick_threshold: 50 })
+
+    const result = await getKickVotes(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    // audienceCount=8, threshold=50 → requiredVotes = ceil(8 * 50 / 100) = ceil(4) = 4
+    expect(result).toEqual({
+      voteCount: 3,
+      requiredVotes: 4,
+      userHasVoted: true,
+    })
+  })
+
+  it('returns userHasVoted=false when user has not voted', async () => {
+    ;(prisma.vote.count as any).mockResolvedValue(2)
+    ;(prisma.participatesIn.count as any).mockResolvedValue(10)
+    ;(prisma.vote.findFirst as any).mockResolvedValue(null)
+    ;(prisma.session.findUnique as any).mockResolvedValue({ kick_threshold: 60 })
+
+    const result = await getKickVotes(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    // audienceCount=10, threshold=60 → requiredVotes = ceil(10 * 60 / 100) = ceil(6) = 6
+    expect(result).toEqual({
+      voteCount: 2,
+      requiredVotes: 6,
+      userHasVoted: false,
+    })
+  })
+})

--- a/__tests__/queue.test.ts
+++ b/__tests__/queue.test.ts
@@ -16,12 +16,16 @@ vi.mock('@/lib/prisma', () => ({
       deleteMany: vi.fn(),
       findFirst: vi.fn(),
       findMany: vi.fn(),
+      findUnique: vi.fn(),
     },
     vote: {
       create: vi.fn(),
       count: vi.fn(),
       findFirst: vi.fn(),
       deleteMany: vi.fn(),
+    },
+    roleHistory: {
+      create: vi.fn(),
     },
     debateState: { findUnique: vi.fn(), update: vi.fn() },
     $transaction: vi.fn((fn) => fn({
@@ -33,12 +37,16 @@ vi.mock('@/lib/prisma', () => ({
         deleteMany: vi.fn(),
         findFirst: vi.fn(),
         findMany: vi.fn(),
+        findUnique: vi.fn(),
       },
       vote: {
         create: vi.fn(),
         count: vi.fn(),
         findFirst: vi.fn(),
         deleteMany: vi.fn(),
+      },
+      roleHistory: {
+        create: vi.fn(),
       },
       debateState: { findUnique: vi.fn(), update: vi.fn() },
     })),
@@ -60,6 +68,7 @@ import {
 const MOCK_USER_ID = 'user-uuid-1234'
 const MOCK_SESSION_ID = 'session-cuid-5678'
 const MOCK_TARGET_USER_ID = 'target-user-uuid'
+const MOCK_HOST_ID = 'host-uuid'
 
 function mockAuth(userId: string | null) {
   ;(createClient as any).mockResolvedValue({
@@ -76,11 +85,35 @@ describe('joinQueue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      status: SessionStatus.LIVE,
+    })
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.AUDIENCE,
+      left_at: null,
+    })
+    ;(prisma.audienceQueue.create as any).mockResolvedValue({})
   })
 
   it('throws if not authenticated', async () => {
     mockAuth(null)
     await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Session not found"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Session is not live"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      status: SessionStatus.WAITING,
+    })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Session is not live')
   })
 
   it('throws if not a participant (findUnique returns null)', async () => {
@@ -105,18 +138,6 @@ describe('joinQueue', () => {
       session_role: SessionRole.HOST,
       left_at: null,
     })
-    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.WAITING })
-    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Only audience members can join the queue')
-  })
-
-  it('throws if not AUDIENCE role (MODERATOR)', async () => {
-    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
-      user_id: MOCK_USER_ID,
-      session_id: MOCK_SESSION_ID,
-      session_role: SessionRole.MODERATOR,
-      left_at: null,
-    })
-    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.WAITING })
     await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Only audience members can join the queue')
   })
 
@@ -127,41 +148,17 @@ describe('joinQueue', () => {
       session_role: SessionRole.DEBATER,
       left_at: null,
     })
-    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.WAITING })
     await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Only audience members can join the queue')
   })
 
-  it('throws if session ended', async () => {
-    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
-      user_id: MOCK_USER_ID,
-      session_id: MOCK_SESSION_ID,
-      session_role: SessionRole.AUDIENCE,
-      left_at: null,
-    })
-    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.ENDED })
-    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Session has ended')
-  })
-
   it('creates AudienceQueue entry on success', async () => {
-    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
-      user_id: MOCK_USER_ID,
-      session_id: MOCK_SESSION_ID,
-      session_role: SessionRole.AUDIENCE,
-      left_at: null,
-    })
-    ;(prisma.session.findUnique as any).mockResolvedValue({ status: SessionStatus.WAITING })
-    ;(prisma.audienceQueue.create as any).mockResolvedValue({})
-
     await joinQueue(MOCK_SESSION_ID)
-
-    expect(prisma.audienceQueue.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          session_id: MOCK_SESSION_ID,
-          user_id: MOCK_USER_ID,
-        }),
-      })
-    )
+    expect(prisma.audienceQueue.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        user_id: MOCK_USER_ID,
+      },
+    })
   })
 })
 
@@ -182,7 +179,7 @@ describe('leaveQueue', () => {
       audienceQueue: { deleteMany: vi.fn().mockResolvedValue({}) },
       vote: { deleteMany: vi.fn().mockResolvedValue({}) },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     await leaveQueue(MOCK_SESSION_ID)
 
@@ -223,21 +220,21 @@ describe('getQueue', () => {
         id: 'entry-1',
         user_id: 'user-1',
         session_id: MOCK_SESSION_ID,
-        added_at: new Date('2026-04-14T10:00:00Z'),
+        joined_queue: new Date('2026-04-14T10:00:00Z'),
         user: { id: 'user-1', username: 'alice', realname: 'Alice Smith' },
       },
       {
         id: 'entry-2',
         user_id: 'user-2',
         session_id: MOCK_SESSION_ID,
-        added_at: new Date('2026-04-14T10:05:00Z'),
+        joined_queue: new Date('2026-04-14T10:05:00Z'),
         user: { id: 'user-2', username: 'bob', realname: null },
       },
       {
         id: 'entry-3',
         user_id: 'user-3',
         session_id: MOCK_SESSION_ID,
-        added_at: new Date('2026-04-14T10:10:00Z'),
+        joined_queue: new Date('2026-04-14T10:10:00Z'),
         user: { id: 'user-3', username: 'charlie', realname: 'Charlie Brown' },
       },
     ])
@@ -281,7 +278,14 @@ describe('getQueue', () => {
 describe('promoteFromQueue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockAuth(MOCK_USER_ID)
+    mockAuth(MOCK_HOST_ID)
+
+    // Mock session with host
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_HOST_ID,
+      moderator_id: null,
+    })
   })
 
   it('throws if not authenticated', async () => {
@@ -295,37 +299,47 @@ describe('promoteFromQueue', () => {
       host_id: 'other-user',
       moderator_id: 'another-user',
     })
-    await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('Only moderator or host can promote from queue')
+    await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authorized')
   })
 
-  it('calls $transaction and returns promoted user', async () => {
-    ;(prisma.session.findUnique as any).mockResolvedValue({
-      id: MOCK_SESSION_ID,
-      host_id: MOCK_USER_ID,
-      moderator_id: null,
-    })
+  it('throws "No one in the queue" when queue is empty', async () => {
+    const mockTx = {
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        findUnique: vi.fn(),
+        delete: vi.fn(),
+      },
+      participatesIn: { update: vi.fn() },
+      roleHistory: { create: vi.fn() },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
+    await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('No one in the queue')
+  })
+
+  it('calls $transaction and returns promoted user on FIFO promote', async () => {
     const mockTx = {
       audienceQueue: {
         findFirst: vi.fn().mockResolvedValue({
           id: 'queue-entry-1',
           session_id: MOCK_SESSION_ID,
           user_id: 'promoted-user',
-          added_at: new Date(),
+          joined_queue: new Date(),
           user: { id: 'promoted-user', username: 'promoted', realname: 'Promoted User' },
         }),
         delete: vi.fn().mockResolvedValue({}),
       },
       participatesIn: { update: vi.fn().mockResolvedValue({}) },
       debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     const result = await promoteFromQueue(MOCK_SESSION_ID)
 
     expect(result).toEqual({
-      userId: 'promoted-user',
-      displayName: 'Promoted User',
+      promotedUserId: 'promoted-user',
     })
     expect(mockTx.audienceQueue.delete).toHaveBeenCalled()
     expect(mockTx.participatesIn.update).toHaveBeenCalledWith(
@@ -339,6 +353,59 @@ describe('promoteFromQueue', () => {
         data: expect.objectContaining({ session_role: SessionRole.DEBATER }),
       })
     )
+  })
+
+  it('promotes specific user when userId is provided', async () => {
+    const specificUserId = 'specific-user-uuid'
+    const mockTx = {
+      audienceQueue: {
+        findFirst: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({
+          user_id: specificUserId,
+          session_id: MOCK_SESSION_ID,
+        }),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      participatesIn: { update: vi.fn().mockResolvedValue({}) },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
+
+    const result = await promoteFromQueue(MOCK_SESSION_ID, specificUserId)
+
+    expect(mockTx.audienceQueue.findUnique).toHaveBeenCalledWith({
+      where: { session_id_user_id: { session_id: MOCK_SESSION_ID, user_id: specificUserId } },
+    })
+    expect(result).toEqual({ promotedUserId: specificUserId })
+  })
+
+  it('allows moderator to promote from queue', async () => {
+    mockAuth('moderator-uuid')
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_HOST_ID,
+      moderator_id: 'moderator-uuid',
+    })
+
+    const mockTx = {
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'queue-entry',
+          session_id: MOCK_SESSION_ID,
+          user_id: 'some-user',
+          joined_queue: new Date(),
+          user: { id: 'some-user', username: 'someone', realname: null },
+        }),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      participatesIn: { update: vi.fn().mockResolvedValue({}) },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
+
+    await promoteFromQueue(MOCK_SESSION_ID)
+    expect(prisma.$transaction).toHaveBeenCalled()
   })
 })
 
@@ -370,7 +437,7 @@ describe('castKickVote', () => {
           }),
       },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Only audience members can vote to kick')
   })
@@ -393,7 +460,7 @@ describe('castKickVote', () => {
           }),
       },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Target must be an active debater')
   })
@@ -423,7 +490,7 @@ describe('castKickVote', () => {
         }),
       },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Cannot vote to kick the host')
   })
@@ -459,12 +526,13 @@ describe('castKickVote', () => {
         count: vi.fn().mockResolvedValue(2),
         deleteMany: vi.fn().mockResolvedValue({}),
       },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
       debateState: { findUnique: vi.fn().mockResolvedValue(null) },
       audienceQueue: {
         findFirst: vi.fn().mockResolvedValue(null),
       },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     const result = await castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
 
@@ -512,6 +580,7 @@ describe('castKickVote', () => {
         count: vi.fn().mockResolvedValue(3),
         deleteMany: vi.fn().mockResolvedValue({}),
       },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
       debateState: {
         findUnique: vi.fn().mockResolvedValue({
           session_id: MOCK_SESSION_ID,
@@ -527,10 +596,10 @@ describe('castKickVote', () => {
         findFirst: vi.fn().mockResolvedValue(null),
       },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
-    // audienceCount=5, threshold=50 → requiredVotes = ceil(5 * 50 / 100) = ceil(2.5) = 3
-    // voteCount=3 → kicked=true
+    // audienceCount=5, threshold=50 -> requiredVotes = ceil(5 * 50 / 100) = ceil(2.5) = 3
+    // voteCount=3 -> kicked=true
     const result = await castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
 
     expect(result).toEqual({ kicked: true, voteCount: 3, requiredVotes: 3 })
@@ -578,15 +647,16 @@ describe('castKickVote', () => {
         count: vi.fn().mockResolvedValue(5),
         deleteMany: vi.fn().mockResolvedValue({}),
       },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
       debateState: { findUnique: vi.fn().mockResolvedValue(null) },
       audienceQueue: {
         findFirst: vi.fn().mockResolvedValue(null),
       },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (fn) => fn(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
-    // audienceCount=10, threshold=60 → requiredVotes = ceil(10 * 60 / 100) = ceil(6) = 6
-    // voteCount=5 → kicked=false
+    // audienceCount=10, threshold=60 -> requiredVotes = ceil(10 * 60 / 100) = ceil(6) = 6
+    // voteCount=5 -> kicked=false
     const result = await castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
 
     expect(result).toEqual({ kicked: false, voteCount: 5, requiredVotes: 6 })
@@ -644,7 +714,7 @@ describe('getKickVotes', () => {
 
     const result = await getKickVotes(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
 
-    // audienceCount=8, threshold=50 → requiredVotes = ceil(8 * 50 / 100) = ceil(4) = 4
+    // audienceCount=8, threshold=50 -> requiredVotes = ceil(8 * 50 / 100) = ceil(4) = 4
     expect(result).toEqual({
       voteCount: 3,
       requiredVotes: 4,
@@ -660,7 +730,7 @@ describe('getKickVotes', () => {
 
     const result = await getKickVotes(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
 
-    // audienceCount=10, threshold=60 → requiredVotes = ceil(10 * 60 / 100) = ceil(6) = 6
+    // audienceCount=10, threshold=60 -> requiredVotes = ceil(10 * 60 / 100) = ceil(6) = 6
     expect(result).toEqual({
       voteCount: 2,
       requiredVotes: 6,

--- a/__tests__/recording.test.ts
+++ b/__tests__/recording.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+    },
+    participatesIn: {
+      findUnique: vi.fn(),
+    },
+    recording: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import {
+  createRecording,
+  getRecordingsBySession,
+  deleteRecording,
+} from '@/lib/actions/recording'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_HOST_ID = 'host-uuid-5678'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+const MOCK_RECORDING_ID = 'recording-id-1234'
+
+// Helper to set up auth mock
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── createRecording ──
+describe('createRecording', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    })
+    ;(prisma.recording.create as any).mockResolvedValue({
+      id: MOCK_RECORDING_ID,
+    })
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Session not found"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(
+      createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    ).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Not authorized" when not host/moderator', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user',
+      moderator_id: null,
+    })
+    await expect(
+      createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    ).rejects.toThrow('Not authorized')
+  })
+
+  it('calls prisma.recording.create on success', async () => {
+    await createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4', 3600, 1024000, 'video/mp4')
+    expect(prisma.recording.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        recorded_by: MOCK_USER_ID,
+        url: 'https://example.com/recording.mp4',
+        duration: 3600,
+        file_size: 1024000,
+        mime_type: 'video/mp4',
+      },
+    })
+  })
+
+  it('calls prisma.recording.create with null for optional fields', async () => {
+    await createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    expect(prisma.recording.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        recorded_by: MOCK_USER_ID,
+        url: 'https://example.com/recording.mp4',
+        duration: null,
+        file_size: null,
+        mime_type: null,
+      },
+    })
+  })
+
+  it('allows moderator to create recording', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user',
+      moderator_id: MOCK_USER_ID,
+    })
+    await createRecording(MOCK_SESSION_ID, 'https://example.com/recording.mp4')
+    expect(prisma.recording.create).toHaveBeenCalled()
+  })
+})
+
+// ── getRecordingsBySession ──
+describe('getRecordingsBySession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.recording.findMany as any).mockResolvedValue([])
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(getRecordingsBySession(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Not a participant"', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(getRecordingsBySession(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('returns recordings ordered by created_at desc', async () => {
+    await getRecordingsBySession(MOCK_SESSION_ID)
+    expect(prisma.recording.findMany).toHaveBeenCalledWith({
+      where: { session_id: MOCK_SESSION_ID },
+      orderBy: { created_at: 'desc' },
+      include: {
+        recorder: { select: { id: true, username: true, realname: true } },
+      },
+    })
+  })
+})
+
+// ── deleteRecording ──
+describe('deleteRecording', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.recording.findUnique as any).mockResolvedValue({
+      id: MOCK_RECORDING_ID,
+      recorded_by: MOCK_USER_ID,
+      session: { host_id: MOCK_HOST_ID },
+    })
+    ;(prisma.recording.delete as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(deleteRecording(MOCK_RECORDING_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Recording not found"', async () => {
+    ;(prisma.recording.findUnique as any).mockResolvedValue(null)
+    await expect(deleteRecording(MOCK_RECORDING_ID)).rejects.toThrow('Recording not found')
+  })
+
+  it('throws "Not authorized" when user is not recorder and not host', async () => {
+    ;(prisma.recording.findUnique as any).mockResolvedValue({
+      id: MOCK_RECORDING_ID,
+      recorded_by: 'other-user',
+      session: { host_id: 'other-host' },
+    })
+    await expect(deleteRecording(MOCK_RECORDING_ID)).rejects.toThrow('Not authorized to delete this recording')
+  })
+
+  it('calls prisma.recording.delete when user is recorder', async () => {
+    await deleteRecording(MOCK_RECORDING_ID)
+    expect(prisma.recording.delete).toHaveBeenCalledWith({
+      where: { id: MOCK_RECORDING_ID },
+    })
+  })
+
+  it('calls prisma.recording.delete when user is host (even if not recorder)', async () => {
+    mockAuth(MOCK_HOST_ID)
+    ;(prisma.recording.findUnique as any).mockResolvedValue({
+      id: MOCK_RECORDING_ID,
+      recorded_by: 'other-user',
+      session: { host_id: MOCK_HOST_ID },
+    })
+    await deleteRecording(MOCK_RECORDING_ID)
+    expect(prisma.recording.delete).toHaveBeenCalledWith({
+      where: { id: MOCK_RECORDING_ID },
+    })
+  })
+})

--- a/__tests__/security/auth.test.ts
+++ b/__tests__/security/auth.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SignJWT } from 'jose'
+
+const TEST_SECRET = 'test-jwt-secret-that-is-long-enough'
+const SECRET_KEY = new TextEncoder().encode(TEST_SECRET)
+
+async function createValidToken(sub = 'user-123') {
+  return new SignJWT({ sub })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime('1h')
+    .sign(SECRET_KEY)
+}
+
+async function createExpiredToken() {
+  return new SignJWT({ sub: 'user-123' })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime('-1h')
+    .sign(SECRET_KEY)
+}
+
+async function createTokenWithoutSub() {
+  return new SignJWT({})
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime('1h')
+    .sign(SECRET_KEY)
+}
+
+function createMockSocket(token?: string) {
+  return {
+    handshake: {
+      auth: token !== undefined ? { token } : {},
+    },
+    data: {} as Record<string, unknown>,
+  }
+}
+
+describe('createAuthMiddleware', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('skips auth when SUPABASE_JWT_SECRET is not set (dev mode)', async () => {
+    delete process.env.SUPABASE_JWT_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const socket = createMockSocket()
+    const next = vi.fn()
+
+    middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects connection when no token is provided', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const socket = createMockSocket()
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Authentication required')
+  })
+
+  it('accepts connection with valid token and attaches userId', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const token = await createValidToken('user-456')
+    const socket = createMockSocket(token)
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(socket.data.userId).toBe('user-456')
+  })
+
+  it('rejects connection with expired token', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const token = await createExpiredToken()
+    const socket = createMockSocket(token)
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Invalid or expired token')
+  })
+
+  it('rejects connection with invalid token', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const socket = createMockSocket('garbage-token')
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Invalid or expired token')
+  })
+
+  it('rejects connection with token signed by wrong secret', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const wrongKey = new TextEncoder().encode('wrong-secret-key-long-enough-here')
+    const wrongToken = await new SignJWT({ sub: 'user-123' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setExpirationTime('1h')
+      .sign(wrongKey)
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const socket = createMockSocket(wrongToken)
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Invalid or expired token')
+  })
+
+  it('rejects token without sub claim', async () => {
+    process.env.SUPABASE_JWT_SECRET = TEST_SECRET
+    delete process.env.NODE_ENV
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    const middleware = createAuthMiddleware()
+    const token = await createTokenWithoutSub()
+    const socket = createMockSocket(token)
+    const next = vi.fn()
+
+    await middleware(socket as any, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    expect(next.mock.calls[0][0].message).toBe('Invalid token: missing sub claim')
+  })
+
+  it('exits process in production when SUPABASE_JWT_SECRET is not set', async () => {
+    process.env.NODE_ENV = 'production'
+    delete process.env.SUPABASE_JWT_SECRET
+
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+
+    const { createAuthMiddleware } = await import('../../realtime/src/auth')
+    createAuthMiddleware()
+
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
+  })
+})

--- a/__tests__/security/path-traversal.test.ts
+++ b/__tests__/security/path-traversal.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import path from 'node:path'
+
+/**
+ * Tests for the path traversal protection logic used in realtime/src/index.ts.
+ * We test the pure logic here rather than spinning up the HTTP server.
+ */
+
+const testClientDir = '/app/test-client'
+
+function isPathSafe(requestUrl: string): { safe: boolean; resolvedPath?: string; error?: string } {
+  let decodedUrl: string
+  try {
+    decodedUrl = decodeURIComponent(requestUrl)
+  } catch {
+    return { safe: false, error: 'bad-request' }
+  }
+
+  const requestedPath = decodedUrl === '/' ? '/index.html' : decodedUrl
+  const resolvedPath = path.resolve(testClientDir, '.' + requestedPath)
+
+  if (resolvedPath !== testClientDir && !resolvedPath.startsWith(testClientDir + path.sep)) {
+    return { safe: false, error: 'forbidden' }
+  }
+
+  return { safe: true, resolvedPath }
+}
+
+describe('Path traversal protection', () => {
+  it('allows root path', () => {
+    const result = isPathSafe('/')
+    expect(result.safe).toBe(true)
+    expect(result.resolvedPath).toBe(path.join(testClientDir, 'index.html'))
+  })
+
+  it('allows normal file paths', () => {
+    const result = isPathSafe('/client.js')
+    expect(result.safe).toBe(true)
+    expect(result.resolvedPath).toBe(path.join(testClientDir, 'client.js'))
+  })
+
+  it('allows nested file paths', () => {
+    const result = isPathSafe('/css/style.css')
+    expect(result.safe).toBe(true)
+    expect(result.resolvedPath).toBe(path.join(testClientDir, 'css', 'style.css'))
+  })
+
+  it('blocks basic directory traversal', () => {
+    const result = isPathSafe('/../../../etc/passwd')
+    expect(result.safe).toBe(false)
+    expect(result.error).toBe('forbidden')
+  })
+
+  it('blocks URL-encoded directory traversal (%2e%2e)', () => {
+    const result = isPathSafe('/%2e%2e/%2e%2e/%2e%2e/etc/passwd')
+    expect(result.safe).toBe(false)
+    expect(result.error).toBe('forbidden')
+  })
+
+  it('blocks double-encoded traversal', () => {
+    // %252e decodes to %2e on first pass, which would decode to . on second
+    // But decodeURIComponent only decodes once, so %252e → %2e
+    // path.resolve would treat %2e as literal characters, not dots
+    // This should still be safe as the resolved path would contain literal %2e
+    const result = isPathSafe('/%252e%252e/%252e%252e/etc/passwd')
+    expect(result.safe).toBe(true) // %2e is literal, stays in testClientDir
+  })
+
+  it('blocks traversal with backslashes (Windows-style)', () => {
+    const result = isPathSafe('/..\\..\\..\\etc\\passwd')
+    // On POSIX, backslashes are literal chars — not path separators
+    // The resolved path stays within testClientDir on POSIX
+    // On Windows, path.resolve treats them as separators, so this would be blocked
+    if (process.platform === 'win32') {
+      expect(result.safe).toBe(false)
+    } else {
+      // On POSIX, backslash is a valid filename char — path stays within dir
+      expect(result.safe).toBe(true)
+    }
+  })
+
+  it('blocks traversal to parent directory', () => {
+    const result = isPathSafe('/..')
+    expect(result.safe).toBe(false)
+    expect(result.error).toBe('forbidden')
+  })
+
+  it('returns bad-request for malformed URL encoding', () => {
+    const result = isPathSafe('/%ZZ')
+    expect(result.safe).toBe(false)
+    expect(result.error).toBe('bad-request')
+  })
+
+  it('allows file with dots in name', () => {
+    const result = isPathSafe('/bundle.min.js')
+    expect(result.safe).toBe(true)
+  })
+})

--- a/__tests__/security/validation.test.ts
+++ b/__tests__/security/validation.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest'
+import { schemas, validatePayload } from '../../realtime/src/validation'
+
+// ── validatePayload helper ──
+describe('validatePayload', () => {
+  it('returns success with parsed data for valid input', () => {
+    const result = validatePayload(schemas.getRouterRtpCapabilities, { roomId: 'room-1' })
+    expect(result).toEqual({ success: true, data: { roomId: 'room-1' } })
+  })
+
+  it('returns error string for invalid input', () => {
+    const result = validatePayload(schemas.getRouterRtpCapabilities, {})
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('Invalid payload')
+    }
+  })
+
+  it('returns error for completely wrong type', () => {
+    const result = validatePayload(schemas.getRouterRtpCapabilities, 'not-an-object')
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── getRouterRtpCapabilities schema ──
+describe('schemas.getRouterRtpCapabilities', () => {
+  it('accepts valid roomId', () => {
+    const result = schemas.getRouterRtpCapabilities.safeParse({ roomId: 'room-123' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing roomId', () => {
+    const result = schemas.getRouterRtpCapabilities.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty roomId', () => {
+    const result = schemas.getRouterRtpCapabilities.safeParse({ roomId: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects roomId exceeding 100 chars', () => {
+    const result = schemas.getRouterRtpCapabilities.safeParse({ roomId: 'a'.repeat(101) })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── joinRoom schema ──
+describe('schemas.joinRoom', () => {
+  const validPayload = {
+    roomId: 'room-1',
+    displayName: 'Alice',
+    rtpCapabilities: { codecs: [] },
+  }
+
+  it('accepts valid payload', () => {
+    const result = schemas.joinRoom.safeParse(validPayload)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing displayName', () => {
+    const result = schemas.joinRoom.safeParse({ roomId: 'room-1', rtpCapabilities: {} })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects displayName exceeding 50 chars', () => {
+    const result = schemas.joinRoom.safeParse({
+      ...validPayload,
+      displayName: 'a'.repeat(51),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing rtpCapabilities', () => {
+    const result = schemas.joinRoom.safeParse({ roomId: 'room-1', displayName: 'Alice' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── createWebRtcTransport schema ──
+describe('schemas.createWebRtcTransport', () => {
+  it('accepts "send" direction', () => {
+    const result = schemas.createWebRtcTransport.safeParse({ direction: 'send' })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts "recv" direction', () => {
+    const result = schemas.createWebRtcTransport.safeParse({ direction: 'recv' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid direction', () => {
+    const result = schemas.createWebRtcTransport.safeParse({ direction: 'both' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing direction', () => {
+    const result = schemas.createWebRtcTransport.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── connectTransport schema ──
+describe('schemas.connectTransport', () => {
+  it('accepts valid payload', () => {
+    const result = schemas.connectTransport.safeParse({
+      transportId: 'transport-1',
+      dtlsParameters: { fingerprints: [] },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing transportId', () => {
+    const result = schemas.connectTransport.safeParse({ dtlsParameters: {} })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing dtlsParameters', () => {
+    const result = schemas.connectTransport.safeParse({ transportId: 'transport-1' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── produce schema ──
+describe('schemas.produce', () => {
+  const validPayload = {
+    transportId: 'transport-1',
+    kind: 'audio' as const,
+    rtpParameters: { codecs: [] },
+  }
+
+  it('accepts valid payload with audio kind', () => {
+    const result = schemas.produce.safeParse(validPayload)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts valid payload with video kind', () => {
+    const result = schemas.produce.safeParse({ ...validPayload, kind: 'video' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid kind', () => {
+    const result = schemas.produce.safeParse({ ...validPayload, kind: 'data' })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts optional appData', () => {
+    const result = schemas.produce.safeParse({ ...validPayload, appData: { source: 'webcam' } })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing rtpParameters', () => {
+    const result = schemas.produce.safeParse({ transportId: 'transport-1', kind: 'audio' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── consume schema ──
+describe('schemas.consume', () => {
+  it('accepts valid producerId', () => {
+    const result = schemas.consume.safeParse({ producerId: 'prod-1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing producerId', () => {
+    const result = schemas.consume.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty producerId', () => {
+    const result = schemas.consume.safeParse({ producerId: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── resumeConsumer schema ──
+describe('schemas.resumeConsumer', () => {
+  it('accepts valid consumerId', () => {
+    const result = schemas.resumeConsumer.safeParse({ consumerId: 'cons-1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing consumerId', () => {
+    const result = schemas.resumeConsumer.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── closeProducer schema ──
+describe('schemas.closeProducer', () => {
+  it('accepts valid producerId', () => {
+    const result = schemas.closeProducer.safeParse({ producerId: 'prod-1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing producerId', () => {
+    const result = schemas.closeProducer.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── getProducers schema ──
+describe('schemas.getProducers', () => {
+  it('accepts any data (no strict schema)', () => {
+    const result = schemas.getProducers.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts undefined', () => {
+    const result = schemas.getProducers.safeParse(undefined)
+    expect(result.success).toBe(true)
+  })
+})

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -38,6 +38,9 @@ vi.mock('@/lib/prisma', () => {
     debateState: {
       findUnique: vi.fn(),
     },
+    roleHistory: {
+      create: vi.fn().mockResolvedValue({}),
+    },
     $transaction: vi.fn(async (callback: any) => callback(prismaMock)),
   }
 
@@ -53,6 +56,9 @@ import {
   joinSessionAsDebater,
   leaveSession,
   updateSessionStatus,
+  assignModerator,
+  kickParticipant,
+  promoteToDebater,
 } from '@/lib/actions/session'
 
 // Helper to set up auth mock
@@ -474,5 +480,207 @@ describe('updateSessionStatus', () => {
     expect(call.data.status).toBe(SessionStatus.ENDED)
     expect(call.data.ended_at).toBeInstanceOf(Date)
     expect(call.data.ended_at.getTime()).toBeGreaterThanOrEqual(before)
+  })
+})
+
+// ── Security: Input bounds validation ──
+describe('createSession — security bounds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    ;(prisma.session.create as any).mockResolvedValue({ id: MOCK_SESSION_ID, code: 'ARG-1234' })
+  })
+
+  it('throws if audienceCapacity exceeds 1000', async () => {
+    await expect(createSession(sessionForm({ audienceCapacity: 1001 }) as any)).rejects.toThrow(
+      'Audience capacity cannot exceed 1000'
+    )
+  })
+
+  it('allows audienceCapacity of exactly 1000', async () => {
+    await expect(createSession(sessionForm({ audienceCapacity: 1000 }) as any)).resolves.not.toThrow()
+  })
+
+  it('throws if turnLength exceeds 1800', async () => {
+    await expect(createSession(sessionForm({ turnLength: 1801 }) as any)).rejects.toThrow(
+      'Turn length cannot exceed 30 minutes'
+    )
+  })
+
+  it('allows turnLength of exactly 1800', async () => {
+    await expect(createSession(sessionForm({ turnLength: 1800 }) as any)).resolves.not.toThrow()
+  })
+})
+
+// ── Security: assignModerator participant check ──
+describe('assignModerator — participant check', () => {
+  const TARGET_USER_ID = 'target-user-id'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    })
+    ;(prisma.$transaction as any).mockResolvedValue([])
+  })
+
+  it('throws if target user is not an active participant', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(assignModerator(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow(
+      'Target user is not an active participant'
+    )
+  })
+
+  it('throws if target user has left the session', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: TARGET_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(assignModerator(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow(
+      'Target user is not an active participant'
+    )
+  })
+
+  it('succeeds when target user is an active participant', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: TARGET_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    await expect(assignModerator(MOCK_SESSION_ID, TARGET_USER_ID)).resolves.not.toThrow()
+  })
+})
+
+// ── Security: kickParticipant participant check ──
+describe('kickParticipant — participant check', () => {
+  const TARGET_USER_ID = 'target-user-id'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    })
+    ;(prisma.participatesIn.update as any).mockResolvedValue({})
+    ;(prisma.audienceQueue.deleteMany as any).mockResolvedValue({})
+    ;(prisma.vote.deleteMany as any).mockResolvedValue({})
+    ;(prisma.debateState.findUnique as any).mockResolvedValue(null)
+    // kickParticipant uses $transaction — restore the implementation after clearAllMocks
+    ;(prisma.$transaction as any).mockImplementation(async (callback: any) => callback(prisma))
+  })
+
+  it('throws if target user is not an active participant', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(kickParticipant(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow(
+      'Target user is not an active participant'
+    )
+  })
+
+  it('throws if target user has already left', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: TARGET_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(kickParticipant(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow(
+      'Target user is not an active participant'
+    )
+  })
+
+  it('kicks active participant successfully', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: TARGET_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+      session_role: SessionRole.AUDIENCE,
+    })
+    await kickParticipant(MOCK_SESSION_ID, TARGET_USER_ID)
+    expect(prisma.participatesIn.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ left_at: expect.any(Date) }),
+      })
+    )
+  })
+})
+
+// ── promoteToDebater ──
+describe('promoteToDebater', () => {
+  const TARGET_USER_ID = 'target-user-uuid'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.update as any).mockResolvedValue({})
+  })
+
+  function mockSessionForPromote(overrides: Record<string, unknown> = {}) {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+      status: SessionStatus.WAITING,
+      ...overrides,
+    })
+  }
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws if session not found', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Session not found')
+  })
+
+  it('throws if caller is not host or moderator', async () => {
+    mockSessionForPromote({ host_id: 'other-user', moderator_id: null })
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Only moderators or hosts')
+  })
+
+  it('throws if session is not in WAITING status', async () => {
+    mockSessionForPromote({ status: SessionStatus.LIVE })
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Can only promote participants before the debate starts')
+  })
+
+  it('throws if trying to promote yourself', async () => {
+    mockSessionForPromote()
+    await expect(promoteToDebater(MOCK_SESSION_ID, MOCK_USER_ID)).rejects.toThrow('Cannot promote yourself')
+  })
+
+  it('updates participant role to DEBATER', async () => {
+    mockSessionForPromote()
+    await promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)
+    expect(prisma.participatesIn.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id_session_id: { user_id: TARGET_USER_ID, session_id: MOCK_SESSION_ID },
+        }),
+        data: expect.objectContaining({ session_role: SessionRole.DEBATER }),
+      })
+    )
+  })
+
+  it('allows moderator to promote', async () => {
+    mockSessionForPromote({ host_id: 'some-host', moderator_id: MOCK_USER_ID })
+    await promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)
+    expect(prisma.participatesIn.update).toHaveBeenCalled()
+  })
+
+  it('throws when session is PAUSED', async () => {
+    mockSessionForPromote({ status: SessionStatus.PAUSED })
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Can only promote participants before the debate starts')
+  })
+
+  it('throws when session is ENDED', async () => {
+    mockSessionForPromote({ status: SessionStatus.ENDED })
+    await expect(promoteToDebater(MOCK_SESSION_ID, TARGET_USER_ID)).rejects.toThrow('Can only promote participants before the debate starts')
   })
 })

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -10,8 +10,13 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }))
 
-vi.mock('@/lib/prisma', () => ({
-  prisma: {
+vi.mock('@/lib/actions/queue', () => ({
+  doPromoteFromQueue: vi.fn().mockResolvedValue(null),
+  cleanupUserVotes: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/prisma', () => {
+  const prismaMock = {
     session: {
       create: vi.fn(),
       findUnique: vi.fn(),
@@ -22,9 +27,22 @@ vi.mock('@/lib/prisma', () => ({
       create: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
-  },
-}))
+    audienceQueue: {
+      deleteMany: vi.fn(),
+    },
+    vote: {
+      deleteMany: vi.fn(),
+    },
+    debateState: {
+      findUnique: vi.fn(),
+    },
+    $transaction: vi.fn(async (callback: any) => callback(prismaMock)),
+  }
+
+  return { prisma: prismaMock }
+})
 
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
@@ -152,6 +170,17 @@ describe('createSession', () => {
   it('throws if audience capacity is negative', async () => {
     await expect(createSession(sessionForm({ audienceCapacity: -1 }) as any)).rejects.toThrow(
       'Audience capacity cannot be negative'
+    )
+  })
+
+  it('stores kick_threshold when provided', async () => {
+    await createSession(sessionForm({ kickThreshold: 75 }) as any)
+    expect(prisma.session.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          kick_threshold: 75,
+        }),
+      })
     )
   })
 })
@@ -328,7 +357,15 @@ describe('leaveSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.AUDIENCE,
+    })
     ;(prisma.participatesIn.update as any).mockResolvedValue({})
+    ;(prisma.audienceQueue.deleteMany as any).mockResolvedValue({})
+    ;(prisma.vote.deleteMany as any).mockResolvedValue({})
+    ;(prisma.debateState.findUnique as any).mockResolvedValue(null)
   })
 
   it('throws if not authenticated', async () => {
@@ -356,6 +393,11 @@ describe('leaveSession', () => {
         }),
       })
     )
+  })
+
+  it('cleans up queue entry and votes', async () => {
+    await leaveSession(MOCK_SESSION_ID)
+    expect(prisma.audienceQueue.deleteMany).toHaveBeenCalled()
   })
 })
 

--- a/__tests__/team.test.ts
+++ b/__tests__/team.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SessionType } from '@/lib/generated/prisma'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+    },
+    teamAssignment: {
+      upsert: vi.fn(),
+      findMany: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import {
+  assignTeam,
+  getTeamAssignments,
+  removeFromTeam,
+} from '@/lib/actions/team'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+const MOCK_TARGET_USER_ID = 'target-user-uuid'
+
+// Helper to set up auth mock
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── assignTeam ──
+describe('assignTeam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+      type: SessionType.TEAM,
+    })
+    ;(prisma.teamAssignment.upsert as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Session not found"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    ).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Not authorized"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user',
+      moderator_id: null,
+      type: SessionType.TEAM,
+    })
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    ).rejects.toThrow('Not authorized')
+  })
+
+  it('throws "Team assignments are only for TEAM format sessions" (mock session.type as ONE_ON_ONE)', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+      type: SessionType.ONE_ON_ONE,
+    })
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    ).rejects.toThrow('Team assignments are only for TEAM format sessions')
+  })
+
+  it('throws "Team must be \'proponent\' or \'opponent\'" with invalid team name', async () => {
+    await expect(
+      assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'invalid-team')
+    ).rejects.toThrow("Team must be 'proponent' or 'opponent'")
+  })
+
+  it('calls prisma.teamAssignment.upsert on success', async () => {
+    await assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'proponent')
+    expect(prisma.teamAssignment.upsert).toHaveBeenCalledWith({
+      where: {
+        session_id_user_id: {
+          session_id: MOCK_SESSION_ID,
+          user_id: MOCK_TARGET_USER_ID,
+        },
+      },
+      create: {
+        session_id: MOCK_SESSION_ID,
+        user_id: MOCK_TARGET_USER_ID,
+        team: 'proponent',
+      },
+      update: { team: 'proponent' },
+    })
+  })
+
+  it('allows moderator to assign team', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: 'other-user',
+      moderator_id: MOCK_USER_ID,
+      type: SessionType.TEAM,
+    })
+    await assignTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, 'opponent')
+    expect(prisma.teamAssignment.upsert).toHaveBeenCalled()
+  })
+})
+
+// ── getTeamAssignments ──
+describe('getTeamAssignments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(prisma.teamAssignment.findMany as any).mockResolvedValue([])
+  })
+
+  it('calls prisma.teamAssignment.findMany with user include', async () => {
+    await getTeamAssignments(MOCK_SESSION_ID)
+    expect(prisma.teamAssignment.findMany).toHaveBeenCalledWith({
+      where: { session_id: MOCK_SESSION_ID },
+      include: {
+        user: { select: { id: true, username: true, realname: true } },
+      },
+      orderBy: { assigned_at: 'asc' },
+    })
+  })
+})
+
+// ── removeFromTeam ──
+describe('removeFromTeam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      host_id: MOCK_USER_ID,
+      moderator_id: null,
+    })
+    ;(prisma.teamAssignment.delete as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      removeFromTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('calls prisma.teamAssignment.delete with correct key', async () => {
+    await removeFromTeam(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+    expect(prisma.teamAssignment.delete).toHaveBeenCalledWith({
+      where: {
+        session_id_user_id: {
+          session_id: MOCK_SESSION_ID,
+          user_id: MOCK_TARGET_USER_ID,
+        },
+      },
+    })
+  })
+})

--- a/__tests__/transcript.test.ts
+++ b/__tests__/transcript.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    participatesIn: {
+      findUnique: vi.fn(),
+    },
+    transcript: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import {
+  createTranscriptSegment,
+  getTranscriptBySession,
+} from '@/lib/actions/transcript'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+
+// Helper to set up auth mock
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── createTranscriptSegment ──
+describe('createTranscriptSegment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.transcript.create as any).mockResolvedValue({
+      id: 'transcript-id',
+    })
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000)
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Not a participant" when no participation', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(
+      createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000)
+    ).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('throws "Not a participant" when left_at is set', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(
+      createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000)
+    ).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('calls prisma.transcript.create with correct data on success', async () => {
+    await createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000, 5, 0.95)
+    expect(prisma.transcript.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        speaker_id: MOCK_USER_ID,
+        content: 'Test content',
+        timestamp: 1000,
+        duration: 5,
+        confidence: 0.95,
+      },
+    })
+  })
+
+  it('calls prisma.transcript.create with null for optional duration/confidence', async () => {
+    await createTranscriptSegment(MOCK_SESSION_ID, 'Test content', 1000)
+    expect(prisma.transcript.create).toHaveBeenCalledWith({
+      data: {
+        session_id: MOCK_SESSION_ID,
+        speaker_id: MOCK_USER_ID,
+        content: 'Test content',
+        timestamp: 1000,
+        duration: null,
+        confidence: null,
+      },
+    })
+  })
+})
+
+// ── getTranscriptBySession ──
+describe('getTranscriptBySession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.transcript.findMany as any).mockResolvedValue([])
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(getTranscriptBySession(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Not a participant"', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(getTranscriptBySession(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('calls prisma.transcript.findMany ordered by timestamp asc, with speaker include', async () => {
+    await getTranscriptBySession(MOCK_SESSION_ID)
+    expect(prisma.transcript.findMany).toHaveBeenCalledWith({
+      where: { session_id: MOCK_SESSION_ID },
+      orderBy: { timestamp: 'asc' },
+      include: {
+        speaker: { select: { id: true, username: true, realname: true } },
+      },
+    })
+  })
+})

--- a/__tests__/user-preferences.test.ts
+++ b/__tests__/user-preferences.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import { getUserPreferences, updateUserPreferences } from '@/lib/actions/user'
+
+function mockAuth(user: { id: string } | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+      }),
+    },
+  })
+}
+
+const MOCK_USER_ID = 'user-uuid-1234'
+
+describe('getUserPreferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(getUserPreferences()).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns user preferences when authenticated', async () => {
+    const mockPreferences = {
+      username: 'testuser',
+      email: 'test@example.com',
+      realname: 'Test User',
+      bio: 'Test bio',
+      notify_invitations: true,
+      notify_messages: true,
+      notify_weekly_digest: false,
+      profile_visibility: 'public',
+      show_online_status: true,
+      allow_direct_messages: true,
+      theme: 'dark',
+      font_size: 'medium',
+      animations_enabled: true,
+      language: 'en',
+      timezone: 'America/Toronto',
+      date_format: 'YYYY-MM-DD',
+    }
+
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.findUnique as any).mockResolvedValue(mockPreferences)
+
+    const result = await getUserPreferences()
+
+    expect(result).toEqual(mockPreferences)
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: MOCK_USER_ID },
+      select: {
+        username: true,
+        email: true,
+        realname: true,
+        bio: true,
+        notify_invitations: true,
+        notify_messages: true,
+        notify_weekly_digest: true,
+        profile_visibility: true,
+        show_online_status: true,
+        allow_direct_messages: true,
+        theme: true,
+        font_size: true,
+        animations_enabled: true,
+        language: true,
+        timezone: true,
+        date_format: true,
+      },
+    })
+  })
+})
+
+describe('updateUserPreferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(updateUserPreferences({ bio: 'test' })).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws when invalid theme value', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    await expect(updateUserPreferences({ theme: 'invalid' })).rejects.toThrow(
+      "Theme must be 'dark', 'light', or 'system'"
+    )
+  })
+
+  it('throws when invalid font_size', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    await expect(updateUserPreferences({ font_size: 'huge' })).rejects.toThrow(
+      "Font size must be 'small', 'medium', or 'large'"
+    )
+  })
+
+  it('throws when invalid profile_visibility', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    await expect(updateUserPreferences({ profile_visibility: 'hidden' })).rejects.toThrow(
+      "Profile visibility must be 'public' or 'private'"
+    )
+  })
+
+  it('updates successfully with valid partial data', async () => {
+    const updateData = {
+      bio: 'Updated bio',
+      notify_invitations: false,
+    }
+    const mockUpdatedUser = {
+      id: MOCK_USER_ID,
+      username: 'testuser',
+      ...updateData,
+    }
+
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue(mockUpdatedUser)
+
+    const result = await updateUserPreferences(updateData)
+
+    expect(result).toEqual(mockUpdatedUser)
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: MOCK_USER_ID },
+      data: updateData,
+    })
+  })
+
+  it('updates with all fields', async () => {
+    const updateData = {
+      bio: 'Full update bio',
+      notify_invitations: true,
+      notify_messages: false,
+      notify_weekly_digest: true,
+      profile_visibility: 'private',
+      show_online_status: false,
+      allow_direct_messages: true,
+      theme: 'light',
+      font_size: 'large',
+      animations_enabled: false,
+      language: 'fr',
+      timezone: 'Europe/Paris',
+      date_format: 'DD/MM/YYYY',
+    }
+    const mockUpdatedUser = {
+      id: MOCK_USER_ID,
+      username: 'testuser',
+      email: 'test@example.com',
+      ...updateData,
+    }
+
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue(mockUpdatedUser)
+
+    const result = await updateUserPreferences(updateData)
+
+    expect(result).toEqual(mockUpdatedUser)
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: MOCK_USER_ID },
+      data: updateData,
+    })
+  })
+
+  it('accepts valid theme values', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue({ id: MOCK_USER_ID })
+
+    await expect(updateUserPreferences({ theme: 'dark' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ theme: 'light' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ theme: 'system' })).resolves.not.toThrow()
+  })
+
+  it('accepts valid font_size values', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue({ id: MOCK_USER_ID })
+
+    await expect(updateUserPreferences({ font_size: 'small' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ font_size: 'medium' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ font_size: 'large' })).resolves.not.toThrow()
+  })
+
+  it('accepts valid profile_visibility values', async () => {
+    mockAuth({ id: MOCK_USER_ID })
+    ;(prisma.user.update as any).mockResolvedValue({ id: MOCK_USER_ID })
+
+    await expect(updateUserPreferences({ profile_visibility: 'public' })).resolves.not.toThrow()
+    await expect(updateUserPreferences({ profile_visibility: 'private' })).resolves.not.toThrow()
+  })
+})

--- a/__tests__/vote.test.ts
+++ b/__tests__/vote.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SessionStatus, VoteType } from '@/lib/generated/prisma'
+
+// ── Mocks ──
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+    },
+    participatesIn: {
+      findUnique: vi.fn(),
+    },
+    vote: {
+      upsert: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+import { castVote, retractVote, getVoteCounts } from '@/lib/actions/vote'
+
+const MOCK_USER_ID = 'user-uuid-1234'
+const MOCK_SESSION_ID = 'session-cuid-5678'
+const MOCK_TARGET_USER_ID = 'target-user-uuid'
+
+// Helper to set up auth mock
+function mockAuth(userId: string | null) {
+  ;(createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  })
+}
+
+// ── castVote ──
+describe('castVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      status: SessionStatus.LIVE,
+    })
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: null,
+    })
+    ;(prisma.vote.upsert as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws "Cannot vote for yourself"', async () => {
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Cannot vote for yourself')
+  })
+
+  it('throws "Session not found"', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Session not found')
+  })
+
+  it('throws "Session is not live" when status is WAITING', async () => {
+    ;(prisma.session.findUnique as any).mockResolvedValue({
+      id: MOCK_SESSION_ID,
+      status: SessionStatus.WAITING,
+    })
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Session is not live')
+  })
+
+  it('throws "Not a participant" when no participation record', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('throws "Not a participant" when left_at is set', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      left_at: new Date(),
+    })
+    await expect(
+      castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('calls prisma.vote.upsert with correct compound key on success', async () => {
+    await castVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    expect(prisma.vote.upsert).toHaveBeenCalledWith({
+      where: {
+        session_id_voter_id_target_user_id_vote_type: {
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+          target_user_id: MOCK_TARGET_USER_ID,
+          vote_type: VoteType.KICK,
+        },
+      },
+      create: {
+        session_id: MOCK_SESSION_ID,
+        voter_id: MOCK_USER_ID,
+        target_user_id: MOCK_TARGET_USER_ID,
+        vote_type: VoteType.KICK,
+      },
+      update: {},
+    })
+  })
+})
+
+// ── retractVote ──
+describe('retractVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+    ;(prisma.vote.delete as any).mockResolvedValue({})
+  })
+
+  it('throws when not authenticated', async () => {
+    mockAuth(null)
+    await expect(
+      retractVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('calls prisma.vote.delete with correct compound key', async () => {
+    await retractVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID, VoteType.KICK)
+    expect(prisma.vote.delete).toHaveBeenCalledWith({
+      where: {
+        session_id_voter_id_target_user_id_vote_type: {
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+          target_user_id: MOCK_TARGET_USER_ID,
+          vote_type: VoteType.KICK,
+        },
+      },
+    })
+  })
+})
+
+// ── getVoteCounts ──
+describe('getVoteCounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(prisma.vote.count as any).mockResolvedValue(5)
+  })
+
+  it('calls prisma.vote.count and returns {count}', async () => {
+    const result = await getVoteCounts(
+      MOCK_SESSION_ID,
+      MOCK_TARGET_USER_ID,
+      VoteType.KICK
+    )
+    expect(prisma.vote.count).toHaveBeenCalledWith({
+      where: {
+        session_id: MOCK_SESSION_ID,
+        target_user_id: MOCK_TARGET_USER_ID,
+        vote_type: VoteType.KICK,
+      },
+    })
+    expect(result).toEqual({ count: 5 })
+  })
+})

--- a/app/api/leave-session/route.ts
+++ b/app/api/leave-session/route.ts
@@ -1,5 +1,7 @@
 import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
+import { SessionRole } from "@/lib/generated/prisma"
+import { doPromoteFromQueue, cleanupUserVotes } from "@/lib/actions/queue"
 import { NextRequest, NextResponse } from "next/server"
 
 export async function POST(req: NextRequest) {
@@ -10,14 +12,54 @@ export async function POST(req: NextRequest) {
   const { sessionId } = await req.json()
   if (!sessionId) return NextResponse.json({ error: "sessionId required" }, { status: 400 })
 
-  await prisma.participatesIn.update({
+  const participation = await prisma.participatesIn.findUnique({
     where: {
-      user_id_session_id: {
-        user_id: user.id,
-        session_id: sessionId,
-      },
+      user_id_session_id: { user_id: user.id, session_id: sessionId },
     },
-    data: { left_at: new Date() },
+  })
+  if (!participation) return NextResponse.json({ error: "Not a participant" }, { status: 400 })
+
+  const wasDebater = participation.session_role === SessionRole.DEBATER
+
+  await prisma.$transaction(async (tx) => {
+    await tx.participatesIn.update({
+      where: {
+        user_id_session_id: { user_id: user.id, session_id: sessionId },
+      },
+      data: { left_at: new Date() },
+    })
+
+    // Remove from queue
+    await tx.audienceQueue.deleteMany({
+      where: { session_id: sessionId, user_id: user.id },
+    })
+
+    // Clean up votes
+    await cleanupUserVotes(tx, sessionId, user.id)
+
+    // If was debater, remove from debater_order and auto-promote
+    if (wasDebater) {
+      const state = await tx.debateState.findUnique({
+        where: { session_id: sessionId },
+      })
+      if (state) {
+        const order = state.debater_order as { userId: string; displayName: string }[]
+        const removedIndex = order.findIndex((d) => d.userId === user.id)
+        const newOrder = order.filter((d) => d.userId !== user.id)
+        let newIndex = state.current_index
+        if (removedIndex < state.current_index) {
+          newIndex = Math.max(0, newIndex - 1)
+        } else if (removedIndex === state.current_index && newOrder.length > 0) {
+          newIndex = newIndex % newOrder.length
+        }
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: { debater_order: newOrder, current_index: newIndex },
+        })
+      }
+
+      await doPromoteFromQueue(tx, sessionId)
+    }
   })
 
   return NextResponse.json({ success: true })

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -26,6 +26,7 @@ export default function CreateRoom() {
   const [debaterCapacityOpponent, setDebaterCapacityOpponent] = useState('1')
   const [debaterCapacityPanel, setDebaterCapacityPanel] = useState('5')
   const [audienceCapacity, setAudienceCapacity] = useState('10')
+  const [kickThreshold, setKickThreshold] = useState('50')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [previewCode, setPreviewCode] = useState('ARG-····')
@@ -82,6 +83,7 @@ export default function CreateRoom() {
         debaterCapacityPanel: selectedFormat === 'panel' ? parseInt(debaterCapacityPanel) : null,
         audienceCapacity: parseInt(audienceCapacity),
         turnLength: parseInt(turnLength),
+        kickThreshold: parseInt(kickThreshold),
       })
       // createSession redirects on success, so we only reach here on error
     } catch (err) {
@@ -270,13 +272,20 @@ export default function CreateRoom() {
                 <div>
                   <label className="block text-sm font-bold debate-mono mb-2 text-white">
                     <Settings className="w-4 h-4 inline mr-2" />
-                    MODERATION
+                    KICK VOTE THRESHOLD
                   </label>
-                  <select className="debate-input w-full">
-                    <option>Auto-moderate</option>
-                    <option>Manual moderation</option>
-                    <option>No moderation</option>
+                  <select
+                    value={kickThreshold}
+                    onChange={(e) => setKickThreshold(e.target.value)}
+                    className="debate-input w-full"
+                  >
+                    <option value="25">25% of audience</option>
+                    <option value="50">50% of audience</option>
+                    <option value="75">75% of audience</option>
                   </select>
+                  <p className="text-xs debate-mono text-gray-500 mt-1">
+                    % of audience votes needed to kick a speaker
+                  </p>
                 </div>
               </div>
             </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import AuthSync from "@/components/AuthSync";
+import { Toaster } from "@/components/ui/toaster";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -16,6 +17,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="antialiased">
         <AuthSync />
+        <Toaster />
         {children}
       </body>
     </html>

--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import {
   Users,
@@ -18,16 +18,23 @@ import {
   VideoOff,
   Settings,
   Loader2,
-  Swords
+  Swords,
+  Hand,
+  ArrowUp,
+  ThumbsDown,
+  Crown,
 } from 'lucide-react'
 import { useMediasoup } from '@/hooks/useMediasoup'
 import { useDebateChannel } from '@/hooks/useDebateChannel'
+import { useQueueChannel } from '@/hooks/useQueueChannel'
+import { useKickVoteChannel } from '@/hooks/useKickVoteChannel'
 import { createClient } from '@/lib/supabase/client'
 import VideoPanel from '@/components/VideoPanel'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { userStub, getInitials, formatTime } from '@/lib/utils'
 import { leaveSession, updateSessionStatus, joinSession, joinSessionAsDebater, kickParticipant, assignModerator } from '@/lib/actions/session'
+import { promoteFromQueue } from '@/lib/actions/queue'
 import { useRouter } from 'next/navigation'
 import { SessionRole, SessionStatus, SessionType } from '@/lib/generated/prisma'
 
@@ -42,6 +49,7 @@ interface SessionData {
   debaterCapacityOpponent: number | null
   debaterCapacityPanel: number | null
   audienceCapacity: number
+  kickThreshold: number
   host: { id: string; username: string; realname: string | null }
   moderator: { id: string; username: string; realname: string | null } | null
   participatesIns: {
@@ -92,6 +100,27 @@ export default function RoomClient({
   const debate = useDebateChannel({
     sessionId: session.id,
     userId: currentUserId,
+  })
+
+  const queueChannel = useQueueChannel({
+    sessionId: session.id,
+    userId: currentUserId,
+  })
+
+  const isAudience = currentRole === SessionRole.AUDIENCE
+  const isExpertVsCrowd = session.type === SessionType.EXPERT_VS_CROWD
+
+  // Compute debater IDs for kick-vote tracking (exclude host)
+  const debaterIdsForVote = useMemo(() => {
+    return debate.debaters
+      .filter((d) => d.userId !== session.host.id)
+      .map((d) => d.userId)
+  }, [debate.debaters, session.host.id])
+
+  const kickVoteChannel = useKickVoteChannel({
+    sessionId: session.id,
+    userId: currentUserId,
+    debaterIds: debaterIdsForVote,
   })
 
   // Refresh page when participants change (via Supabase Realtime)
@@ -205,6 +234,9 @@ export default function RoomClient({
   async function handleLeave() {
     disconnectSfu()
     try {
+      if (queueChannel.isInQueue) {
+        await queueChannel.leaveQueue()
+      }
       await leaveSession(session.id)
       router.push('/browse')
     } catch (err) {
@@ -239,15 +271,17 @@ export default function RoomClient({
 
   async function handleStartSession() {
     try {
-      await updateSessionStatus(session.id, 'LIVE')
-
       // Build debater list from participants with HOST or DEBATER role
       const debaterList = debaters.map((p) => ({
         userId: p.user.id,
         displayName: p.user.realname || p.user.username,
       }))
 
-      if (debaterList.length >= 2) {
+      if (isExpertVsCrowd) {
+        // Expert vs Crowd: pass only the expert (host), backend auto-promotes from queue
+        const expert = debaterList.find((d) => d.userId === session.host.id) ?? debaterList[0]
+        await debate.startDebate([expert], session.turnLength)
+      } else if (debaterList.length >= 2) {
         await debate.startDebate(debaterList, session.turnLength)
       }
 
@@ -314,8 +348,9 @@ export default function RoomClient({
   }
 
   // Check if debate can start
-  const canStartDebate =
-    session.type === SessionType.ONE_ON_ONE
+  const canStartDebate = isExpertVsCrowd
+    ? debaters.length >= 1 && queueChannel.queue.length >= 1
+    : session.type === SessionType.ONE_ON_ONE
       ? debaters.length === 2
       : debaters.length >= 2
 
@@ -428,38 +463,95 @@ export default function RoomClient({
                     ) : (
                       <div className="flex flex-col space-y-4">
                         {/* Debater display */}
-                        {isDebateLive && debate.debaters.length === 2 ? (
+                        {isDebateLive && debate.debaters.length >= 2 ? (
                           <div className="flex items-center justify-center gap-6">
                             {debate.debaters.map((d, i) => {
                               const isSpeaking = debate.currentSpeaker?.userId === d.userId
+                              const isHostDebater = d.userId === session.host.id
+                              const voteState = kickVoteChannel.voteStates[d.userId]
+                              const canVoteToKick = isAudience && !isHostDebater
                               return (
                                 <div
                                   key={d.userId}
-                                  className={`flex items-center space-x-3 p-3 border-2 transition-all ${
+                                  className={`flex flex-col p-3 border-2 transition-all ${
                                     isSpeaking
                                       ? 'border-yellow-400 bg-yellow-400/10 shadow-[0_0_15px_rgba(250,204,21,0.3)]'
                                       : 'border-white/20 opacity-60'
                                   }`}
                                 >
-                                  <div
-                                    className={`w-14 h-14 border-2 border-black flex items-center justify-center text-white font-bold text-lg ${
-                                      i === 0
-                                        ? 'bg-gradient-to-br from-red-600 to-red-800'
-                                        : 'bg-gradient-to-br from-blue-600 to-blue-800'
-                                    }`}
-                                  >
-                                    {getInitials(d.displayName)}
+                                  <div className="flex items-center space-x-3">
+                                    <div
+                                      className={`w-14 h-14 border-2 border-black flex items-center justify-center text-white font-bold text-lg ${
+                                        i === 0
+                                          ? 'bg-gradient-to-br from-red-600 to-red-800'
+                                          : 'bg-gradient-to-br from-blue-600 to-blue-800'
+                                      }`}
+                                    >
+                                      {getInitials(d.displayName)}
+                                    </div>
+                                    <div>
+                                      <div className="flex items-center gap-2">
+                                        <h3 className="text-lg font-bold debate-title text-white">
+                                          {d.displayName}
+                                        </h3>
+                                        {isExpertVsCrowd && i === 0 && (
+                                          <span className="debate-badge bg-purple-600 text-white text-xs flex items-center gap-1">
+                                            <Crown className="w-3 h-3" /> EXPERT
+                                          </span>
+                                        )}
+                                        {isExpertVsCrowd && i === 1 && (
+                                          <span className="debate-badge bg-orange-600 text-white text-xs">
+                                            CHALLENGER
+                                          </span>
+                                        )}
+                                      </div>
+                                      {isSpeaking && (
+                                        <span className="debate-badge bg-yellow-400 text-black text-xs">
+                                          SPEAKING
+                                        </span>
+                                      )}
+                                    </div>
                                   </div>
-                                  <div>
-                                    <h3 className="text-lg font-bold debate-title text-white">
-                                      {d.displayName}
-                                    </h3>
-                                    {isSpeaking && (
-                                      <span className="debate-badge bg-yellow-400 text-black text-xs">
-                                        SPEAKING
-                                      </span>
-                                    )}
-                                  </div>
+                                  {/* Kick vote UI */}
+                                  {canVoteToKick && voteState && (
+                                    <div className="mt-2 pt-2 border-t border-white/10">
+                                      <div className="flex items-center justify-between mb-1">
+                                        <span className="text-xs debate-mono text-gray-400">
+                                          {voteState.voteCount} / {voteState.requiredVotes} votes to kick
+                                        </span>
+                                      </div>
+                                      <div className="w-full bg-gray-700 h-1.5 mb-2">
+                                        <div
+                                          className="bg-red-500 h-1.5 transition-all"
+                                          style={{
+                                            width: `${Math.min(100, voteState.requiredVotes > 0 ? (voteState.voteCount / voteState.requiredVotes) * 100 : 0)}%`,
+                                          }}
+                                        />
+                                      </div>
+                                      <Button
+                                        variant="outline"
+                                        size="sm"
+                                        className={`debate-button w-full text-xs ${
+                                          voteState.userHasVoted ? 'border-red-500 text-red-400' : ''
+                                        }`}
+                                        onClick={async () => {
+                                          try {
+                                            if (voteState.userHasVoted) {
+                                              await kickVoteChannel.removeVote(d.userId)
+                                            } else {
+                                              await kickVoteChannel.castVote(d.userId)
+                                            }
+                                            router.refresh()
+                                          } catch (err) {
+                                            console.error('Vote failed:', err)
+                                          }
+                                        }}
+                                      >
+                                        <ThumbsDown className="w-3 h-3 mr-1" />
+                                        {voteState.userHasVoted ? 'REMOVE VOTE' : 'VOTE TO KICK'}
+                                      </Button>
+                                    </div>
+                                  )}
                                 </div>
                               )
                             })}
@@ -562,7 +654,121 @@ export default function RoomClient({
                 </Card>
               </div>
 
-              {/* Audience Queue */}
+              {/* Speaker Queue */}
+              <div>
+                <Card className="debate-card border-2">
+                  <CardHeader className="border-b-2 border-white/20">
+                    <CardTitle className="debate-title flex items-center justify-between text-white">
+                      <div className="flex items-center">
+                        <Hand className="w-4 h-4 mr-2" />
+                        SPEAKER QUEUE ({queueChannel.queue.length})
+                      </div>
+                      {queueChannel.queue.length > 0 && isExpertVsCrowd && (
+                        <span className="text-xs debate-mono text-orange-400 font-normal">
+                          NEXT UP: {queueChannel.queue[0]?.displayName}
+                        </span>
+                      )}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="p-4">
+                    {/* Queue actions for audience members */}
+                    {isAudience && (
+                      <div className="mb-4">
+                        {queueChannel.isInQueue ? (
+                          <div className="space-y-2">
+                            <div className="text-center p-2 border-2 border-yellow-500/30 bg-yellow-500/5">
+                              <p className="text-yellow-400 debate-mono text-sm font-bold">
+                                You are #{queueChannel.myPosition} in queue
+                              </p>
+                            </div>
+                            <Button
+                              variant="outline"
+                              className="debate-button w-full text-xs"
+                              onClick={async () => {
+                                try {
+                                  await queueChannel.leaveQueue()
+                                } catch (err) {
+                                  console.error('Failed to leave queue:', err)
+                                }
+                              }}
+                            >
+                              LEAVE QUEUE
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            className="debate-button bg-yellow-500 text-black border-yellow-600 w-full font-bold"
+                            onClick={async () => {
+                              try {
+                                await queueChannel.joinQueue()
+                              } catch (err) {
+                                console.error('Failed to join queue:', err)
+                              }
+                            }}
+                          >
+                            <Hand className="w-4 h-4 mr-2" />
+                            {isExpertVsCrowd ? 'JOIN SPEAKER QUEUE' : 'JOIN QUEUE'}
+                          </Button>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Moderator promote button */}
+                    {isModeratorOrCreator && queueChannel.queue.length > 0 && (
+                      <div className="mb-4">
+                        <Button
+                          variant="outline"
+                          className="debate-button w-full text-xs"
+                          onClick={async () => {
+                            try {
+                              await promoteFromQueue(session.id)
+                              router.refresh()
+                            } catch (err) {
+                              console.error('Failed to promote:', err)
+                            }
+                          }}
+                        >
+                          <ArrowUp className="w-3 h-3 mr-1" />
+                          PROMOTE NEXT: {queueChannel.queue[0]?.displayName}
+                        </Button>
+                      </div>
+                    )}
+
+                    {/* Queue list */}
+                    {queueChannel.queue.length === 0 ? (
+                      <p className="text-gray-500 debate-mono text-sm text-center py-2">Queue is empty</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {queueChannel.queue.map((entry) => (
+                          <div
+                            key={entry.id}
+                            className={`flex items-center gap-3 p-2 border-2 ${
+                              entry.userId === currentUserId
+                                ? 'border-yellow-500/50 bg-yellow-500/5'
+                                : 'border-white/10'
+                            }`}
+                          >
+                            <span className="text-xs debate-mono text-gray-500 w-6 text-right">
+                              #{entry.rank}
+                            </span>
+                            <div className="w-8 h-8 bg-gray-600 text-white font-bold text-xs flex items-center justify-center border border-black">
+                              {getInitials(entry.displayName)}
+                            </div>
+                            <span className="text-sm debate-mono text-white truncate flex-1">
+                              {entry.displayName}
+                            </span>
+                            {entry.rank === 1 && isExpertVsCrowd && (
+                              <span className="debate-badge bg-orange-600 text-white text-[10px]">NEXT</span>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+
+              {/* Audience (watching, not in queue) */}
               <div>
                 <Card className="debate-card border-2">
                   <CardHeader className="border-b-2 border-white/20">
@@ -572,7 +778,8 @@ export default function RoomClient({
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="p-4">
-                    {canUpgradeToDebater && (
+                    {/* Direct debater upgrade (non-Expert vs Crowd, non-queue path) */}
+                    {canUpgradeToDebater && !isExpertVsCrowd && (
                       <div className="mb-4">
                         {session.type === SessionType.PANEL ? (
                           <Button
@@ -649,23 +856,34 @@ export default function RoomClient({
                       <p className="text-gray-500 debate-mono text-sm text-center py-4">No audience members yet</p>
                     ) : (
                       <div className="grid grid-cols-4 gap-3">
-                        {audience.map((person, index) => (
-                          <motion.div
-                            key={person.userId}
-                            initial={{ opacity: 0, y: 20 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            transition={{ delay: index * 0.1 }}
-                            className="text-center p-3 border-2 border-white/20 hover:border-red-600 transition-colors cursor-pointer"
-                          >
-                            <div className="w-12 h-12 bg-gray-600 text-white font-bold text-sm flex items-center justify-center mx-auto mb-2 border-2 border-black">
-                              {getInitials(displayName(person.user))}
-                            </div>
-                            <p className="text-xs debate-mono font-medium truncate text-white">
-                              {displayName(person.user)}
-                            </p>
-                            <p className="text-xs debate-mono text-gray-400">#{index + 1}</p>
-                          </motion.div>
-                        ))}
+                        {audience.map((person, index) => {
+                          const queueEntry = queueChannel.queue.find((q) => q.userId === person.userId)
+                          return (
+                            <motion.div
+                              key={person.userId}
+                              initial={{ opacity: 0, y: 20 }}
+                              animate={{ opacity: 1, y: 0 }}
+                              transition={{ delay: index * 0.05 }}
+                              className={`text-center p-3 border-2 transition-colors ${
+                                queueEntry
+                                  ? 'border-yellow-500/40 bg-yellow-500/5'
+                                  : 'border-white/20 hover:border-red-600'
+                              }`}
+                            >
+                              <div className="w-12 h-12 bg-gray-600 text-white font-bold text-sm flex items-center justify-center mx-auto mb-2 border-2 border-black">
+                                {getInitials(displayName(person.user))}
+                              </div>
+                              <p className="text-xs debate-mono font-medium truncate text-white">
+                                {displayName(person.user)}
+                              </p>
+                              {queueEntry ? (
+                                <p className="text-xs debate-mono text-yellow-400">Queue #{queueEntry.rank}</p>
+                              ) : (
+                                <p className="text-xs debate-mono text-gray-400">watching</p>
+                              )}
+                            </motion.div>
+                          )
+                        })}
                       </div>
                     )}
                   </CardContent>

--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { motion } from 'framer-motion'
 import {
   Users,
@@ -13,6 +13,7 @@ import {
   Pause,
   Play,
   SkipForward,
+  Timer,
   Volume2,
   Video,
   VideoOff,
@@ -23,7 +24,9 @@ import {
   ArrowUp,
   ThumbsDown,
   Crown,
+  RefreshCw,
 } from 'lucide-react'
+import { toast } from 'sonner'
 import { useMediasoup } from '@/hooks/useMediasoup'
 import { useDebateChannel } from '@/hooks/useDebateChannel'
 import { useQueueChannel } from '@/hooks/useQueueChannel'
@@ -32,9 +35,11 @@ import { createClient } from '@/lib/supabase/client'
 import VideoPanel from '@/components/VideoPanel'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { userStub, getInitials, formatTime } from '@/lib/utils'
-import { leaveSession, updateSessionStatus, joinSession, joinSessionAsDebater, kickParticipant, assignModerator } from '@/lib/actions/session'
+import { leaveSession, updateSessionStatus, joinSession, joinSessionAsDebater, kickParticipant, assignModerator, promoteToDebater } from '@/lib/actions/session'
 import { promoteFromQueue } from '@/lib/actions/queue'
+import { extendTurn } from '@/lib/actions/debate'
 import { useRouter } from 'next/navigation'
 import { SessionRole, SessionStatus, SessionType } from '@/lib/generated/prisma'
 
@@ -71,10 +76,25 @@ export default function RoomClient({
   currentUsername: string
 }) {
   const router = useRouter()
-  const [isPaused, setIsPaused] = useState(session.status === SessionStatus.PAUSED)
-  const [timeRemaining, setTimeRemaining] = useState(session.turnLength)
   const [isJoining, setIsJoining] = useState(false)
   const [showDebaterOptions, setShowDebaterOptions] = useState(false)
+
+  // Loading states for async operations
+  const [isStarting, setIsStarting] = useState(false)
+  const [isPauseToggling, setIsPauseToggling] = useState(false)
+  const [isEnding, setIsEnding] = useState(false)
+  const [isAdvancingTurn, setIsAdvancingTurn] = useState(false)
+  const [isExtendingTurn, setIsExtendingTurn] = useState(false)
+  const [isAssigningModerator, setIsAssigningModerator] = useState<string | null>(null)
+  const [isKicking, setIsKicking] = useState<string | null>(null)
+  const [isPromoting, setIsPromoting] = useState<string | null>(null)
+
+  // Confirmation dialog state
+  const [confirmDialog, setConfirmDialog] = useState<{
+    type: 'kick' | 'end' | 'moderator' | 'promote'
+    targetUserId?: string
+    targetName?: string
+  } | null>(null)
 
   const isModeratorOrCreator = currentRole === SessionRole.MODERATOR || currentRole === SessionRole.HOST
   const isHost = currentRole === SessionRole.HOST
@@ -90,6 +110,7 @@ export default function RoomClient({
     toggleMute,
     toggleVideo,
     disconnect: disconnectSfu,
+    reconnect: reconnectSfu,
   } = useMediasoup({
     sfuUrl: process.env.NEXT_PUBLIC_SFU_URL,
     roomId: session.code,
@@ -123,6 +144,18 @@ export default function RoomClient({
     debaterIds: debaterIdsForVote,
   })
 
+  // Derive isPaused from debate channel (authoritative source via Supabase Realtime)
+  const isPaused = debate.isPaused || session.status === SessionStatus.PAUSED
+
+  // Toast on video connection error
+  const prevConnectionState = useRef(connectionState)
+  useEffect(() => {
+    if (prevConnectionState.current !== 'error' && connectionState === 'error') {
+      toast.error('Video connection failed')
+    }
+    prevConnectionState.current = connectionState
+  }, [connectionState])
+
   // Refresh page when participants change (via Supabase Realtime)
   useEffect(() => {
     const supabase = createClient()
@@ -155,6 +188,7 @@ export default function RoomClient({
         }
       } catch (err) {
         console.error('Auto-join failed:', err)
+        toast.error('Failed to join room automatically')
       }
     }
     autoJoin()
@@ -177,9 +211,6 @@ export default function RoomClient({
   }, [isParticipant, session.id])
 
   // Filter participants by role
-  const moderators = session.participatesIns.filter(
-    (p) => p.sessionRole === SessionRole.MODERATOR || p.sessionRole === SessionRole.HOST
-  )
   const debaters = session.participatesIns.filter(
     (p) => p.sessionRole === SessionRole.DEBATER || p.sessionRole === SessionRole.HOST
   )
@@ -205,12 +236,12 @@ export default function RoomClient({
     currentRole === SessionRole.AUDIENCE && canJoinAsDebater
 
   // Check proponent/opponent specific availability
-  const proponentsFull = 
-    session.type !== SessionType.PANEL && 
+  const proponentsFull =
+    session.type !== SessionType.PANEL &&
     (session.debaterCapacityProponent ?? 0) > 0 &&
     debaters.filter(d => d.sessionRole === SessionRole.DEBATER).length >= (session.debaterCapacityProponent ?? 0)
-  
-  const opponentsFull = 
+
+  const opponentsFull =
     session.type !== SessionType.PANEL &&
     (session.debaterCapacityOpponent ?? 0) > 0 &&
     debaters.filter(d => d.sessionRole === SessionRole.DEBATER).length >= totalDebaterCapacity
@@ -221,15 +252,7 @@ export default function RoomClient({
       ? debate.timeRemaining
       : session.turnLength
 
-  // Timer countdown
-  useEffect(() => {
-    if (!isPaused && session.status === SessionStatus.LIVE) {
-      const interval = setInterval(() => {
-        setTimeRemaining((prev) => (prev > 0 ? prev - 1 : 0))
-      }, 1000)
-      return () => clearInterval(interval)
-    }
-  }, [isPaused, session.status])
+  // --- Handlers with toast + loading ---
 
   async function handleLeave() {
     disconnectSfu()
@@ -238,38 +261,50 @@ export default function RoomClient({
         await queueChannel.leaveQueue()
       }
       await leaveSession(session.id)
-      router.push('/browse')
     } catch (err) {
       console.error('Failed to leave:', err)
-      router.push('/browse')
+      toast.error('Failed to leave session')
     }
+    router.push('/browse')
   }
 
   async function handleTogglePause() {
+    setIsPauseToggling(true)
     try {
       if (isPaused) {
         await debate.resume()
         await updateSessionStatus(session.id, 'LIVE')
+        toast.success('Debate resumed')
       } else {
         await debate.pause()
         await updateSessionStatus(session.id, 'PAUSED')
+        toast.success('Debate paused')
       }
     } catch (err) {
       console.error('Failed to toggle pause:', err)
+      toast.error('Failed to toggle pause')
+    } finally {
+      setIsPauseToggling(false)
     }
   }
 
   async function handleEndSession() {
+    setIsEnding(true)
     try {
       await debate.endDebate()
       await updateSessionStatus(session.id, SessionStatus.ENDED)
+      toast.success('Session ended')
       router.push('/browse')
     } catch (err) {
       console.error('Failed to end session:', err)
+      toast.error('Failed to end session')
+    } finally {
+      setIsEnding(false)
     }
   }
 
   async function handleStartSession() {
+    setIsStarting(true)
     try {
       // Build debater list from participants with HOST or DEBATER role
       const debaterList = debaters.map((p) => ({
@@ -286,9 +321,13 @@ export default function RoomClient({
       }
 
       await updateSessionStatus(session.id, SessionStatus.LIVE)
+      toast.success('Debate started')
       router.refresh()
     } catch (err) {
       console.error('Failed to start session:', err)
+      toast.error('Failed to start debate')
+    } finally {
+      setIsStarting(false)
     }
   }
 
@@ -296,9 +335,11 @@ export default function RoomClient({
     setIsJoining(true)
     try {
       await joinSessionAsDebater(session.id, isProponent)
+      toast.success('Joined as debater')
       router.refresh()
     } catch (err) {
       console.error('Failed to upgrade to debater:', err)
+      toast.error('Failed to join as debater')
     } finally {
       setIsJoining(false)
       setShowDebaterOptions(false)
@@ -306,28 +347,92 @@ export default function RoomClient({
   }
 
   async function handleAssignModerator(userId: string) {
+    setIsAssigningModerator(userId)
     try {
       await assignModerator(session.id, userId)
+      toast.success('Moderator assigned')
       router.refresh()
     } catch (err) {
       console.error('Failed to assign moderator:', err)
+      toast.error('Failed to assign moderator')
+    } finally {
+      setIsAssigningModerator(null)
     }
   }
 
   async function handleNextTurn() {
+    setIsAdvancingTurn(true)
     try {
       await debate.nextTurn()
+      toast.success('Turn advanced')
     } catch (err) {
       console.error('Failed to advance turn:', err)
+      toast.error('Failed to advance turn')
+    } finally {
+      setIsAdvancingTurn(false)
+    }
+  }
+
+  async function handleExtendTurn() {
+    setIsExtendingTurn(true)
+    try {
+      await extendTurn(session.id, 30)
+      toast.success('Turn extended by 30s')
+    } catch (err) {
+      console.error('Failed to extend turn:', err)
+      toast.error('Failed to extend turn')
+    } finally {
+      setIsExtendingTurn(false)
     }
   }
 
   async function handleKick(userId: string) {
+    setIsKicking(userId)
     try {
       await kickParticipant(session.id, userId)
+      toast.success('Participant removed')
       router.refresh()
     } catch (err) {
       console.error('Failed to kick participant:', err)
+      toast.error('Failed to remove participant')
+    } finally {
+      setIsKicking(null)
+    }
+  }
+
+  async function handlePromote(userId: string) {
+    setIsPromoting(userId)
+    try {
+      await promoteToDebater(session.id, userId)
+      toast.success('Participant promoted to debater')
+      router.refresh()
+    } catch (err) {
+      console.error('Failed to promote participant:', err)
+      toast.error('Failed to promote participant')
+    } finally {
+      setIsPromoting(null)
+    }
+  }
+
+  // Confirmation dialog handler
+  async function handleConfirmAction() {
+    if (!confirmDialog) return
+    const { type, targetUserId } = confirmDialog
+    setConfirmDialog(null)
+
+    switch (type) {
+      case 'kick':
+        if (targetUserId) await handleKick(targetUserId)
+        break
+      case 'end':
+        await handleEndSession()
+        break
+      case 'moderator':
+        if (targetUserId) await handleAssignModerator(targetUserId)
+        break
+      case 'promote':
+        if (targetUserId) await handlePromote(targetUserId)
+        break
     }
   }
 
@@ -360,6 +465,34 @@ export default function RoomClient({
     : displayTime <= 30
     ? 'text-orange-400'
     : 'text-white'
+
+  // Confirm dialog config
+  const confirmDialogConfig = confirmDialog ? {
+    kick: {
+      title: 'KICK PARTICIPANT',
+      description: `Remove ${confirmDialog.targetName} from this session? They can rejoin if the room is still open.`,
+      confirmLabel: 'KICK',
+      variant: 'destructive' as const,
+    },
+    end: {
+      title: 'END SESSION',
+      description: 'End the debate for all participants? This action cannot be undone.',
+      confirmLabel: 'END SESSION',
+      variant: 'destructive' as const,
+    },
+    moderator: {
+      title: 'ASSIGN MODERATOR',
+      description: `Promote ${confirmDialog.targetName} to moderator? The current moderator will be demoted to audience.`,
+      confirmLabel: 'PROMOTE',
+      variant: 'default' as const,
+    },
+    promote: {
+      title: 'PROMOTE TO DEBATER',
+      description: `Promote ${confirmDialog.targetName} from audience to debater?`,
+      confirmLabel: 'PROMOTE',
+      variant: 'default' as const,
+    },
+  }[confirmDialog.type] : null
 
   return (
     <div className="min-h-screen debate-container bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 dark">
@@ -453,9 +586,16 @@ export default function RoomClient({
                             <Button
                               className="debate-button bg-red-600 text-white border-red-700"
                               onClick={handleStartSession}
-                              disabled={!canStartDebate}
+                              disabled={!canStartDebate || isStarting}
                             >
-                              START DEBATE
+                              {isStarting ? (
+                                <>
+                                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                  STARTING...
+                                </>
+                              ) : (
+                                'START DEBATE'
+                              )}
                             </Button>
                           )}
                         </div>
@@ -597,7 +737,16 @@ export default function RoomClient({
                                 <div className="min-h-[250px] bg-gradient-to-br from-gray-900 to-gray-700 rounded-md border-2 border-red-600/50 flex items-center justify-center">
                                   <div className="text-center">
                                     <VideoOff className="w-10 h-10 text-red-400/60 mx-auto mb-2" />
-                                    <p className="text-red-400/60 debate-mono text-sm">VIDEO CONNECTION FAILED</p>
+                                    <p className="text-red-400/60 debate-mono text-sm mb-3">VIDEO CONNECTION FAILED</p>
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      className="debate-button"
+                                      onClick={reconnectSfu}
+                                    >
+                                      <RefreshCw className="w-4 h-4 mr-2" />
+                                      RETRY CONNECTION
+                                    </Button>
                                   </div>
                                 </div>
                               ) : connectionState === 'connected' ? (
@@ -920,8 +1069,15 @@ export default function RoomClient({
                         size="sm"
                         onClick={handleTogglePause}
                         className="debate-button col-span-2"
+                        disabled={isPauseToggling}
                       >
-                        {isPaused ? <Play className="w-4 h-4 mr-2" /> : <Pause className="w-4 h-4 mr-2" />}
+                        {isPauseToggling ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : isPaused ? (
+                          <Play className="w-4 h-4 mr-2" />
+                        ) : (
+                          <Pause className="w-4 h-4 mr-2" />
+                        )}
                         {isPaused ? 'RESUME' : 'PAUSE'}
                       </Button>
                       <Button
@@ -929,16 +1085,39 @@ export default function RoomClient({
                         size="sm"
                         className="debate-button"
                         onClick={handleNextTurn}
+                        disabled={isAdvancingTurn}
                       >
-                        <SkipForward className="w-4 h-4 mr-1" />
+                        {isAdvancingTurn ? (
+                          <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                        ) : (
+                          <SkipForward className="w-4 h-4 mr-1" />
+                        )}
                         NEXT
                       </Button>
                       <Button
                         variant="outline"
                         size="sm"
                         className="debate-button"
-                        onClick={handleEndSession}
+                        onClick={handleExtendTurn}
+                        disabled={isExtendingTurn}
                       >
+                        {isExtendingTurn ? (
+                          <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                        ) : (
+                          <Timer className="w-4 h-4 mr-1" />
+                        )}
+                        +30s
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="debate-button col-span-2"
+                        onClick={() => setConfirmDialog({ type: 'end' })}
+                        disabled={isEnding}
+                      >
+                        {isEnding ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : null}
                         END
                       </Button>
                     </div>
@@ -955,8 +1134,19 @@ export default function RoomClient({
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="p-4 h-64 overflow-y-auto">
-                  <div className="h-full flex items-center justify-center">
-                    <p className="text-gray-500 debate-mono text-sm">Transcript will appear here during the debate</p>
+                  <div className="h-full flex flex-col items-center justify-center space-y-3">
+                    <div className="w-12 h-12 border-2 border-dashed border-white/20 flex items-center justify-center">
+                      <MessageSquare className="w-6 h-6 text-white/20" />
+                    </div>
+                    <div className="text-center">
+                      <p className="text-white/40 debate-title text-sm mb-1">COMING SOON</p>
+                      <p className="text-gray-500 debate-mono text-xs max-w-[200px]">
+                        Live transcription will be available in a future update
+                      </p>
+                    </div>
+                    <span className="debate-badge bg-gray-800 text-gray-400 text-[10px]">
+                      PLANNED FEATURE
+                    </span>
                   </div>
                 </CardContent>
               </Card>
@@ -983,26 +1173,64 @@ export default function RoomClient({
                             {displayName(person.user)}
                           </span>
                         </div>
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-1">
                           <span className="text-xs debate-mono text-gray-400">
                             {person.sessionRole}
                           </span>
-                          {isHost && person.userId !== currentUserId && person.sessionRole !== SessionRole.MODERATOR && (
+                          {/* Promote audience to debater (WAITING only) */}
+                          {isModeratorOrCreator && person.userId !== currentUserId && person.sessionRole === SessionRole.AUDIENCE && session.status === SessionStatus.WAITING && canJoinAsDebater && (
                             <button
-                              onClick={() => handleAssignModerator(person.userId)}
-                              className="text-blue-400 hover:text-blue-300 text-xs opacity-60 hover:opacity-100"
-                              title="Assign as moderator"
+                              onClick={() => setConfirmDialog({ type: 'promote', targetUserId: person.userId, targetName: displayName(person.user) })}
+                              className="text-green-400 hover:text-green-300 text-xs opacity-60 hover:opacity-100"
+                              title="Promote to debater"
+                              disabled={isPromoting === person.userId}
                             >
-                              MOD
+                              {isPromoting === person.userId ? (
+                                <Loader2 className="w-3 h-3 animate-spin" />
+                              ) : (
+                                <ArrowUp className="w-3 h-3" />
+                              )}
                             </button>
                           )}
+                          {/* Mute stub for debaters */}
+                          {isModeratorOrCreator && person.userId !== currentUserId && (person.sessionRole === SessionRole.DEBATER || person.sessionRole === SessionRole.HOST) && session.status !== SessionStatus.WAITING && (
+                            <button
+                              onClick={() => toast.info('Remote mute is not yet supported. Ask the participant to mute themselves.')}
+                              className="text-yellow-400 hover:text-yellow-300 text-xs opacity-60 hover:opacity-100"
+                              title="Mute participant (coming soon)"
+                            >
+                              {/* TODO: Implement server-side mute via SFU pauseProducer */}
+                              <MicOff className="w-3 h-3" />
+                            </button>
+                          )}
+                          {/* Assign moderator */}
+                          {isHost && person.userId !== currentUserId && person.sessionRole !== SessionRole.MODERATOR && (
+                            <button
+                              onClick={() => setConfirmDialog({ type: 'moderator', targetUserId: person.userId, targetName: displayName(person.user) })}
+                              className="text-blue-400 hover:text-blue-300 text-xs opacity-60 hover:opacity-100"
+                              title="Assign as moderator"
+                              disabled={isAssigningModerator === person.userId}
+                            >
+                              {isAssigningModerator === person.userId ? (
+                                <Loader2 className="w-3 h-3 animate-spin" />
+                              ) : (
+                                'MOD'
+                              )}
+                            </button>
+                          )}
+                          {/* Kick participant */}
                           {isModeratorOrCreator && person.userId !== currentUserId && (
                             <button
-                              onClick={() => handleKick(person.userId)}
+                              onClick={() => setConfirmDialog({ type: 'kick', targetUserId: person.userId, targetName: displayName(person.user) })}
                               className="text-red-400 hover:text-red-300 text-xs ml-1 opacity-60 hover:opacity-100"
                               title="Kick participant"
+                              disabled={isKicking === person.userId}
                             >
-                              ✕
+                              {isKicking === person.userId ? (
+                                <Loader2 className="w-3 h-3 animate-spin" />
+                              ) : (
+                                '✕'
+                              )}
                             </button>
                           )}
                         </div>
@@ -1015,6 +1243,20 @@ export default function RoomClient({
           </div>
         </div>
       </main>
+
+      {/* Confirmation Dialog */}
+      {confirmDialogConfig && (
+        <ConfirmDialog
+          open={confirmDialog !== null}
+          onOpenChange={(open) => { if (!open) setConfirmDialog(null) }}
+          title={confirmDialogConfig.title}
+          description={confirmDialogConfig.description}
+          confirmLabel={confirmDialogConfig.confirmLabel}
+          variant={confirmDialogConfig.variant}
+          loading={isEnding || isKicking !== null || isAssigningModerator !== null || isPromoting !== null}
+          onConfirm={handleConfirmAction}
+        />
+      )}
     </div>
   )
 }

--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -42,6 +42,7 @@ export default async function RoomPage({ params }: { params: Promise<{ code: str
     debaterCapacityOpponent: session.debater_capacity_opponent,
     debaterCapacityPanel: session.debater_capacity_panel,
     audienceCapacity: session.audience_capacity,
+    kickThreshold: session.kick_threshold,
     host: {
       id: session.host.id,
       username: session.host.username,

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import * as Dialog from '@radix-ui/react-dialog'
+import { Button } from '@/components/ui/button'
+import { Loader2, X } from 'lucide-react'
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'default' | 'destructive'
+  loading?: boolean
+  onConfirm: () => void | Promise<void>
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'CONFIRM',
+  cancelLabel = 'CANCEL',
+  variant = 'default',
+  loading = false,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 border-2 border-white/20 bg-gray-900 p-6 shadow-[6px_6px_0px_rgba(0,0,0,0.3)]">
+          <div className="flex items-center justify-between mb-4">
+            <Dialog.Title className="text-lg font-bold debate-title text-white">
+              {title}
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button className="text-gray-400 hover:text-white transition-colors">
+                <X className="w-5 h-5" />
+              </button>
+            </Dialog.Close>
+          </div>
+          <Dialog.Description className="text-gray-400 debate-mono text-sm mb-6">
+            {description}
+          </Dialog.Description>
+          <div className="flex justify-end gap-3">
+            <Dialog.Close asChild>
+              <Button variant="outline" size="sm" className="debate-button" disabled={loading}>
+                {cancelLabel}
+              </Button>
+            </Dialog.Close>
+            <Button
+              variant={variant === 'destructive' ? 'destructive' : 'default'}
+              size="sm"
+              className="debate-button"
+              onClick={onConfirm}
+              disabled={loading}
+            >
+              {loading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              {confirmLabel}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { Toaster as Sonner } from 'sonner'
+
+export function Toaster() {
+  return (
+    <Sonner
+      position="bottom-right"
+      theme="dark"
+      toastOptions={{
+        className: 'debate-mono',
+        style: {
+          background: 'rgb(17 24 39)',
+          border: '2px solid rgba(255,255,255,0.2)',
+          boxShadow: '4px 4px 0px rgba(0,0,0,0.3)',
+          color: 'white',
+        },
+      }}
+    />
+  )
+}

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -237,40 +237,454 @@ Update session status.
 
 ---
 
-# `lib/action/debate.ts` Documentation
+# `lib/action/utils.ts` Documentation
 
 ## Overview
-Manages the lifecycle and turn-based logic of a debate session:
-- Authorization (moderator/host)
-- Debate state retrieval
-- Turn control (start, advance, auto-advance)
-- Pause / resume
-- End debate
+Shared utility functions for authentication and authorization checks across server actions.
 
 ---
 
-## requireModerator(sessionId)
+## requireAuth()
 
-**Description**  
-Ensures the current user is authorized (HOST or MODERATOR).
+**Description**
+Require authenticated user. Returns the Supabase user object.
+
+**Logic**
+- Fetch current user from Supabase
+- Throw error if not authenticated
+
+**Returns**
+- Supabase `User` object
+
+**Errors**
+- Not authenticated
+
+---
+
+## requireHostOrModerator(sessionId)
+
+**Description**
+Require that the current user is the host or moderator of the given session.
 
 **Params**
 - `sessionId: string`
 
 **Logic**
-- Authenticate user (Supabase)
+- Authenticate user
 - Fetch session
-- अनुमति if:
-  - `user.id === session.host_id`
-  - OR `user.id === session.moderator_id`
+- Verify user is either host or moderator
 
 **Returns**
-- `{ user, session }`
+- `{ user, session }` - Both user and session objects
 
 **Errors**
 - Not authenticated
 - Session not found
 - Not authorized
+
+---
+
+## requireParticipant(sessionId)
+
+**Description**
+Verify that the authenticated user is an active participant in the session.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Authenticate user
+- Fetch participation record
+- Verify user is in session and `left_at` is null
+
+**Returns**
+- Supabase `User` object
+
+**Errors**
+- Not authenticated
+- Not a participant in this session
+- User has left the session
+
+---
+
+# `lib/action/transcript.ts` Documentation
+
+## Overview
+Manages transcript segments for live debate transcription (REQ-6).
+
+---
+
+## createTranscriptSegment(sessionId, content, timestamp, duration?, confidence?)
+
+**Description**
+Create a new transcript segment for a debate session.
+
+**Params**
+- `sessionId: string`
+- `content: string` - Transcribed text
+- `timestamp: number` - Seconds since debate start
+- `duration?: number` - Duration of speech segment (seconds)
+- `confidence?: number` - Confidence score (0.0 - 1.0)
+
+**Logic**
+- Verify user is an active participant
+- Create transcript record with speaker attribution
+
+**Returns**
+- `Transcript` object
+
+**Errors**
+- Not authenticated
+- Not a participant in this session
+
+---
+
+## getTranscriptBySession(sessionId)
+
+**Description**
+Fetch all transcript segments for a session in chronological order.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Verify user is an active participant
+- Fetch all segments ordered by timestamp
+- Include speaker details (id, username, realname)
+
+**Returns**
+- `Transcript[]` with speaker information
+
+**Errors**
+- Not authenticated
+- Not a participant in this session
+
+---
+
+# `lib/action/recording.ts` Documentation
+
+## Overview
+Manages video recordings of completed debate sessions (REQ-8).
+
+---
+
+## createRecording(sessionId, url, duration?, fileSize?, mimeType?)
+
+**Description**
+Create a recording entry for a debate session. Only host or moderator can create recordings.
+
+**Params**
+- `sessionId: string`
+- `url: string` - Recording file URL
+- `duration?: number` - Duration in seconds
+- `fileSize?: number` - File size in bytes
+- `mimeType?: string` - MIME type (e.g., "video/webm")
+
+**Logic**
+- Verify user is host or moderator
+- Create recording record
+
+**Returns**
+- `Recording` object
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
+
+---
+
+## getRecordingsBySession(sessionId)
+
+**Description**
+Fetch all recordings for a session, most recent first.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Verify user is an active participant
+- Fetch recordings ordered by creation date (desc)
+- Include recorder details
+
+**Returns**
+- `Recording[]` with recorder information
+
+**Errors**
+- Not authenticated
+- Not a participant in this session
+
+---
+
+## deleteRecording(recordingId)
+
+**Description**
+Delete a recording. Only the recording creator or session host can delete.
+
+**Params**
+- `recordingId: string`
+
+**Logic**
+- Authenticate user
+- Fetch recording with session host info
+- Verify user is either the recorder or the session host
+- Delete recording
+
+**Errors**
+- Not authenticated
+- Recording not found
+- Not authorized to delete this recording
+
+---
+
+# `lib/action/vote.ts` Documentation
+
+## Overview
+Manages audience voting for kick and promote actions (REQ-4).
+
+---
+
+## castVote(sessionId, targetUserId, voteType)
+
+**Description**
+Cast a vote to kick or promote a participant.
+
+**Params**
+- `sessionId: string`
+- `targetUserId: string`
+- `voteType: VoteType` - KICK or PROMOTE
+
+**Logic**
+- Authenticate user
+- Verify user is not voting for themselves
+- Verify session is LIVE
+- Verify voter is an active participant
+- Upsert vote (idempotent)
+
+**Returns**
+- `Vote` object
+
+**Errors**
+- Not authenticated
+- Cannot vote for yourself
+- Session not found
+- Session is not live
+- Not a participant in this session
+
+**Notes**
+- Uses `upsert` to prevent duplicate votes
+- Unique constraint: one vote of each type per voter-target pair per session
+
+---
+
+## retractVote(sessionId, targetUserId, voteType)
+
+**Description**
+Retract a previously cast vote.
+
+**Params**
+- `sessionId: string`
+- `targetUserId: string`
+- `voteType: VoteType`
+
+**Logic**
+- Authenticate user
+- Delete the vote record
+
+**Errors**
+- Not authenticated
+- Vote not found
+
+---
+
+## getVoteCounts(sessionId, targetUserId, voteType)
+
+**Description**
+Get the count of votes for a specific target and vote type.
+
+**Params**
+- `sessionId: string`
+- `targetUserId: string`
+- `voteType: VoteType`
+
+**Returns**
+- `{ count: number }`
+
+---
+
+# `lib/action/queue.ts` Documentation
+
+## Overview
+Manages the FIFO audience queue for promoting speakers (REQ-4).
+
+---
+
+## joinQueue(sessionId)
+
+**Description**
+Add the current user to the audience queue.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Authenticate user
+- Verify session is LIVE
+- Verify user is an active AUDIENCE member
+- Add to queue
+
+**Returns**
+- `AudienceQueue` object
+
+**Errors**
+- Not authenticated
+- Session not found
+- Session is not live
+- Not a participant in this session
+- Only audience members can join the queue
+
+---
+
+## leaveQueue(sessionId)
+
+**Description**
+Remove the current user from the audience queue.
+
+**Params**
+- `sessionId: string`
+
+**Logic**
+- Authenticate user
+- Delete queue entry
+
+**Errors**
+- Not authenticated
+- Queue entry not found
+
+---
+
+## getQueue(sessionId)
+
+**Description**
+Fetch the current audience queue in FIFO order.
+
+**Params**
+- `sessionId: string`
+
+**Returns**
+- `AudienceQueue[]` ordered by `joined_queue` (ascending)
+- Includes user details (id, username, realname)
+
+---
+
+## promoteFromQueue(sessionId, userId?)
+
+**Description**
+Promote a user from the audience queue to DEBATER. Only host or moderator can promote.
+
+**Params**
+- `sessionId: string`
+- `userId?: string` - Optional specific user; if omitted, promotes FIFO head
+
+**Logic**
+- Verify user is host or moderator
+- Transaction:
+  - Find queue entry (specific user or FIFO head)
+  - Update role to DEBATER
+  - Remove from queue
+  - Log role transition
+
+**Returns**
+- `{ promotedUserId: string }`
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
+- No one in the queue
+
+---
+
+# `lib/action/team.ts` Documentation
+
+## Overview
+Manages team assignments for TEAM format debates.
+
+---
+
+## assignTeam(sessionId, userId, team)
+
+**Description**
+Assign a user to a team. Only host or moderator can assign.
+
+**Params**
+- `sessionId: string`
+- `userId: string`
+- `team: string` - Must be "proponent" or "opponent"
+
+**Logic**
+- Verify user is host or moderator
+- Verify session type is TEAM
+- Verify team value is valid
+- Upsert team assignment
+
+**Returns**
+- `TeamAssignment` object
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
+- Team assignments are only for TEAM format sessions
+- Team must be 'proponent' or 'opponent'
+
+---
+
+## getTeamAssignments(sessionId)
+
+**Description**
+Fetch all team assignments for a session.
+
+**Params**
+- `sessionId: string`
+
+**Returns**
+- `TeamAssignment[]` ordered by `assigned_at` (ascending)
+- Includes user details (id, username, realname)
+
+---
+
+## removeFromTeam(sessionId, userId)
+
+**Description**
+Remove a user from their team. Only host or moderator can remove.
+
+**Params**
+- `sessionId: string`
+- `userId: string`
+
+**Logic**
+- Verify user is host or moderator
+- Delete team assignment
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
+- Team assignment not found
+
+---
+
+# `lib/action/debate.ts` Documentation
+
+## Overview
+Manages the lifecycle and turn-based logic of a debate session:
+- Debate state retrieval
+- Turn control (start, advance, auto-advance)
+- Pause / resume
+- End debate
+
+**Note:** This file now uses the shared `requireHostOrModerator` function from `utils.ts` for authorization checks.
 
 ---
 
@@ -297,7 +711,7 @@ Fetch current debate state.
 
 ## startDebate(sessionId, debaters, turnLength)
 
-**Description**  
+**Description**
 Initializes or resets a debate.
 
 **Params**
@@ -306,7 +720,7 @@ Initializes or resets a debate.
 - `turnLength: number` (seconds)
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Require exactly 2 debaters
 - Set:
   - `current_index = 0`
@@ -318,18 +732,20 @@ Initializes or resets a debate.
   - Reset if exists
 
 **Errors**
-- Unauthorized
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 - Invalid debater count
 
 ---
 
 ## advanceTurn(sessionId)
 
-**Description**  
+**Description**
 Manually advance to next speaker.
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Ensure state exists
 - Rotate:
   - `current_index = (index + 1) % 2`
@@ -339,7 +755,9 @@ Manually advance to next speaker.
   - `is_paused = false`
 
 **Errors**
-- Unauthorized
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 - No active debate
 
 ---
@@ -368,11 +786,11 @@ Auto-advances turn when timer expires (safe against race conditions).
 
 ## pauseDebate(sessionId)
 
-**Description**  
+**Description**
 Pauses the debate timer.
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Ensure:
   - state exists
   - not already paused
@@ -384,7 +802,9 @@ Pauses the debate timer.
   - `paused_time_remaining = remaining`
 
 **Errors**
-- Unauthorized
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 - No active debate
 - Already paused
 
@@ -392,11 +812,11 @@ Pauses the debate timer.
 
 ## resumeDebate(sessionId)
 
-**Description**  
+**Description**
 Resumes a paused debate.
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Ensure:
   - state exists
   - currently paused
@@ -405,7 +825,9 @@ Resumes a paused debate.
   - `is_paused = false`
 
 **Errors**
-- Unauthorized
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 - No active debate
 - Not paused
 
@@ -413,13 +835,18 @@ Resumes a paused debate.
 
 ## endDebate(sessionId)
 
-**Description**  
+**Description**
 Ends the debate and clears state.
 
 **Logic**
-- Require moderator/host
+- Require host/moderator (via `requireHostOrModerator`)
 - Delete `debateState`
 - Silently ignore if already deleted
+
+**Errors**
+- Not authenticated
+- Not authorized (not host or moderator)
+- Session not found
 
 ---
 
@@ -452,8 +879,8 @@ Handles user profile initialization and synchronization with the database.
 
 ## ensureUserProfile()
 
-**Description**  
-Ensures the currently authenticated user has a profile in the database.  
+**Description**
+Ensures the currently authenticated user has a profile in the database.
 Creates one if it does not exist.
 
 ---
@@ -512,3 +939,71 @@ Creates one if it does not exist.
 - Cache username availability checks
 - Move collision handling to DB-level unique constraints + retry
 - Allow user-defined usernames (with validation layer)
+
+---
+
+## getUserPreferences()
+
+**Description**
+Fetch user preferences for the currently authenticated user.
+
+**Logic**
+- Authenticate user (via `requireAuth`)
+- Fetch user record with all preference fields
+
+**Returns**
+- User object containing:
+  - `username, email, realname, bio`
+  - Notification preferences: `notify_invitations, notify_messages, notify_weekly_digest`
+  - Privacy preferences: `profile_visibility, show_online_status, allow_direct_messages`
+  - Appearance preferences: `theme, font_size, animations_enabled`
+  - Language & region: `language, timezone, date_format`
+
+**Errors**
+- Not authenticated
+
+---
+
+## updateUserPreferences(prefs)
+
+**Description**
+Update user preferences for the currently authenticated user.
+
+**Params**
+- `prefs: UserPreferences` - Object containing preferences to update
+
+**UserPreferences Type:**
+```typescript
+{
+  bio?: string | null
+  notify_invitations?: boolean
+  notify_messages?: boolean
+  notify_weekly_digest?: boolean
+  profile_visibility?: string
+  show_online_status?: boolean
+  allow_direct_messages?: boolean
+  theme?: string
+  font_size?: string
+  animations_enabled?: boolean
+  language?: string
+  timezone?: string
+  date_format?: string
+}
+```
+
+**Logic**
+- Authenticate user (via `requireAuth`)
+- Validate constraints:
+  - `theme`: must be "dark", "light", or "system"
+  - `font_size`: must be "small", "medium", or "large"
+  - `profile_visibility`: must be "public" or "private"
+- Update user record with provided preferences
+
+**Returns**
+- Updated `User` object
+
+**Errors**
+- Not authenticated
+- Theme must be 'dark', 'light', or 'system'
+- Font size must be 'small', 'medium', or 'large'
+- Profile visibility must be 'public' or 'private'

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -27,6 +27,10 @@ This document describes the database schema for Arguably.
 - `PAUSED` - Temporarily paused
 - `ENDED` - Debate concluded
 
+### VoteType
+- `KICK` - Vote to remove a participant
+- `PROMOTE` - Vote to promote an audience member to debater
+
 ## Models
 
 ### User
@@ -43,11 +47,31 @@ Represents a platform user account.
 | `realname` | String? | - | null | Display name |
 | `role` | UniversalRole | - | USER | System role |
 | `created_at` | DateTime | - | now() | Account creation |
+| `bio` | String? | - | null | User biography |
+| `notify_invitations` | Boolean | - | true | Email notification for invitations |
+| `notify_messages` | Boolean | - | true | Email notification for messages |
+| `notify_weekly_digest` | Boolean | - | false | Weekly digest emails |
+| `profile_visibility` | String | - | "public" | Profile visibility setting |
+| `show_online_status` | Boolean | - | true | Display online status |
+| `allow_direct_messages` | Boolean | - | true | Allow DMs from other users |
+| `theme` | String | - | "dark" | UI theme preference |
+| `font_size` | String | - | "medium" | Font size preference |
+| `animations_enabled` | Boolean | - | true | Enable UI animations |
+| `language` | String | - | "en" | Preferred language |
+| `timezone` | String | - | "UTC" | User timezone |
+| `date_format` | String | - | "MM/DD/YYYY" | Date format preference |
 
 **Relations:**
 - `hosted_sessions: Session[]` - Sessions created by this user
 - `moderated_sessions: Session[]` - Sessions moderated by this user
 - `participates_ins: ParticipatesIn[]` - All session participations
+- `transcripts: Transcript[]` - Transcript segments spoken by this user
+- `recordings: Recording[]` - Recordings created by this user
+- `votes_cast: Vote[]` - Votes cast by this user
+- `votes_received: Vote[]` - Votes received by this user
+- `audience_queues: AudienceQueue[]` - Queue entries for this user
+- `team_assignments: TeamAssignment[]` - Team assignments for this user
+- `role_history: RoleHistory[]` - Role change history for this user
 
 ---
 
@@ -72,6 +96,7 @@ Represents a debate session/room.
 | `debater_capacity_panel` | Int? | - | 5 | Max panel slots (PANEL only) |
 | `audience_capacity` | Int | - | 10 | Max audience slots |
 | `turn_length` | Int | - | 120 | Turn duration (seconds) |
+| `format_locked` | Boolean | - | false | Format locked after debate begins |
 | `created_at` | DateTime | - | now() | Creation timestamp |
 | `ended_at` | DateTime? | - | null | End timestamp |
 
@@ -79,6 +104,13 @@ Represents a debate session/room.
 - `host: User` - Session creator
 - `moderator: User?` - Session moderator (optional)
 - `participates_ins: ParticipatesIn[]` - All participants
+- `debate_state: DebateState?` - Current debate state (optional)
+- `transcripts: Transcript[]` - Transcript segments for this session
+- `recordings: Recording[]` - Recordings of this session
+- `votes: Vote[]` - All votes cast in this session
+- `audience_queue: AudienceQueue[]` - Audience members in queue
+- `team_assignments: TeamAssignment[]` - Team assignments for this session
+- `role_history: RoleHistory[]` - Role change history for this session
 
 **Notes:**
 - The term "proponent" refers to the debaters that agree with the host
@@ -108,13 +140,186 @@ Join table tracking user participation in sessions.
 
 ---
 
+### Transcript
+
+Speaker-attributed, timestamped transcript segment (REQ-6).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this segment belongs to |
+| `speaker_id` | UUID | FK → User | - | User who spoke this segment |
+| `content` | String | - | - | Transcribed text |
+| `timestamp` | Float | - | - | Seconds since debate start |
+| `duration` | Float? | - | null | Duration of speech segment (seconds) |
+| `confidence` | Float? | - | null | Confidence score (0.0 - 1.0) |
+| `created_at` | DateTime | - | now() | Creation timestamp |
+
+**Relations:**
+- `session: Session` - Session this transcript belongs to
+- `speaker: User` - User who spoke this segment
+
+**Indexes:**
+- Composite index on `(session_id, timestamp)` for efficient timeline queries
+
+---
+
+### Recording
+
+Video recording link for a completed session (REQ-8).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this recording is for |
+| `recorded_by` | UUID | FK → User | - | User who created the recording |
+| `url` | String | - | - | Recording file URL |
+| `duration` | Float? | - | null | Duration in seconds |
+| `file_size` | Int? | - | null | File size in bytes |
+| `mime_type` | String? | - | null | MIME type (e.g., "video/webm") |
+| `created_at` | DateTime | - | now() | Creation timestamp |
+
+**Relations:**
+- `session: Session` - Session this recording is for
+- `recorder: User` - User who created the recording
+
+**Indexes:**
+- Index on `session_id`
+
+---
+
+### Vote
+
+Audience vote to kick or promote a participant (REQ-4).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this vote is in |
+| `voter_id` | UUID | FK → User | - | User casting the vote |
+| `target_user_id` | UUID | FK → User | - | User being voted on |
+| `vote_type` | VoteType | - | - | Type of vote (KICK or PROMOTE) |
+| `created_at` | DateTime | - | now() | Vote timestamp |
+
+**Relations:**
+- `session: Session` - Session this vote belongs to
+- `voter: User` - User who cast the vote
+- `target: User` - User being voted on
+
+**Indexes:**
+- Index on `session_id`
+
+**Constraints:**
+- Unique constraint on `(session_id, voter_id, target_user_id, vote_type)` - each user can only cast one vote of each type against each target per session
+
+---
+
+### AudienceQueue
+
+FIFO queue for audience members waiting to speak (REQ-4).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this queue entry is for |
+| `user_id` | UUID | FK → User | - | User in queue |
+| `joined_queue` | DateTime | - | now() | When user joined the queue |
+
+**Relations:**
+- `session: Session` - Session this queue entry belongs to
+- `user: User` - User in the queue
+
+**Indexes:**
+- Index on `session_id`
+
+**Constraints:**
+- Unique constraint on `(session_id, user_id)` - a user can only be in the queue once per session
+
+---
+
+### TeamAssignment
+
+Team membership for team debates.
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session this assignment is for |
+| `user_id` | UUID | FK → User | - | User on the team |
+| `team` | String | - | - | Team identifier: "proponent" or "opponent" |
+| `assigned_at` | DateTime | - | now() | Assignment timestamp |
+
+**Relations:**
+- `session: Session` - Session this assignment belongs to
+- `user: User` - User on the team
+
+**Indexes:**
+- Index on `session_id`
+
+**Constraints:**
+- Unique constraint on `(session_id, user_id)` - a user can only be on one team per session
+
+---
+
+### RoleHistory
+
+Tracks role transitions with timestamps for audit purposes (REQ-2.8).
+
+**Fields:**
+
+| Field | Type | Constraints | Default | Notes |
+|-------|------|-------------|---------|-------|
+| `id` | String | PK | CUID | - |
+| `session_id` | String | FK → Session | - | Session where role changed |
+| `user_id` | UUID | FK → User | - | User whose role changed |
+| `old_role` | SessionRole | - | - | Previous role |
+| `new_role` | SessionRole | - | - | New role |
+| `changed_at` | DateTime | - | now() | Timestamp of role change |
+| `reason` | String? | - | null | Optional reason for role change |
+
+**Relations:**
+- `session: Session` - Session this role change belongs to
+- `user: User` - User whose role changed
+
+**Indexes:**
+- Index on `session_id`
+- Index on `user_id`
+
+---
+
 ## Relationships
 
 ```
 User
 ├─ (1) ─ hosts ─ (Many) → Session ─ has ─ (Many) → ParticipatesIn
 ├─ (1) ─ moderates ─ (Many) → Session
-└─ (1) ─ participates ─ (Many) → ParticipatesIn
+├─ (1) ─ participates ─ (Many) → ParticipatesIn
+├─ (1) ─ speaks ─ (Many) → Transcript
+├─ (1) ─ records ─ (Many) → Recording
+├─ (1) ─ casts_votes ─ (Many) → Vote
+├─ (1) ─ receives_votes ─ (Many) → Vote
+├─ (1) ─ queues ─ (Many) → AudienceQueue
+├─ (1) ─ assigned_to ─ (Many) → TeamAssignment
+└─ (1) ─ role_changes ─ (Many) → RoleHistory
+
+Session
+├─ (1) ─ has ─ (1?) → DebateState
+├─ (1) ─ has ─ (Many) → Transcript
+├─ (1) ─ has ─ (Many) → Recording
+├─ (1) ─ has ─ (Many) → Vote
+├─ (1) ─ has ─ (Many) → AudienceQueue
+├─ (1) ─ has ─ (Many) → TeamAssignment
+└─ (1) ─ has ─ (Many) → RoleHistory
 ```
 
 ---
@@ -170,8 +375,15 @@ totalDebaterCapacity = debater_capacity_panel
 | `User.username` | Must be unique across all users |
 | `Session.code` | Must be unique across all sessions |
 | `Session.moderator_id` | Optional; can be null initially |
+| `Session.format_locked` | Set to true when session status changes to LIVE (REQ-1.8) |
 | `ParticipatesIn.left_at` | null = actively in session |
 | `Session.ended_at` | null until session ends |
+| `Vote unique constraint` | Each user can cast only one vote of each type against each target per session |
+| `AudienceQueue unique constraint` | A user can only be in the queue once per session |
+| `TeamAssignment unique constraint` | A user can only be on one team per session |
+| `Transcript.timestamp` | Seconds since debate start, used for replay synchronization |
+| `Vote.vote_type` | Must be KICK or PROMOTE |
+| `TeamAssignment.team` | Must be "proponent" or "opponent" for TEAM format sessions |
 
 ---
 
@@ -186,6 +398,19 @@ totalDebaterCapacity = debater_capacity_panel
 │ email (String?)                                             │
 │ realname (String?)                                          │
 │ role (UniversalRole)                                        │
+│ bio (String?)                                               │
+│ notify_invitations (Boolean)                                │
+│ notify_messages (Boolean)                                   │
+│ notify_weekly_digest (Boolean)                              │
+│ profile_visibility (String)                                 │
+│ show_online_status (Boolean)                                │
+│ allow_direct_messages (Boolean)                             │
+│ theme (String)                                              │
+│ font_size (String)                                          │
+│ animations_enabled (Boolean)                                │
+│ language (String)                                           │
+│ timezone (String)                                           │
+│ date_format (String)                                        │
 │ created_at (DateTime)                                       │
 └─────────────────────────────────────────────────────────────┘
         │                                        │
@@ -208,6 +433,7 @@ totalDebaterCapacity = debater_capacity_panel
 │ debater_capacity_panel (Int?)                               │
 │ audience_capacity (Int)                                     │
 │ turn_length (Int)                                           │
+│ format_locked (Boolean)                                     │
 │ created_at (DateTime)                                       │
 │ ended_at (DateTime?)                                        │
 └─────────────────────────────────────────────────────────────┘
@@ -224,4 +450,75 @@ totalDebaterCapacity = debater_capacity_panel
 │ joined_at (DateTime)                                        │
 │ left_at (DateTime?)                                         │
 │ session_role (SessionRole)                                  │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                     Transcript                              │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ speaker_id (UUID, FK → User)                                │
+│ content (String)                                            │
+│ timestamp (Float)                                           │
+│ duration (Float?)                                           │
+│ confidence (Float?)                                         │
+│ created_at (DateTime)                                       │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                     Recording                               │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ recorded_by (UUID, FK → User)                               │
+│ url (String)                                                │
+│ duration (Float?)                                           │
+│ file_size (Int?)                                            │
+│ mime_type (String?)                                         │
+│ created_at (DateTime)                                       │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                        Vote                                 │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ voter_id (UUID, FK → User)                                  │
+│ target_user_id (UUID, FK → User)                            │
+│ vote_type (VoteType)                                        │
+│ created_at (DateTime)                                       │
+│ UNIQUE (session_id, voter_id, target_user_id, vote_type)   │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                   AudienceQueue                             │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ user_id (UUID, FK → User)                                   │
+│ joined_queue (DateTime)                                     │
+│ UNIQUE (session_id, user_id)                                │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                  TeamAssignment                             │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ user_id (UUID, FK → User)                                   │
+│ team (String)                                               │
+│ assigned_at (DateTime)                                      │
+│ UNIQUE (session_id, user_id)                                │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                    RoleHistory                              │
+├─────────────────────────────────────────────────────────────┤
+│ id (String, PK, CUID)                                       │
+│ session_id (String, FK → Session)                           │
+│ user_id (UUID, FK → User)                                   │
+│ old_role (SessionRole)                                      │
+│ new_role (SessionRole)                                      │
+│ changed_at (DateTime)                                       │
+│ reason (String?)                                            │
 └─────────────────────────────────────────────────────────────┘

--- a/hooks/useKickVoteChannel.ts
+++ b/hooks/useKickVoteChannel.ts
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import {
+  castKickVote as castKickVoteAction,
+  removeKickVote as removeKickVoteAction,
+  getKickVotes as getKickVotesAction,
+} from '@/lib/actions/queue'
+
+export interface KickVoteState {
+  voteCount: number
+  requiredVotes: number
+  userHasVoted: boolean
+}
+
+interface UseKickVoteChannelOptions {
+  sessionId: string
+  userId: string | null
+  debaterIds: string[]
+}
+
+export function useKickVoteChannel({
+  sessionId,
+  userId,
+  debaterIds,
+}: UseKickVoteChannelOptions) {
+  const [voteStates, setVoteStates] = useState<Record<string, KickVoteState>>({})
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const fetchVotes = useCallback(async () => {
+    if (!userId || debaterIds.length === 0) return
+    try {
+      const results = await Promise.all(
+        debaterIds.map(async (targetId) => {
+          const data = await getKickVotesAction(sessionId, targetId)
+          return [targetId, data] as const
+        })
+      )
+      setVoteStates(Object.fromEntries(results))
+    } catch (err) {
+      console.error('Failed to fetch kick votes:', err)
+    }
+  }, [sessionId, userId, debaterIds])
+
+  const debouncedFetch = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(fetchVotes, 500)
+  }, [fetchVotes])
+
+  // Subscribe to Vote table changes
+  useEffect(() => {
+    const supabase = createClient()
+
+    const channel = supabase
+      .channel(`votes:${sessionId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'Vote',
+          filter: `session_id=eq.${sessionId}`,
+        },
+        () => { debouncedFetch() },
+      )
+      .subscribe(async (status) => {
+        if (status === 'SUBSCRIBED') {
+          await fetchVotes()
+        }
+      })
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      supabase.removeChannel(channel)
+    }
+  }, [sessionId, fetchVotes, debouncedFetch])
+
+  const castVote = useCallback(
+    (targetUserId: string) => castKickVoteAction(sessionId, targetUserId),
+    [sessionId],
+  )
+
+  const removeVote = useCallback(
+    (targetUserId: string) => removeKickVoteAction(sessionId, targetUserId),
+    [sessionId],
+  )
+
+  return {
+    voteStates,
+    castVote,
+    removeVote,
+  }
+}

--- a/hooks/useMediasoup.ts
+++ b/hooks/useMediasoup.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { createClient } from '@/lib/supabase/client'
 
 type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error'
 
@@ -26,6 +27,7 @@ interface UseMediasoupReturn {
   toggleMute: () => void
   toggleVideo: () => void
   disconnect: () => void
+  reconnect: () => void
 }
 
 // Socket.io emit with ack helper
@@ -52,6 +54,7 @@ export function useMediasoup({
   const [remoteStreams, setRemoteStreams] = useState<Map<string, RemoteStream>>(new Map())
   const [audioMuted, setAudioMuted] = useState(false)
   const [videoOff, setVideoOff] = useState(false)
+  const [reconnectTrigger, setReconnectTrigger] = useState(0)
 
   const socketRef = useRef<any>(null)
   const deviceRef = useRef<any>(null)
@@ -133,6 +136,12 @@ export function useMediasoup({
     }
   }, [])
 
+  const reconnect = useCallback(() => {
+    cleanup()
+    cleanedUpRef.current = false
+    setReconnectTrigger((n) => n + 1)
+  }, [cleanup])
+
   useEffect(() => {
     if (!enabled || !sfuUrl || !roomId || !displayName) {
       return
@@ -153,7 +162,19 @@ export function useMediasoup({
 
         if (cancelled) return
 
-        const socket = io(sfuUrl!, { transports: ['websocket'] })
+        // Get Supabase auth token for Socket.IO authentication
+        const supabase = createClient()
+        const { data: { session } } = await supabase.auth.getSession()
+        if (!session?.access_token) {
+          console.error('No auth token available — cannot connect to SFU')
+          setConnectionState('error')
+          return
+        }
+
+        const socket = io(sfuUrl!, {
+          transports: ['websocket'],
+          auth: { token: session.access_token },
+        })
         socketRef.current = socket
 
         socket.on('connect', async () => {
@@ -231,6 +252,16 @@ export function useMediasoup({
             localStreamRef.current = stream
             setLocalStream(stream)
 
+            // Start 15s timeout after getUserMedia (not before, since permission dialog can take arbitrarily long)
+            const connectionTimeout = setTimeout(() => {
+              if (!cancelled) {
+                console.error('SFU connection timed out after 15s')
+                cleanup()
+                cleanedUpRef.current = false
+                setConnectionState('error')
+              }
+            }, 15000)
+
             const videoTrack = stream.getVideoTracks()[0]
             if (videoTrack) {
               const videoProducer = await sendTransport.produce({ track: videoTrack })
@@ -249,6 +280,7 @@ export function useMediasoup({
               await consumeProducer(socket, recvTransport, p.producerId)
             }
 
+            clearTimeout(connectionTimeout)
             setConnectionState('connected')
           } catch (err: any) {
             console.error('SFU setup error:', err)
@@ -355,7 +387,7 @@ export function useMediasoup({
       cancelled = true
       cleanup()
     }
-  }, [enabled, sfuUrl, roomId, displayName, cleanup])
+  }, [enabled, sfuUrl, roomId, displayName, cleanup, reconnectTrigger])
 
   return {
     connectionState,
@@ -366,5 +398,6 @@ export function useMediasoup({
     toggleMute,
     toggleVideo,
     disconnect,
+    reconnect,
   }
 }

--- a/hooks/useQueueChannel.ts
+++ b/hooks/useQueueChannel.ts
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import {
+  getQueue as getQueueAction,
+  joinQueue as joinQueueAction,
+  leaveQueue as leaveQueueAction,
+} from '@/lib/actions/queue'
+
+export interface QueueEntry {
+  id: string
+  userId: string
+  rank: number
+  displayName: string
+  addedAt: string
+}
+
+interface UseQueueChannelOptions {
+  sessionId: string
+  userId: string | null
+}
+
+export function useQueueChannel({ sessionId, userId }: UseQueueChannelOptions) {
+  const [queue, setQueue] = useState<QueueEntry[]>([])
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const fetchQueue = useCallback(async () => {
+    try {
+      const entries = await getQueueAction(sessionId)
+      setQueue(entries)
+    } catch (err) {
+      console.error('Failed to fetch queue:', err)
+    }
+  }, [sessionId])
+
+  const debouncedFetch = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(fetchQueue, 500)
+  }, [fetchQueue])
+
+  // Subscribe to Realtime + fetch initial state
+  useEffect(() => {
+    const supabase = createClient()
+
+    const channel = supabase
+      .channel(`queue:${sessionId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'AudienceQueue',
+          filter: `session_id=eq.${sessionId}`,
+        },
+        () => { debouncedFetch() },
+      )
+      .subscribe(async (status) => {
+        if (status === 'SUBSCRIBED') {
+          await fetchQueue()
+        }
+      })
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      supabase.removeChannel(channel)
+    }
+  }, [sessionId, fetchQueue, debouncedFetch])
+
+  const myPosition = userId
+    ? queue.find((e) => e.userId === userId)?.rank ?? null
+    : null
+
+  const isInQueue = myPosition !== null
+
+  const joinQueue = useCallback(
+    () => joinQueueAction(sessionId),
+    [sessionId],
+  )
+
+  const leaveQueue = useCallback(
+    () => leaveQueueAction(sessionId),
+    [sessionId],
+  )
+
+  return {
+    queue,
+    myPosition,
+    isInQueue,
+    joinQueue,
+    leaveQueue,
+  }
+}

--- a/lib/actions/debate.ts
+++ b/lib/actions/debate.ts
@@ -3,28 +3,15 @@
 import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
 import { SessionRole, SessionType } from "@/lib/generated/prisma"
+import { requireHostOrModerator } from "@/lib/actions/utils"
 import { doPromoteFromQueue } from "@/lib/actions/queue"
 
-async function requireModerator(sessionId: string) {
+export async function getDebateState(sessionId: string) {
+  // Auth check: require authenticated user
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: { user } } = await supabase.auth.getUser()
   if (!user) throw new Error("Not authenticated")
 
-  const session = await prisma.session.findUnique({
-    where: { id: sessionId },
-  })
-  if (!session) throw new Error("Session not found")
-
-  const allowed =
-    session.moderator_id === user.id || session.host_id === user.id
-  if (!allowed) throw new Error("Not authorized")
-
-  return { user, session }
-}
-
-export async function getDebateState(sessionId: string) {
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
   })
@@ -48,11 +35,30 @@ export async function startDebate(
   debaters: { userId: string; displayName: string }[],
   turnLength: number
 ) {
-  const { session } = await requireModerator(sessionId)
+  const { session } = await requireHostOrModerator(sessionId)
+
+  if (turnLength < 1) throw new Error("Turn length must be at least 1 second")
+  if (turnLength > 1800) throw new Error("Turn length cannot exceed 30 minutes (1800 seconds)")
 
   if (session.type === SessionType.EXPERT_VS_CROWD) {
     // Expert vs Crowd: accept 1 debater (expert), auto-promote first queue member
     if (debaters.length !== 1) throw new Error("Expert vs. Crowd requires exactly 1 expert")
+
+    // Validate the expert is an active participant
+    const participation = await prisma.participatesIn.findMany({
+      where: {
+        session_id: sessionId,
+        left_at: null,
+        user_id: { in: debaters.map((d) => d.userId) },
+      },
+      select: { user_id: true },
+    })
+    const participantIds = new Set(participation.map((p: { user_id: string }) => p.user_id))
+    for (const debater of debaters) {
+      if (!participantIds.has(debater.userId)) {
+        throw new Error(`Debater ${debater.userId} is not an active participant in this session`)
+      }
+    }
 
     return prisma.$transaction(async (tx) => {
       // Pop first queue member as challenger
@@ -87,6 +93,22 @@ export async function startDebate(
   // All other formats: require at least 2 debaters
   if (debaters.length < 2) throw new Error("At least 2 debaters required")
 
+  // Validate debater IDs are active participants in the session
+  const participants = await prisma.participatesIn.findMany({
+    where: {
+      session_id: sessionId,
+      left_at: null,
+      user_id: { in: debaters.map((d) => d.userId) },
+    },
+    select: { user_id: true },
+  })
+  const participantIds = new Set(participants.map((p: { user_id: string }) => p.user_id))
+  for (const debater of debaters) {
+    if (!participantIds.has(debater.userId)) {
+      throw new Error(`Debater ${debater.userId} is not an active participant in this session`)
+    }
+  }
+
   const now = Date.now()
   await prisma.debateState.upsert({
     where: { session_id: sessionId },
@@ -111,7 +133,7 @@ export async function startDebate(
 }
 
 export async function advanceTurn(sessionId: string) {
-  const { session } = await requireModerator(sessionId)
+  const { session } = await requireHostOrModerator(sessionId)
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
@@ -195,6 +217,12 @@ export async function advanceTurnIfExpired(sessionId: string) {
     data: { user },
   } = await supabase.auth.getUser()
   if (!user) return
+
+  // Verify user is an active participant in this session
+  const participation = await prisma.participatesIn.findUnique({
+    where: { user_id_session_id: { user_id: user.id, session_id: sessionId } },
+  })
+  if (!participation || participation.left_at !== null) return
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
@@ -284,7 +312,7 @@ export async function advanceTurnIfExpired(sessionId: string) {
 }
 
 export async function pauseDebate(sessionId: string) {
-  await requireModerator(sessionId)
+  await requireHostOrModerator(sessionId)
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
@@ -307,7 +335,7 @@ export async function pauseDebate(sessionId: string) {
 }
 
 export async function resumeDebate(sessionId: string) {
-  await requireModerator(sessionId)
+  await requireHostOrModerator(sessionId)
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
@@ -325,8 +353,34 @@ export async function resumeDebate(sessionId: string) {
   })
 }
 
+export async function extendTurn(sessionId: string, extraSeconds: number) {
+  await requireHostOrModerator(sessionId)
+
+  const state = await prisma.debateState.findUnique({
+    where: { session_id: sessionId },
+  })
+  if (!state) throw new Error("No active debate")
+
+  if (state.is_paused) {
+    await prisma.debateState.update({
+      where: { session_id: sessionId },
+      data: {
+        paused_time_remaining: state.paused_time_remaining + extraSeconds,
+      },
+    })
+  } else {
+    if (!state.turn_ends_at) throw new Error("No active turn")
+    await prisma.debateState.update({
+      where: { session_id: sessionId },
+      data: {
+        turn_ends_at: state.turn_ends_at + extraSeconds * 1000,
+      },
+    })
+  }
+}
+
 export async function endDebate(sessionId: string) {
-  await requireModerator(sessionId)
+  await requireHostOrModerator(sessionId)
   await prisma.debateState
     .delete({ where: { session_id: sessionId } })
     .catch(() => {})

--- a/lib/actions/debate.ts
+++ b/lib/actions/debate.ts
@@ -2,6 +2,8 @@
 
 import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
+import { SessionRole, SessionType } from "@/lib/generated/prisma"
+import { doPromoteFromQueue } from "@/lib/actions/queue"
 
 async function requireModerator(sessionId: string) {
   const supabase = await createClient()
@@ -46,8 +48,44 @@ export async function startDebate(
   debaters: { userId: string; displayName: string }[],
   turnLength: number
 ) {
-  await requireModerator(sessionId)
-  if (debaters.length !== 2) throw new Error("Exactly 2 debaters required")
+  const { session } = await requireModerator(sessionId)
+
+  if (session.type === SessionType.EXPERT_VS_CROWD) {
+    // Expert vs Crowd: accept 1 debater (expert), auto-promote first queue member
+    if (debaters.length !== 1) throw new Error("Expert vs. Crowd requires exactly 1 expert")
+
+    return prisma.$transaction(async (tx) => {
+      // Pop first queue member as challenger
+      const challenger = await doPromoteFromQueue(tx, sessionId)
+      if (!challenger) throw new Error("No one in the queue to challenge the expert")
+
+      const debaterOrder = [debaters[0], challenger]
+      const now = Date.now()
+      await tx.debateState.upsert({
+        where: { session_id: sessionId },
+        create: {
+          session_id: sessionId,
+          debater_order: debaterOrder,
+          current_index: 0,
+          turn_length: turnLength,
+          turn_ends_at: now + turnLength * 1000,
+          is_paused: false,
+          paused_time_remaining: turnLength,
+        },
+        update: {
+          debater_order: debaterOrder,
+          current_index: 0,
+          turn_length: turnLength,
+          turn_ends_at: now + turnLength * 1000,
+          is_paused: false,
+          paused_time_remaining: turnLength,
+        },
+      })
+    })
+  }
+
+  // All other formats: require at least 2 debaters
+  if (debaters.length < 2) throw new Error("At least 2 debaters required")
 
   const now = Date.now()
   await prisma.debateState.upsert({
@@ -73,18 +111,77 @@ export async function startDebate(
 }
 
 export async function advanceTurn(sessionId: string) {
-  await requireModerator(sessionId)
+  const { session } = await requireModerator(sessionId)
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
   })
   if (!state) throw new Error("No active debate")
 
+  const order = state.debater_order as { userId: string; displayName: string }[]
+
+  if (session.type === SessionType.EXPERT_VS_CROWD && state.current_index === 1) {
+    // Challenger just finished — rotate challenger from queue
+    return prisma.$transaction(async (tx) => {
+      const oldChallenger = order[1]
+
+      // Demote old challenger back to AUDIENCE
+      if (oldChallenger) {
+        await tx.participatesIn.update({
+          where: {
+            user_id_session_id: {
+              user_id: oldChallenger.userId,
+              session_id: sessionId,
+            },
+          },
+          data: { session_role: SessionRole.AUDIENCE },
+        })
+      }
+
+      // Promote next from queue
+      const newChallenger = await doPromoteFromQueue(tx, sessionId)
+
+      if (!newChallenger) {
+        // No one in queue — pause debate
+        const remaining = state.turn_ends_at
+          ? Math.max(0, (state.turn_ends_at - Date.now()) / 1000)
+          : state.turn_length
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: {
+            // Keep expert at index 0, remove old challenger
+            debater_order: [order[0]],
+            current_index: 0,
+            is_paused: true,
+            turn_ends_at: null,
+            paused_time_remaining: remaining,
+          },
+        })
+        return
+      }
+
+      // doPromoteFromQueue appends to debater_order, but we need to replace index 1
+      // So we manually set the order to [expert, newChallenger]
+      const now = Date.now()
+      await tx.debateState.update({
+        where: { session_id: sessionId },
+        data: {
+          debater_order: [order[0], newChallenger],
+          current_index: 0,
+          turn_ends_at: now + state.turn_length * 1000,
+          is_paused: false,
+          paused_time_remaining: state.turn_length,
+        },
+      })
+    })
+  }
+
+  // Standard turn advancement for all formats
   const now = Date.now()
   await prisma.debateState.update({
     where: { session_id: sessionId },
     data: {
-      current_index: (state.current_index + 1) % 2,
+      current_index: (state.current_index + 1) % order.length,
       turn_ends_at: now + state.turn_length * 1000,
       is_paused: false,
       paused_time_remaining: state.turn_length,
@@ -105,8 +202,73 @@ export async function advanceTurnIfExpired(sessionId: string) {
   if (!state || state.is_paused || !state.turn_ends_at) return
   if (Date.now() < state.turn_ends_at - 1000) return
 
+  const order = state.debater_order as { userId: string; displayName: string }[]
+
+  // Check if this is Expert vs Crowd and challenger's turn ended
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { type: true },
+  })
+
+  if (session?.type === SessionType.EXPERT_VS_CROWD && state.current_index === 1) {
+    // Challenger turn expired — rotate via transaction
+    return prisma.$transaction(async (tx) => {
+      // Atomic guard: only proceed if state hasn't changed
+      const current = await tx.debateState.findUnique({
+        where: { session_id: sessionId },
+      })
+      if (
+        !current ||
+        current.current_index !== state.current_index ||
+        current.is_paused
+      ) {
+        return // Already advanced by someone else
+      }
+
+      const oldChallenger = order[1]
+      if (oldChallenger) {
+        await tx.participatesIn.update({
+          where: {
+            user_id_session_id: {
+              user_id: oldChallenger.userId,
+              session_id: sessionId,
+            },
+          },
+          data: { session_role: SessionRole.AUDIENCE },
+        })
+      }
+
+      const newChallenger = await doPromoteFromQueue(tx, sessionId)
+
+      if (!newChallenger) {
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: {
+            debater_order: [order[0]],
+            current_index: 0,
+            is_paused: true,
+            turn_ends_at: null,
+            paused_time_remaining: state.turn_length,
+          },
+        })
+        return
+      }
+
+      const now = Date.now()
+      await tx.debateState.update({
+        where: { session_id: sessionId },
+        data: {
+          debater_order: [order[0], newChallenger],
+          current_index: 0,
+          turn_ends_at: now + state.turn_length * 1000,
+          paused_time_remaining: state.turn_length,
+        },
+      })
+    })
+  }
+
+  // Standard auto-advance for all other formats
   const now = Date.now()
-  // Atomic guard: only advance if current_index hasn't changed (prevents double-advance)
   await prisma.debateState.updateMany({
     where: {
       session_id: sessionId,
@@ -114,7 +276,7 @@ export async function advanceTurnIfExpired(sessionId: string) {
       is_paused: false,
     },
     data: {
-      current_index: (state.current_index + 1) % 2,
+      current_index: (state.current_index + 1) % order.length,
       turn_ends_at: now + state.turn_length * 1000,
       paused_time_remaining: state.turn_length,
     },

--- a/lib/actions/queue.ts
+++ b/lib/actions/queue.ts
@@ -1,0 +1,343 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+import { prisma } from "@/lib/prisma"
+import { SessionRole, VoteType } from "@/lib/generated/prisma"
+import type { PrismaClient } from "@/lib/generated/prisma"
+
+type TransactionClient = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0]
+
+// ---------------------------------------------------------------------------
+// Internal helpers (NOT server actions — called within transactions)
+// ---------------------------------------------------------------------------
+
+/** Pop the front of the queue (oldest added_at), promote to DEBATER, update DebateState. */
+async function doPromoteFromQueue(
+  tx: TransactionClient,
+  sessionId: string
+): Promise<{ userId: string; displayName: string } | null> {
+  const front = await tx.audienceQueue.findFirst({
+    where: { session_id: sessionId },
+    orderBy: [{ added_at: "asc" }, { id: "asc" }],
+    include: { user: { select: { id: true, username: true, realname: true } } },
+  })
+  if (!front) return null
+
+  // Remove from queue
+  await tx.audienceQueue.delete({ where: { id: front.id } })
+
+  // Update ParticipatesIn to DEBATER
+  await tx.participatesIn.update({
+    where: {
+      user_id_session_id: {
+        user_id: front.user_id,
+        session_id: sessionId,
+      },
+    },
+    data: { session_role: SessionRole.DEBATER },
+  })
+
+  const displayName = front.user.realname || front.user.username
+  const promoted = { userId: front.user_id, displayName }
+
+  // Append to DebateState.debater_order if debate is active
+  const state = await tx.debateState.findUnique({
+    where: { session_id: sessionId },
+  })
+  if (state) {
+    const order = state.debater_order as { userId: string; displayName: string }[]
+    order.push(promoted)
+    await tx.debateState.update({
+      where: { session_id: sessionId },
+      data: { debater_order: order },
+    })
+  }
+
+  return promoted
+}
+
+/** Delete all votes cast by and targeting a user in a session. */
+async function cleanupUserVotes(
+  tx: TransactionClient,
+  sessionId: string,
+  userId: string
+) {
+  await tx.vote.deleteMany({
+    where: {
+      session_id: sessionId,
+      OR: [{ voter_id: userId }, { target_user_id: userId }],
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Exported server actions
+// ---------------------------------------------------------------------------
+
+export async function joinQueue(sessionId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  // Verify user is AUDIENCE in this session
+  const participation = await prisma.participatesIn.findUnique({
+    where: {
+      user_id_session_id: { user_id: user.id, session_id: sessionId },
+    },
+  })
+  if (!participation || participation.left_at) {
+    throw new Error("Not a participant in this session")
+  }
+  if (
+    participation.session_role !== SessionRole.AUDIENCE
+  ) {
+    throw new Error("Only audience members can join the queue")
+  }
+
+  // Check session not ended
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { status: true },
+  })
+  if (!session || session.status === "ENDED") {
+    throw new Error("Session has ended")
+  }
+
+  await prisma.audienceQueue.create({
+    data: {
+      session_id: sessionId,
+      user_id: user.id,
+    },
+  })
+}
+
+export async function leaveQueue(sessionId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  await prisma.$transaction(async (tx) => {
+    await tx.audienceQueue.deleteMany({
+      where: { session_id: sessionId, user_id: user.id },
+    })
+    // Also clean up any votes this user cast
+    await tx.vote.deleteMany({
+      where: { session_id: sessionId, voter_id: user.id },
+    })
+  })
+}
+
+export async function getQueue(sessionId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  const entries = await prisma.audienceQueue.findMany({
+    where: { session_id: sessionId },
+    orderBy: [{ added_at: "asc" }, { id: "asc" }],
+    include: {
+      user: { select: { id: true, username: true, realname: true } },
+    },
+  })
+
+  return entries.map((entry, index) => ({
+    id: entry.id,
+    userId: entry.user_id,
+    rank: index + 1,
+    displayName: entry.user.realname || entry.user.username,
+    addedAt: entry.added_at.toISOString(),
+  }))
+}
+
+export async function promoteFromQueue(sessionId: string) {
+  // Require moderator/host
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { host_id: true, moderator_id: true },
+  })
+  if (!session) throw new Error("Session not found")
+  if (session.host_id !== user.id && session.moderator_id !== user.id) {
+    throw new Error("Only moderator or host can promote from queue")
+  }
+
+  return prisma.$transaction(async (tx) => {
+    return doPromoteFromQueue(tx, sessionId)
+  })
+}
+
+export async function castKickVote(sessionId: string, targetUserId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+  if (user.id === targetUserId) throw new Error("Cannot vote to kick yourself")
+
+  return prisma.$transaction(async (tx) => {
+    // Verify voter is AUDIENCE
+    const voterPart = await tx.participatesIn.findUnique({
+      where: {
+        user_id_session_id: { user_id: user.id, session_id: sessionId },
+      },
+    })
+    if (!voterPart || voterPart.left_at || voterPart.session_role !== SessionRole.AUDIENCE) {
+      throw new Error("Only audience members can vote to kick")
+    }
+
+    // Verify target is DEBATER and not HOST
+    const targetPart = await tx.participatesIn.findUnique({
+      where: {
+        user_id_session_id: { user_id: targetUserId, session_id: sessionId },
+      },
+    })
+    if (!targetPart || targetPart.left_at || targetPart.session_role !== SessionRole.DEBATER) {
+      throw new Error("Target must be an active debater")
+    }
+
+    // Get session for threshold
+    const session = await tx.session.findUnique({
+      where: { id: sessionId },
+      select: { kick_threshold: true, host_id: true },
+    })
+    if (!session) throw new Error("Session not found")
+    if (targetUserId === session.host_id) throw new Error("Cannot vote to kick the host")
+
+    // Create vote (unique constraint prevents double-voting)
+    await tx.vote.create({
+      data: {
+        session_id: sessionId,
+        voter_id: user.id,
+        target_user_id: targetUserId,
+        vote_type: VoteType.KICK,
+      },
+    })
+
+    // Count votes and audience
+    const voteCount = await tx.vote.count({
+      where: {
+        session_id: sessionId,
+        target_user_id: targetUserId,
+        vote_type: VoteType.KICK,
+      },
+    })
+    const audienceCount = await tx.participatesIn.count({
+      where: {
+        session_id: sessionId,
+        left_at: null,
+        session_role: SessionRole.AUDIENCE,
+      },
+    })
+
+    const requiredVotes = Math.ceil((audienceCount * session.kick_threshold) / 100)
+    const kicked = voteCount >= requiredVotes && requiredVotes > 0
+
+    if (kicked) {
+      // Kick the target
+      await tx.participatesIn.update({
+        where: {
+          user_id_session_id: { user_id: targetUserId, session_id: sessionId },
+        },
+        data: { left_at: new Date() },
+      })
+
+      // Remove target from debater_order
+      const state = await tx.debateState.findUnique({
+        where: { session_id: sessionId },
+      })
+      if (state) {
+        const order = state.debater_order as { userId: string; displayName: string }[]
+        const newOrder = order.filter((d) => d.userId !== targetUserId)
+        // Adjust current_index if needed
+        let newIndex = state.current_index
+        const removedIndex = order.findIndex((d) => d.userId === targetUserId)
+        if (removedIndex < state.current_index) {
+          newIndex = Math.max(0, newIndex - 1)
+        } else if (removedIndex === state.current_index) {
+          newIndex = newOrder.length > 0 ? newIndex % newOrder.length : 0
+        }
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: { debater_order: newOrder, current_index: newIndex },
+        })
+      }
+
+      // Clean up all votes for this target
+      await tx.vote.deleteMany({
+        where: {
+          session_id: sessionId,
+          target_user_id: targetUserId,
+          vote_type: VoteType.KICK,
+        },
+      })
+
+      // Auto-promote from queue
+      await doPromoteFromQueue(tx, sessionId)
+    }
+
+    return { kicked, voteCount, requiredVotes }
+  })
+}
+
+export async function removeKickVote(sessionId: string, targetUserId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  await prisma.vote.deleteMany({
+    where: {
+      session_id: sessionId,
+      voter_id: user.id,
+      target_user_id: targetUserId,
+      vote_type: VoteType.KICK,
+    },
+  })
+}
+
+export async function getKickVotes(sessionId: string, targetUserId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  const [voteCount, audienceCount, userVote, session] = await Promise.all([
+    prisma.vote.count({
+      where: {
+        session_id: sessionId,
+        target_user_id: targetUserId,
+        vote_type: VoteType.KICK,
+      },
+    }),
+    prisma.participatesIn.count({
+      where: {
+        session_id: sessionId,
+        left_at: null,
+        session_role: SessionRole.AUDIENCE,
+      },
+    }),
+    prisma.vote.findFirst({
+      where: {
+        session_id: sessionId,
+        voter_id: user.id,
+        target_user_id: targetUserId,
+        vote_type: VoteType.KICK,
+      },
+    }),
+    prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { kick_threshold: true },
+    }),
+  ])
+
+  const threshold = session?.kick_threshold ?? 50
+  const requiredVotes = Math.ceil((audienceCount * threshold) / 100)
+
+  return {
+    voteCount,
+    requiredVotes,
+    userHasVoted: !!userVote,
+  }
+}
+
+// Re-export internal helpers for use by other server action modules
+export { doPromoteFromQueue, cleanupUserVotes }

--- a/lib/actions/queue.ts
+++ b/lib/actions/queue.ts
@@ -1,8 +1,8 @@
 "use server"
 
-import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
-import { SessionRole, VoteType } from "@/lib/generated/prisma"
+import { requireAuth, requireHostOrModerator } from "@/lib/actions/utils"
+import { SessionRole, SessionStatus, VoteType } from "@/lib/generated/prisma"
 import type { PrismaClient } from "@/lib/generated/prisma"
 
 type TransactionClient = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0]
@@ -11,14 +11,14 @@ type TransactionClient = Parameters<Parameters<PrismaClient["$transaction"]>[0]>
 // Internal helpers (NOT server actions — called within transactions)
 // ---------------------------------------------------------------------------
 
-/** Pop the front of the queue (oldest added_at), promote to DEBATER, update DebateState. */
+/** Pop the front of the queue (oldest joined_queue), promote to DEBATER, update DebateState. */
 async function doPromoteFromQueue(
   tx: TransactionClient,
   sessionId: string
 ): Promise<{ userId: string; displayName: string } | null> {
   const front = await tx.audienceQueue.findFirst({
     where: { session_id: sessionId },
-    orderBy: [{ added_at: "asc" }, { id: "asc" }],
+    orderBy: [{ joined_queue: "asc" }, { id: "asc" }],
     include: { user: { select: { id: true, username: true, realname: true } } },
   })
   if (!front) return null
@@ -53,6 +53,17 @@ async function doPromoteFromQueue(
     })
   }
 
+  // Log role transition
+  await tx.roleHistory.create({
+    data: {
+      session_id: sessionId,
+      user_id: front.user_id,
+      old_role: SessionRole.AUDIENCE,
+      new_role: SessionRole.DEBATER,
+      reason: "Promoted from queue",
+    },
+  })
+
   return promoted
 }
 
@@ -75,11 +86,16 @@ async function cleanupUserVotes(
 // ---------------------------------------------------------------------------
 
 export async function joinQueue(sessionId: string) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error("Not authenticated")
+  const user = await requireAuth()
 
-  // Verify user is AUDIENCE in this session
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { status: true },
+  })
+  if (!session) throw new Error("Session not found")
+  if (session.status !== SessionStatus.LIVE) throw new Error("Session is not live")
+
+  // Verify user is an audience member
   const participation = await prisma.participatesIn.findUnique({
     where: {
       user_id_session_id: { user_id: user.id, session_id: sessionId },
@@ -88,22 +104,11 @@ export async function joinQueue(sessionId: string) {
   if (!participation || participation.left_at) {
     throw new Error("Not a participant in this session")
   }
-  if (
-    participation.session_role !== SessionRole.AUDIENCE
-  ) {
+  if (participation.session_role !== SessionRole.AUDIENCE) {
     throw new Error("Only audience members can join the queue")
   }
 
-  // Check session not ended
-  const session = await prisma.session.findUnique({
-    where: { id: sessionId },
-    select: { status: true },
-  })
-  if (!session || session.status === "ENDED") {
-    throw new Error("Session has ended")
-  }
-
-  await prisma.audienceQueue.create({
+  return await prisma.audienceQueue.create({
     data: {
       session_id: sessionId,
       user_id: user.id,
@@ -112,9 +117,7 @@ export async function joinQueue(sessionId: string) {
 }
 
 export async function leaveQueue(sessionId: string) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error("Not authenticated")
+  const user = await requireAuth()
 
   await prisma.$transaction(async (tx) => {
     await tx.audienceQueue.deleteMany({
@@ -128,13 +131,12 @@ export async function leaveQueue(sessionId: string) {
 }
 
 export async function getQueue(sessionId: string) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await requireAuth()
   if (!user) throw new Error("Not authenticated")
 
   const entries = await prisma.audienceQueue.findMany({
     where: { session_id: sessionId },
-    orderBy: [{ added_at: "asc" }, { id: "asc" }],
+    orderBy: [{ joined_queue: "asc" }, { id: "asc" }],
     include: {
       user: { select: { id: true, username: true, realname: true } },
     },
@@ -145,34 +147,60 @@ export async function getQueue(sessionId: string) {
     userId: entry.user_id,
     rank: index + 1,
     displayName: entry.user.realname || entry.user.username,
-    addedAt: entry.added_at.toISOString(),
+    addedAt: entry.joined_queue.toISOString(),
   }))
 }
 
-export async function promoteFromQueue(sessionId: string) {
-  // Require moderator/host
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error("Not authenticated")
-
-  const session = await prisma.session.findUnique({
-    where: { id: sessionId },
-    select: { host_id: true, moderator_id: true },
-  })
-  if (!session) throw new Error("Session not found")
-  if (session.host_id !== user.id && session.moderator_id !== user.id) {
-    throw new Error("Only moderator or host can promote from queue")
-  }
+export async function promoteFromQueue(sessionId: string, userId?: string) {
+  await requireHostOrModerator(sessionId)
 
   return prisma.$transaction(async (tx) => {
-    return doPromoteFromQueue(tx, sessionId)
+    if (userId) {
+      // Promote specific user
+      const queueEntry = await tx.audienceQueue.findUnique({
+        where: { session_id_user_id: { session_id: sessionId, user_id: userId } },
+      })
+      if (!queueEntry) throw new Error("No one in the queue")
+
+      await tx.participatesIn.update({
+        where: {
+          user_id_session_id: {
+            user_id: userId,
+            session_id: sessionId,
+          },
+        },
+        data: { session_role: SessionRole.DEBATER },
+      })
+      await tx.audienceQueue.delete({
+        where: {
+          session_id_user_id: {
+            session_id: sessionId,
+            user_id: userId,
+          },
+        },
+      })
+      await tx.roleHistory.create({
+        data: {
+          session_id: sessionId,
+          user_id: userId,
+          old_role: SessionRole.AUDIENCE,
+          new_role: SessionRole.DEBATER,
+          reason: "Promoted from queue",
+        },
+      })
+      return { promotedUserId: userId }
+    }
+
+    // FIFO promote
+    return doPromoteFromQueue(tx, sessionId).then((result) => {
+      if (!result) throw new Error("No one in the queue")
+      return { promotedUserId: result.userId }
+    })
   })
 }
 
 export async function castKickVote(sessionId: string, targetUserId: string) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error("Not authenticated")
+  const user = await requireAuth()
   if (user.id === targetUserId) throw new Error("Cannot vote to kick yourself")
 
   return prisma.$transaction(async (tx) => {
@@ -272,6 +300,17 @@ export async function castKickVote(sessionId: string, targetUserId: string) {
         },
       })
 
+      // Log role transition
+      await tx.roleHistory.create({
+        data: {
+          session_id: sessionId,
+          user_id: targetUserId,
+          old_role: SessionRole.DEBATER,
+          new_role: SessionRole.AUDIENCE,
+          reason: "Kicked by audience vote",
+        },
+      })
+
       // Auto-promote from queue
       await doPromoteFromQueue(tx, sessionId)
     }
@@ -281,9 +320,7 @@ export async function castKickVote(sessionId: string, targetUserId: string) {
 }
 
 export async function removeKickVote(sessionId: string, targetUserId: string) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error("Not authenticated")
+  const user = await requireAuth()
 
   await prisma.vote.deleteMany({
     where: {
@@ -296,8 +333,7 @@ export async function removeKickVote(sessionId: string, targetUserId: string) {
 }
 
 export async function getKickVotes(sessionId: string, targetUserId: string) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await requireAuth()
   if (!user) throw new Error("Not authenticated")
 
   const [voteCount, audienceCount, userVote, session] = await Promise.all([

--- a/lib/actions/recording.ts
+++ b/lib/actions/recording.ts
@@ -1,0 +1,53 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+import { requireAuth, requireHostOrModerator, requireParticipant } from "@/lib/actions/utils"
+
+export async function createRecording(
+  sessionId: string,
+  url: string,
+  duration?: number,
+  fileSize?: number,
+  mimeType?: string
+) {
+  const { user } = await requireHostOrModerator(sessionId)
+
+  return await prisma.recording.create({
+    data: {
+      session_id: sessionId,
+      recorded_by: user.id,
+      url,
+      duration: duration ?? null,
+      file_size: fileSize ?? null,
+      mime_type: mimeType ?? null,
+    },
+  })
+}
+
+export async function getRecordingsBySession(sessionId: string) {
+  await requireParticipant(sessionId)
+
+  return await prisma.recording.findMany({
+    where: { session_id: sessionId },
+    orderBy: { created_at: "desc" },
+    include: {
+      recorder: { select: { id: true, username: true, realname: true } },
+    },
+  })
+}
+
+export async function deleteRecording(recordingId: string) {
+  const user = await requireAuth()
+
+  const recording = await prisma.recording.findUnique({
+    where: { id: recordingId },
+    include: { session: { select: { host_id: true } } },
+  })
+  if (!recording) throw new Error("Recording not found")
+
+  if (recording.recorded_by !== user.id && recording.session.host_id !== user.id) {
+    throw new Error("Not authorized to delete this recording")
+  }
+
+  await prisma.recording.delete({ where: { id: recordingId } })
+}

--- a/lib/actions/session.ts
+++ b/lib/actions/session.ts
@@ -25,9 +25,11 @@ export async function createSession(formData: {
 
     if (!formData.name.trim()) throw new Error("Room name is required")
 
-    // Validate capacities
+    // Validate capacities and bounds
     if (formData.audienceCapacity < 0) throw new Error("Audience capacity cannot be negative")
+    if (formData.audienceCapacity > 1000) throw new Error("Audience capacity cannot exceed 1000")
     if (formData.turnLength < 1) throw new Error("Turn length must be at least 1 second")
+    if (formData.turnLength > 1800) throw new Error("Turn length cannot exceed 30 minutes (1800 seconds)")
 
     // Panel-specific validation
     if (formData.type === SessionType.PANEL) {
@@ -272,6 +274,8 @@ export async function joinSessionAsDebater(sessionId: string, isProponent: boole
         },
     })
 
+    const previousRole = existing?.session_role ?? SessionRole.AUDIENCE
+
     if (existing) {
         await prisma.participatesIn.update({
             where: {
@@ -291,6 +295,17 @@ export async function joinSessionAsDebater(sessionId: string, isProponent: boole
             },
         })
     }
+
+    // Log role transition
+    await prisma.roleHistory.create({
+        data: {
+            session_id: sessionId,
+            user_id: user.id,
+            old_role: previousRole,
+            new_role: SessionRole.DEBATER,
+            reason: "Joined as debater",
+        },
+    })
 }
 
 export async function leaveSession(sessionId: string) {
@@ -363,15 +378,37 @@ export async function assignModerator(sessionId: string, targetUserId: string) {
   if (session.host_id !== user.id) throw new Error("Only the host can assign a moderator")
   if (targetUserId === user.id) throw new Error("Host cannot assign themselves as moderator")
 
-  // Demote previous moderator back to AUDIENCE (if any)
-  if (session.moderator_id && session.moderator_id !== targetUserId) {
-    await prisma.participatesIn.updateMany({
-      where: { session_id: sessionId, user_id: session.moderator_id },
-      data: { session_role: SessionRole.AUDIENCE },
-    })
+  // Verify target is an active participant and get role for history logging
+  const targetParticipation = await prisma.participatesIn.findUnique({
+    where: { user_id_session_id: { user_id: targetUserId, session_id: sessionId } },
+    select: { session_role: true, left_at: true },
+  })
+  if (!targetParticipation || targetParticipation.left_at !== null) {
+    throw new Error("Target user is not an active participant in this session")
   }
 
-  await prisma.$transaction([
+  const txOps = []
+
+  // Demote previous moderator back to AUDIENCE (if any)
+  if (session.moderator_id && session.moderator_id !== targetUserId) {
+    txOps.push(
+      prisma.participatesIn.updateMany({
+        where: { session_id: sessionId, user_id: session.moderator_id },
+        data: { session_role: SessionRole.AUDIENCE },
+      }),
+      prisma.roleHistory.create({
+        data: {
+          session_id: sessionId,
+          user_id: session.moderator_id,
+          old_role: SessionRole.MODERATOR,
+          new_role: SessionRole.AUDIENCE,
+          reason: "Demoted: new moderator assigned",
+        },
+      })
+    )
+  }
+
+  txOps.push(
     prisma.session.update({
       where: { id: sessionId },
       data: { moderator_id: targetUserId },
@@ -380,7 +417,18 @@ export async function assignModerator(sessionId: string, targetUserId: string) {
       where: { user_id_session_id: { user_id: targetUserId, session_id: sessionId } },
       data: { session_role: SessionRole.MODERATOR },
     }),
-  ])
+    prisma.roleHistory.create({
+      data: {
+        session_id: sessionId,
+        user_id: targetUserId,
+        old_role: targetParticipation.session_role,
+        new_role: SessionRole.MODERATOR,
+        reason: "Assigned as moderator by host",
+      },
+    })
+  )
+
+  await prisma.$transaction(txOps)
 }
 
 export async function kickParticipant(sessionId: string, targetUserId: string) {
@@ -399,12 +447,15 @@ export async function kickParticipant(sessionId: string, targetUserId: string) {
   }
   if (targetUserId === user.id) throw new Error("Cannot kick yourself")
 
+  // Verify target is an active participant and get role for history logging
   const participation = await prisma.participatesIn.findUnique({
-    where: {
-      user_id_session_id: { user_id: targetUserId, session_id: sessionId },
-    },
+    where: { user_id_session_id: { user_id: targetUserId, session_id: sessionId } },
+    select: { session_role: true, left_at: true },
   })
-  const wasDebater = participation?.session_role === SessionRole.DEBATER
+  if (!participation || participation.left_at !== null) {
+    throw new Error("Target user is not an active participant in this session")
+  }
+  const wasDebater = participation.session_role === SessionRole.DEBATER
 
   await prisma.$transaction(async (tx) => {
     await tx.participatesIn.update({
@@ -446,6 +497,47 @@ export async function kickParticipant(sessionId: string, targetUserId: string) {
       await doPromoteFromQueue(tx, sessionId)
     }
   })
+
+  if (participation) {
+    await prisma.roleHistory.create({
+      data: {
+        session_id: sessionId,
+        user_id: targetUserId,
+        old_role: participation.session_role,
+        new_role: SessionRole.AUDIENCE,
+        reason: "Kicked by moderator/host",
+      },
+    })
+  }
+}
+
+export async function promoteToDebater(sessionId: string, targetUserId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { host_id: true, moderator_id: true, status: true },
+  })
+  if (!session) throw new Error("Session not found")
+  if (session.host_id !== user.id && session.moderator_id !== user.id) {
+    throw new Error("Only moderators or hosts can promote participants")
+  }
+  if (session.status !== SessionStatus.WAITING) {
+    throw new Error("Can only promote participants before the debate starts")
+  }
+  if (targetUserId === user.id) throw new Error("Cannot promote yourself")
+
+  await prisma.participatesIn.update({
+    where: {
+      user_id_session_id: {
+        user_id: targetUserId,
+        session_id: sessionId,
+      },
+    },
+    data: { session_role: SessionRole.DEBATER },
+  })
 }
 
 export async function updateSessionStatus(sessionId: string, status: SessionStatus) {
@@ -471,6 +563,10 @@ export async function updateSessionStatus(sessionId: string, status: SessionStat
 
     const data : Prisma.SessionUpdateInput = { }
     data.status = status
+
+    if (status === SessionStatus.LIVE) {
+        data.format_locked = true
+    }
 
     if (status === SessionStatus.ENDED) {
         data.ended_at = new Date()

--- a/lib/actions/session.ts
+++ b/lib/actions/session.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma"
 import { generateRoomCode, SessionCapacityInfo, getSessionCapacity, getTotalDebaterCapacity } from "@/lib/utils"
 import { redirect } from "next/navigation"
 import { Prisma, SessionRole, SessionStatus, SessionType } from "@/lib/generated/prisma"
+import { doPromoteFromQueue, cleanupUserVotes } from "@/lib/actions/queue"
 
 export async function createSession(formData: {
     name: string
@@ -15,6 +16,7 @@ export async function createSession(formData: {
     debaterCapacityPanel: number | null
     audienceCapacity: number
     turnLength: number
+    kickThreshold?: number
 }) 
 {
     const supabase = await createClient()
@@ -68,6 +70,7 @@ export async function createSession(formData: {
             debater_capacity_panel: formData.debaterCapacityPanel,
             audience_capacity: formData.audienceCapacity,
             turn_length: formData.turnLength,
+            kick_threshold: formData.kickThreshold ?? 50,
             participates_ins: {
                 create: {
                     user_id: user.id,
@@ -295,14 +298,55 @@ export async function leaveSession(sessionId: string) {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) throw new Error("Not authenticated")
 
-    await prisma.participatesIn.update({
+    const participation = await prisma.participatesIn.findUnique({
         where: {
-            user_id_session_id: {
-                user_id: user.id,
-                session_id: sessionId,
-            },
+            user_id_session_id: { user_id: user.id, session_id: sessionId },
         },
-        data: { left_at: new Date() },
+    })
+    if (!participation) throw new Error("Not a participant")
+
+    const wasDebater = participation.session_role === SessionRole.DEBATER
+
+    await prisma.$transaction(async (tx) => {
+        // Mark as left
+        await tx.participatesIn.update({
+            where: {
+                user_id_session_id: { user_id: user.id, session_id: sessionId },
+            },
+            data: { left_at: new Date() },
+        })
+
+        // Remove from queue if queued
+        await tx.audienceQueue.deleteMany({
+            where: { session_id: sessionId, user_id: user.id },
+        })
+
+        // Clean up votes
+        await cleanupUserVotes(tx, sessionId, user.id)
+
+        // If was a debater, remove from debater_order and auto-promote
+        if (wasDebater) {
+            const state = await tx.debateState.findUnique({
+                where: { session_id: sessionId },
+            })
+            if (state) {
+                const order = state.debater_order as { userId: string; displayName: string }[]
+                const removedIndex = order.findIndex((d) => d.userId === user.id)
+                const newOrder = order.filter((d) => d.userId !== user.id)
+                let newIndex = state.current_index
+                if (removedIndex < state.current_index) {
+                    newIndex = Math.max(0, newIndex - 1)
+                } else if (removedIndex === state.current_index && newOrder.length > 0) {
+                    newIndex = newIndex % newOrder.length
+                }
+                await tx.debateState.update({
+                    where: { session_id: sessionId },
+                    data: { debater_order: newOrder, current_index: newIndex },
+                })
+            }
+
+            await doPromoteFromQueue(tx, sessionId)
+        }
     })
 }
 
@@ -353,17 +397,54 @@ export async function kickParticipant(sessionId: string, targetUserId: string) {
   if (session.host_id !== user.id && session.moderator_id !== user.id) {
     throw new Error("Only moderators or hosts can kick participants")
   }
-  // Cannot kick yourself
   if (targetUserId === user.id) throw new Error("Cannot kick yourself")
 
-  await prisma.participatesIn.update({
+  const participation = await prisma.participatesIn.findUnique({
     where: {
-      user_id_session_id: {
-        user_id: targetUserId,
-        session_id: sessionId,
-      },
+      user_id_session_id: { user_id: targetUserId, session_id: sessionId },
     },
-    data: { left_at: new Date() },
+  })
+  const wasDebater = participation?.session_role === SessionRole.DEBATER
+
+  await prisma.$transaction(async (tx) => {
+    await tx.participatesIn.update({
+      where: {
+        user_id_session_id: { user_id: targetUserId, session_id: sessionId },
+      },
+      data: { left_at: new Date() },
+    })
+
+    // Remove from queue if queued
+    await tx.audienceQueue.deleteMany({
+      where: { session_id: sessionId, user_id: targetUserId },
+    })
+
+    // Clean up votes
+    await cleanupUserVotes(tx, sessionId, targetUserId)
+
+    // If was a debater, remove from debater_order and auto-promote
+    if (wasDebater) {
+      const state = await tx.debateState.findUnique({
+        where: { session_id: sessionId },
+      })
+      if (state) {
+        const order = state.debater_order as { userId: string; displayName: string }[]
+        const removedIndex = order.findIndex((d) => d.userId === targetUserId)
+        const newOrder = order.filter((d) => d.userId !== targetUserId)
+        let newIndex = state.current_index
+        if (removedIndex < state.current_index) {
+          newIndex = Math.max(0, newIndex - 1)
+        } else if (removedIndex === state.current_index && newOrder.length > 0) {
+          newIndex = newIndex % newOrder.length
+        }
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: { debater_order: newOrder, current_index: newIndex },
+        })
+      }
+
+      await doPromoteFromQueue(tx, sessionId)
+    }
   })
 }
 

--- a/lib/actions/team.ts
+++ b/lib/actions/team.ts
@@ -1,0 +1,59 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+import { requireHostOrModerator } from "@/lib/actions/utils"
+import { SessionType } from "@/lib/generated/prisma"
+
+export async function assignTeam(
+  sessionId: string,
+  userId: string,
+  team: string
+) {
+  const { session } = await requireHostOrModerator(sessionId)
+
+  if (session.type !== SessionType.TEAM) {
+    throw new Error("Team assignments are only for TEAM format sessions")
+  }
+
+  if (team !== "proponent" && team !== "opponent") {
+    throw new Error("Team must be 'proponent' or 'opponent'")
+  }
+
+  return await prisma.teamAssignment.upsert({
+    where: {
+      session_id_user_id: {
+        session_id: sessionId,
+        user_id: userId,
+      },
+    },
+    create: {
+      session_id: sessionId,
+      user_id: userId,
+      team,
+    },
+    update: { team },
+  })
+}
+
+export async function getTeamAssignments(sessionId: string) {
+  return await prisma.teamAssignment.findMany({
+    where: { session_id: sessionId },
+    include: {
+      user: { select: { id: true, username: true, realname: true } },
+    },
+    orderBy: { assigned_at: "asc" },
+  })
+}
+
+export async function removeFromTeam(sessionId: string, userId: string) {
+  await requireHostOrModerator(sessionId)
+
+  await prisma.teamAssignment.delete({
+    where: {
+      session_id_user_id: {
+        session_id: sessionId,
+        user_id: userId,
+      },
+    },
+  })
+}

--- a/lib/actions/transcript.ts
+++ b/lib/actions/transcript.ts
@@ -1,0 +1,37 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+import { requireParticipant } from "@/lib/actions/utils"
+
+export async function createTranscriptSegment(
+  sessionId: string,
+  content: string,
+  timestamp: number,
+  duration?: number,
+  confidence?: number
+) {
+  const user = await requireParticipant(sessionId)
+
+  return await prisma.transcript.create({
+    data: {
+      session_id: sessionId,
+      speaker_id: user.id,
+      content,
+      timestamp,
+      duration: duration ?? null,
+      confidence: confidence ?? null,
+    },
+  })
+}
+
+export async function getTranscriptBySession(sessionId: string) {
+  await requireParticipant(sessionId)
+
+  return await prisma.transcript.findMany({
+    where: { session_id: sessionId },
+    orderBy: { timestamp: "asc" },
+    include: {
+      speaker: { select: { id: true, username: true, realname: true } },
+    },
+  })
+}

--- a/lib/actions/user.ts
+++ b/lib/actions/user.ts
@@ -2,6 +2,27 @@
 
 import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
+import { requireAuth } from "@/lib/actions/utils"
+
+const VALID_THEMES = ["dark", "light", "system"] as const
+const VALID_FONT_SIZES = ["small", "medium", "large"] as const
+const VALID_PROFILE_VISIBILITY = ["public", "private"] as const
+
+type UserPreferences = {
+    bio?: string | null
+    notify_invitations?: boolean
+    notify_messages?: boolean
+    notify_weekly_digest?: boolean
+    profile_visibility?: string
+    show_online_status?: boolean
+    allow_direct_messages?: boolean
+    theme?: string
+    font_size?: string
+    animations_enabled?: boolean
+    language?: string
+    timezone?: string
+    date_format?: string
+}
 
 export async function ensureUserProfile() {
     const supabase = await createClient()
@@ -35,4 +56,50 @@ export async function ensureUserProfile() {
     })
 
     return result
+}
+
+export async function getUserPreferences() {
+    const user = await requireAuth()
+
+    return await prisma.user.findUnique({
+        where: { id: user.id },
+        select: {
+            username: true,
+            email: true,
+            realname: true,
+            bio: true,
+            notify_invitations: true,
+            notify_messages: true,
+            notify_weekly_digest: true,
+            profile_visibility: true,
+            show_online_status: true,
+            allow_direct_messages: true,
+            theme: true,
+            font_size: true,
+            animations_enabled: true,
+            language: true,
+            timezone: true,
+            date_format: true,
+        },
+    })
+}
+
+export async function updateUserPreferences(prefs: UserPreferences) {
+    const user = await requireAuth()
+
+    // Validate allowed values
+    if (prefs.theme !== undefined && !VALID_THEMES.includes(prefs.theme as typeof VALID_THEMES[number])) {
+        throw new Error("Theme must be 'dark', 'light', or 'system'")
+    }
+    if (prefs.font_size !== undefined && !VALID_FONT_SIZES.includes(prefs.font_size as typeof VALID_FONT_SIZES[number])) {
+        throw new Error("Font size must be 'small', 'medium', or 'large'")
+    }
+    if (prefs.profile_visibility !== undefined && !VALID_PROFILE_VISIBILITY.includes(prefs.profile_visibility as typeof VALID_PROFILE_VISIBILITY[number])) {
+        throw new Error("Profile visibility must be 'public' or 'private'")
+    }
+
+    return await prisma.user.update({
+        where: { id: user.id },
+        data: prefs,
+    })
 }

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -1,0 +1,57 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+import { prisma } from "@/lib/prisma"
+
+/**
+ * Require authenticated user. Returns the Supabase user object.
+ * Throws if not authenticated.
+ */
+export async function requireAuth() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error("Not authenticated")
+  return user
+}
+
+/**
+ * Require that the current user is the host or moderator of the given session.
+ * Returns both the user and session objects.
+ */
+export async function requireHostOrModerator(sessionId: string) {
+  const user = await requireAuth()
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+  })
+  if (!session) throw new Error("Session not found")
+
+  if (session.host_id !== user.id && session.moderator_id !== user.id) {
+    throw new Error("Not authorized")
+  }
+
+  return { user, session }
+}
+
+/**
+ * Verify that the authenticated user is an active participant in the session.
+ * Returns the user object.
+ */
+export async function requireParticipant(sessionId: string) {
+  const user = await requireAuth()
+
+  const participation = await prisma.participatesIn.findUnique({
+    where: {
+      user_id_session_id: {
+        user_id: user.id,
+        session_id: sessionId,
+      },
+    },
+  })
+
+  if (!participation || participation.left_at) {
+    throw new Error("Not a participant in this session")
+  }
+
+  return user
+}

--- a/lib/actions/vote.ts
+++ b/lib/actions/vote.ts
@@ -1,0 +1,85 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+import { requireAuth } from "@/lib/actions/utils"
+import { SessionStatus, VoteType } from "@/lib/generated/prisma"
+
+export async function castVote(
+  sessionId: string,
+  targetUserId: string,
+  voteType: VoteType
+) {
+  const user = await requireAuth()
+
+  if (user.id === targetUserId) throw new Error("Cannot vote for yourself")
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { status: true },
+  })
+  if (!session) throw new Error("Session not found")
+  if (session.status !== SessionStatus.LIVE) throw new Error("Session is not live")
+
+  // Verify voter is an active participant
+  const participation = await prisma.participatesIn.findUnique({
+    where: {
+      user_id_session_id: { user_id: user.id, session_id: sessionId },
+    },
+  })
+  if (!participation || participation.left_at) {
+    throw new Error("Not a participant in this session")
+  }
+
+  return await prisma.vote.upsert({
+    where: {
+      session_id_voter_id_target_user_id_vote_type: {
+        session_id: sessionId,
+        voter_id: user.id,
+        target_user_id: targetUserId,
+        vote_type: voteType,
+      },
+    },
+    create: {
+      session_id: sessionId,
+      voter_id: user.id,
+      target_user_id: targetUserId,
+      vote_type: voteType,
+    },
+    update: {},
+  })
+}
+
+export async function retractVote(
+  sessionId: string,
+  targetUserId: string,
+  voteType: VoteType
+) {
+  const user = await requireAuth()
+
+  await prisma.vote.delete({
+    where: {
+      session_id_voter_id_target_user_id_vote_type: {
+        session_id: sessionId,
+        voter_id: user.id,
+        target_user_id: targetUserId,
+        vote_type: voteType,
+      },
+    },
+  })
+}
+
+export async function getVoteCounts(
+  sessionId: string,
+  targetUserId: string,
+  voteType: VoteType
+) {
+  const count = await prisma.vote.count({
+    where: {
+      session_id: sessionId,
+      target_user_id: targetUserId,
+      vote_type: voteType,
+    },
+  })
+
+  return { count }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -40,6 +41,7 @@
         "@vitest/coverage-v8": "^2.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "jose": "^6.2.2",
         "jsdom": "^29.0.1",
         "prisma": "^7.3.0",
         "socket.io": "^4.8.3",
@@ -168,6 +170,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -532,6 +535,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -580,6 +584,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -589,7 +594,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -2104,6 +2110,7 @@
       "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.1"
       },
@@ -4134,6 +4141,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.93.3.tgz",
       "integrity": "sha512-paUqEqdBI9ztr/4bbMoCgeJ6M8ZTm2fpfjSOlzarPuzYveKFM20ZfDZqUpi9CFfYagYj5Iv3m3ztUjaI9/tM1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.93.3",
         "@supabase/functions-js": "2.93.3",
@@ -4431,7 +4439,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4452,7 +4459,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4501,8 +4507,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -4578,6 +4583,7 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4588,6 +4594,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4646,6 +4653,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -5319,6 +5327,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5740,6 +5749,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6301,7 +6311,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6347,8 +6356,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -6798,6 +6806,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6983,6 +6992,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7920,6 +7930,7 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8580,6 +8591,16 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9127,7 +9148,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9853,6 +9873,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -10117,7 +10138,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10133,7 +10153,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10144,7 +10163,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10157,8 +10175,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prisma": {
       "version": "7.3.0",
@@ -10167,6 +10184,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.3.0",
         "@prisma/dev": "0.20.0",
@@ -10289,6 +10307,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10298,6 +10317,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11011,6 +11031,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -11513,6 +11543,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11751,6 +11782,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11977,6 +12009,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -12082,6 +12115,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -12524,6 +12558,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
@@ -47,6 +48,7 @@
     "@vitest/coverage-v8": "^2.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "jose": "^6.2.2",
     "jsdom": "^29.0.1",
     "prisma": "^7.3.0",
     "socket.io": "^4.8.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,8 @@ datasource db {
   provider = "postgresql"
 }
 
+// ── Enums ──
+
 enum UniversalRole {
   ADMIN
   USER
@@ -33,9 +35,14 @@ enum SessionStatus {
   ENDED
 }
 
+/// Type of vote cast by audience members
 enum VoteType {
   KICK
+  PROMOTE
 }
+
+// ── Models ──
+
 
 model User {
   id         String        @id @db.Uuid
@@ -45,12 +52,40 @@ model User {
   role       UniversalRole @default(USER)
   created_at DateTime      @default(now())
 
+  // Profile
+  bio String?
+
+  // Notification preferences
+  notify_invitations   Boolean @default(true)
+  notify_messages      Boolean @default(true)
+  notify_weekly_digest Boolean @default(false)
+
+  // Privacy preferences
+  profile_visibility    String  @default("public")
+  show_online_status    Boolean @default(true)
+  allow_direct_messages Boolean @default(true)
+
+  // Appearance preferences
+  theme              String  @default("dark")
+  font_size          String  @default("medium")
+  animations_enabled Boolean @default(true)
+
+  // Language & region preferences
+  language    String @default("en")
+  timezone    String @default("UTC")
+  date_format String @default("MM/DD/YYYY")
+
+  // Relations
   hosted_sessions    Session[]        @relation("HostToSession")
   moderated_sessions Session[]        @relation("ModeratorToSession")
   participates_ins   ParticipatesIn[]
-  queue_entries      AudienceQueue[]
-  votes_cast         Vote[]           @relation("VoteCaster")
-  votes_received     Vote[]           @relation("VoteTarget")
+  transcripts        Transcript[]
+  recordings         Recording[]
+  votes_cast         Vote[]           @relation("VoterToVote")
+  votes_received     Vote[]           @relation("TargetToVote")
+  audience_queues    AudienceQueue[]
+  team_assignments   TeamAssignment[]
+  role_history       RoleHistory[]
 }
 
 model ParticipatesIn {
@@ -81,6 +116,8 @@ model Session {
   audience_capacity          Int           @default(10)
   turn_length                Int           @default(120)
   kick_threshold             Int           @default(50)
+  /// Whether the debate format is locked (true after debate begins, per REQ-1.8)
+  format_locked              Boolean       @default(false)
   created_at                 DateTime      @default(now())
   ended_at                   DateTime?
 
@@ -88,8 +125,12 @@ model Session {
   moderator        User?            @relation("ModeratorToSession", fields: [moderator_id], references: [id])
   participates_ins ParticipatesIn[]
   debate_state     DebateState?
-  queue_entries    AudienceQueue[]
+  transcripts      Transcript[]
+  recordings       Recording[]
   votes            Vote[]
+  audience_queue   AudienceQueue[]
+  team_assignments TeamAssignment[]
+  role_history     RoleHistory[]
 }
 
 model DebateState {
@@ -105,18 +146,46 @@ model DebateState {
   session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
 }
 
-model AudienceQueue {
+/// Speaker-attributed, timestamped transcript segment (REQ-6)
+model Transcript {
   id         String   @id @default(cuid())
   session_id String
-  user_id    String   @db.Uuid
-  added_at   DateTime @default(now())
+  speaker_id String   @db.Uuid
+  content    String
+  /// Seconds since debate start
+  timestamp  Float
+  /// Duration of this speech segment in seconds
+  duration   Float?
+  /// Confidence score from the transcription engine (0.0 - 1.0)
+  confidence Float?
+  created_at DateTime @default(now())
 
   session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
-  user    User    @relation(fields: [user_id], references: [id])
+  speaker User    @relation(fields: [speaker_id], references: [id])
 
-  @@unique([session_id, user_id])
-  @@index([session_id, added_at])
+  @@index([session_id, timestamp])
 }
+
+/// Video recording link for a completed session (REQ-8)
+model Recording {
+  id          String   @id @default(cuid())
+  session_id  String
+  recorded_by String   @db.Uuid
+  url         String
+  /// Duration in seconds
+  duration    Float?
+  /// File size in bytes
+  file_size   Int?
+  mime_type   String?
+  created_at  DateTime @default(now())
+
+  session  Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  recorder User    @relation(fields: [recorded_by], references: [id])
+
+  @@index([session_id])
+}
+
+/// Audience vote to kick or promote a participant (REQ-4)
 
 model Vote {
   id             String   @id @default(cuid())
@@ -127,8 +196,59 @@ model Vote {
   created_at     DateTime @default(now())
 
   session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
-  voter   User    @relation("VoteCaster", fields: [voter_id], references: [id])
-  target  User    @relation("VoteTarget", fields: [target_user_id], references: [id])
+  voter   User    @relation("VoterToVote", fields: [voter_id], references: [id])
+  target  User    @relation("TargetToVote", fields: [target_user_id], references: [id])
 
+  /// Each user can only cast one vote of each type against each target per session
   @@unique([session_id, voter_id, target_user_id, vote_type])
+  @@index([session_id])
+}
+
+/// FIFO queue for audience members waiting to speak (REQ-4)
+model AudienceQueue {
+  id           String   @id @default(cuid())
+  session_id   String
+  user_id      String   @db.Uuid
+  joined_queue DateTime @default(now())
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [user_id], references: [id])
+
+  /// A user can only be in the queue once per session
+  @@unique([session_id, user_id])
+  @@index([session_id])
+}
+
+/// Team membership for team debates
+model TeamAssignment {
+  id          String   @id @default(cuid())
+  session_id  String
+  user_id     String   @db.Uuid
+  /// Team identifier: "proponent" or "opponent"
+  team        String
+  assigned_at DateTime @default(now())
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [user_id], references: [id])
+
+  /// A user can only be on one team per session
+  @@unique([session_id, user_id])
+  @@index([session_id])
+}
+
+/// Tracks role transitions with timestamps for audit purposes (REQ-2.8)
+model RoleHistory {
+  id         String      @id @default(cuid())
+  session_id String
+  user_id    String      @db.Uuid
+  old_role   SessionRole
+  new_role   SessionRole
+  changed_at DateTime    @default(now())
+  reason     String?
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [user_id], references: [id])
+
+  @@index([session_id])
+  @@index([user_id])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,10 @@ enum SessionStatus {
   ENDED
 }
 
+enum VoteType {
+  KICK
+}
+
 model User {
   id         String        @id @db.Uuid
   username   String        @unique
@@ -44,6 +48,9 @@ model User {
   hosted_sessions    Session[]        @relation("HostToSession")
   moderated_sessions Session[]        @relation("ModeratorToSession")
   participates_ins   ParticipatesIn[]
+  queue_entries      AudienceQueue[]
+  votes_cast         Vote[]           @relation("VoteCaster")
+  votes_received     Vote[]           @relation("VoteTarget")
 }
 
 model ParticipatesIn {
@@ -73,6 +80,7 @@ model Session {
   debater_capacity_panel     Int?          @default(5)
   audience_capacity          Int           @default(10)
   turn_length                Int           @default(120)
+  kick_threshold             Int           @default(50)
   created_at                 DateTime      @default(now())
   ended_at                   DateTime?
 
@@ -80,6 +88,8 @@ model Session {
   moderator        User?            @relation("ModeratorToSession", fields: [moderator_id], references: [id])
   participates_ins ParticipatesIn[]
   debate_state     DebateState?
+  queue_entries    AudienceQueue[]
+  votes            Vote[]
 }
 
 model DebateState {
@@ -93,4 +103,32 @@ model DebateState {
   paused_time_remaining Float   @default(0)
 
   session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+}
+
+model AudienceQueue {
+  id         String   @id @default(cuid())
+  session_id String
+  user_id    String   @db.Uuid
+  added_at   DateTime @default(now())
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [user_id], references: [id])
+
+  @@unique([session_id, user_id])
+  @@index([session_id, added_at])
+}
+
+model Vote {
+  id             String   @id @default(cuid())
+  session_id     String
+  voter_id       String   @db.Uuid
+  target_user_id String   @db.Uuid
+  vote_type      VoteType
+  created_at     DateTime @default(now())
+
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  voter   User    @relation("VoteCaster", fields: [voter_id], references: [id])
+  target  User    @relation("VoteTarget", fields: [target_user_id], references: [id])
+
+  @@unique([session_id, voter_id, target_user_id, vote_type])
 }

--- a/realtime/.env.example
+++ b/realtime/.env.example
@@ -20,5 +20,9 @@ TURN_PORT=3478
 TURN_USERNAME=arguably
 TURN_PASSWORD=CHANGE_ME_IN_PRODUCTION
 
-# CORS: comma-separated allowed origins (omit for wildcard in dev)
+# CORS: comma-separated allowed origins (required in production, defaults to localhost in dev)
 # ALLOWED_ORIGINS=https://your-app.vercel.app
+
+# Authentication: Supabase JWT secret for Socket.IO auth (required in production)
+# Get this from Supabase dashboard: Settings > API > JWT Secret
+# SUPABASE_JWT_SECRET=your-jwt-secret

--- a/realtime/package-lock.json
+++ b/realtime/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "dotenv": "^16.4.7",
+        "jose": "^6.2.2",
         "mediasoup": "^3.19.0",
-        "socket.io": "^4.8.0"
+        "socket.io": "^4.8.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "^20.17.0",
@@ -762,6 +764,15 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/mediasoup": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/mediasoup/-/mediasoup-3.19.3.tgz",
@@ -1055,6 +1066,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "dotenv": "^16.4.7",
+    "jose": "^6.2.2",
     "mediasoup": "^3.19.0",
-    "socket.io": "^4.8.0"
+    "socket.io": "^4.8.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^20.17.0",

--- a/realtime/src/auth.ts
+++ b/realtime/src/auth.ts
@@ -1,0 +1,51 @@
+import { jwtVerify } from "jose";
+import type { Socket } from "socket.io";
+
+const isProduction = process.env.NODE_ENV === "production";
+
+export function createAuthMiddleware() {
+  const secret = process.env.SUPABASE_JWT_SECRET;
+
+  if (!secret && isProduction) {
+    console.error(
+      "\n[FATAL] SUPABASE_JWT_SECRET is required in production.\n" +
+        "Get it from your Supabase dashboard: Settings > API > JWT Secret.\n",
+    );
+    process.exit(1);
+  }
+
+  if (!secret) {
+    console.warn(
+      "[WARN] SUPABASE_JWT_SECRET not set — Socket.IO auth disabled. " +
+        "Set it for authenticated connections.",
+    );
+    return (_socket: Socket, next: (err?: Error) => void) => {
+      next();
+    };
+  }
+
+  const encodedSecret = new TextEncoder().encode(secret);
+
+  return async (socket: Socket, next: (err?: Error) => void) => {
+    const token = socket.handshake.auth?.token as string | undefined;
+
+    if (!token) {
+      return next(new Error("Authentication required"));
+    }
+
+    try {
+      const { payload } = await jwtVerify(token, encodedSecret, {
+        algorithms: ["HS256"],
+      });
+
+      if (!payload.sub) {
+        return next(new Error("Invalid token: missing sub claim"));
+      }
+
+      socket.data.userId = payload.sub;
+      next();
+    } catch {
+      next(new Error("Invalid or expired token"));
+    }
+  };
+}

--- a/realtime/src/config.ts
+++ b/realtime/src/config.ts
@@ -19,8 +19,25 @@ const RTC_MAX_PORT = parseInt(process.env.RTC_MAX_PORT || "40100", 10);
 
 const TURN_HOST = process.env.TURN_HOST || ANNOUNCED_IP;
 const TURN_PORT = parseInt(process.env.TURN_PORT || "3478", 10);
-const TURN_USERNAME = process.env.TURN_USERNAME || "arguably";
-const TURN_PASSWORD = process.env.TURN_PASSWORD || "arguably-turn-password";
+
+const DEFAULT_TURN_USERNAME = "arguably";
+const DEFAULT_TURN_PASSWORD = "arguably-turn-password";
+const TURN_USERNAME = process.env.TURN_USERNAME || DEFAULT_TURN_USERNAME;
+const TURN_PASSWORD = process.env.TURN_PASSWORD || DEFAULT_TURN_PASSWORD;
+
+// Warn if default TURN credentials are used in production
+if (process.env.NODE_ENV === "production") {
+  if (TURN_USERNAME === DEFAULT_TURN_USERNAME || TURN_PASSWORD === DEFAULT_TURN_PASSWORD) {
+    console.warn(
+      "\n╔══════════════════════════════════════════════════════════╗\n" +
+        "║  WARNING: Default TURN credentials detected in prod!    ║\n" +
+        "║  Set TURN_USERNAME and TURN_PASSWORD env vars to        ║\n" +
+        "║  strong, unique values. Default creds are public in     ║\n" +
+        "║  source code and can be abused for bandwidth theft.     ║\n" +
+        "╚══════════════════════════════════════════════════════════╝\n",
+    );
+  }
+}
 
 // ── mediasoup worker settings ──
 

--- a/realtime/src/index.ts
+++ b/realtime/src/index.ts
@@ -6,12 +6,36 @@ import { Server as SocketIOServer } from "socket.io";
 import { createWorkers } from "./mediasoup/workers.js";
 import { setupSignaling } from "./signaling.js";
 import { LISTEN_PORT } from "./config.js";
+import { createAuthMiddleware } from "./auth.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const isProduction = process.env.NODE_ENV === "production";
+
 // Resolve test-client directory (works for both src/ and dist/)
 const testClientDir = path.resolve(__dirname, "..", "test-client");
+
+// ── CORS configuration ──
+
+function getCorsOrigin(): string[] {
+  const envOrigins = process.env.ALLOWED_ORIGINS;
+  if (envOrigins) {
+    return envOrigins.split(",").map((o) => o.trim());
+  }
+  if (isProduction) {
+    console.error(
+      "\n[FATAL] ALLOWED_ORIGINS env var is required in production.\n" +
+        "Set it to a comma-separated list of allowed origins.\n",
+    );
+    process.exit(1);
+  }
+  console.warn(
+    "[WARN] ALLOWED_ORIGINS not set — defaulting to localhost only. " +
+      "Set ALLOWED_ORIGINS for non-local access.",
+  );
+  return ["http://localhost:3000", "http://127.0.0.1:3000"];
+}
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
@@ -30,14 +54,30 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // Serve static test-client files
-  let filePath = req.url === "/" ? "/index.html" : req.url || "/index.html";
-  filePath = path.join(testClientDir, filePath);
+  // Serve static test-client files — with path traversal protection
+  let decodedUrl: string;
+  try {
+    decodedUrl = decodeURIComponent(req.url || "/");
+  } catch {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end("Bad Request");
+    return;
+  }
 
-  const ext = path.extname(filePath);
+  const requestedPath = decodedUrl === "/" ? "/index.html" : decodedUrl;
+  const resolvedPath = path.resolve(testClientDir, "." + requestedPath);
+
+  // Verify resolved path is within testClientDir
+  if (resolvedPath !== testClientDir && !resolvedPath.startsWith(testClientDir + path.sep)) {
+    res.writeHead(403, { "Content-Type": "text/plain" });
+    res.end("Forbidden");
+    return;
+  }
+
+  const ext = path.extname(resolvedPath);
   const contentType = MIME_TYPES[ext] || "application/octet-stream";
 
-  fs.readFile(filePath, (err, data) => {
+  fs.readFile(resolvedPath, (err, data) => {
     if (err) {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not Found");
@@ -52,10 +92,13 @@ const server = http.createServer((req, res) => {
 
 const io = new SocketIOServer(server, {
   cors: {
-    origin: process.env.ALLOWED_ORIGINS?.split(",") || "*",
+    origin: getCorsOrigin(),
     methods: ["GET", "POST"],
   },
 });
+
+// ── Socket.IO authentication middleware ──
+io.use(createAuthMiddleware());
 
 // ── Start ──
 

--- a/realtime/src/signaling.ts
+++ b/realtime/src/signaling.ts
@@ -1,20 +1,13 @@
 import type { Server as SocketIOServer, Socket } from "socket.io";
-import type {
-  Peer,
-  JoinRequest,
-  CreateTransportRequest,
-  ConnectTransportRequest,
-  ProduceRequest,
-  ConsumeRequest,
-  ResumeConsumerRequest,
-  CloseProducerRequest,
-} from "./types.js";
+import type { Peer } from "./types.js";
 import { iceServers } from "./config.js";
 import { getOrCreateRoom, addPeerToRoom, removePeerFromRoom, getRoom } from "./mediasoup/rooms.js";
 import { createWebRtcTransport, getTransportOptions } from "./mediasoup/transports.js";
 import { createProducer } from "./mediasoup/producers.js";
 import { createConsumer } from "./mediasoup/consumers.js";
 import type { RtpCapabilities } from "mediasoup/types";
+import { schemas, validatePayload } from "./validation.js";
+
 // Track which room each socket is in
 const socketRoomMap = new Map<string, string>();
 const socketPeerMap = new Map<string, { rtpCapabilities: RtpCapabilities }>();
@@ -24,9 +17,12 @@ export function setupSignaling(io: SocketIOServer): void {
     console.log(`Socket connected [id:${socket.id}]`);
 
     // ── getRouterRtpCapabilities ──
-    socket.on("getRouterRtpCapabilities", async (data: { roomId: string }, callback) => {
+    socket.on("getRouterRtpCapabilities", async (data: unknown, callback) => {
       try {
-        const room = await getOrCreateRoom(data.roomId);
+        const parsed = validatePayload(schemas.getRouterRtpCapabilities, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
+        const room = await getOrCreateRoom(parsed.data.roomId);
         callback({
           success: true,
           rtpCapabilities: room.router.rtpCapabilities,
@@ -39,29 +35,33 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── joinRoom ──
-    socket.on("joinRoom", async (data: JoinRequest, callback) => {
+    socket.on("joinRoom", async (data: unknown, callback) => {
       try {
-        const room = await getOrCreateRoom(data.roomId);
+        const parsed = validatePayload(schemas.joinRoom, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
+        const { roomId, displayName, rtpCapabilities } = parsed.data;
+        const room = await getOrCreateRoom(roomId);
 
         const peer: Peer = {
           id: socket.id,
-          displayName: data.displayName,
+          displayName,
           transports: new Map(),
           producers: new Map(),
           consumers: new Map(),
         };
 
         addPeerToRoom(room, peer);
-        socketRoomMap.set(socket.id, data.roomId);
-        socketPeerMap.set(socket.id, { rtpCapabilities: data.rtpCapabilities });
+        socketRoomMap.set(socket.id, roomId);
+        socketPeerMap.set(socket.id, { rtpCapabilities: rtpCapabilities as RtpCapabilities });
 
         // Join socket.io room for broadcasting
-        socket.join(data.roomId);
+        socket.join(roomId);
 
         // Notify other peers
-        socket.to(data.roomId).emit("peerJoined", {
+        socket.to(roomId).emit("peerJoined", {
           peerId: socket.id,
-          displayName: data.displayName,
+          displayName,
         });
 
         // Return list of existing peers
@@ -77,8 +77,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── createWebRtcTransport ──
-    socket.on("createWebRtcTransport", async (data: CreateTransportRequest, callback) => {
+    socket.on("createWebRtcTransport", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.createWebRtcTransport, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -109,8 +112,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── connectTransport ──
-    socket.on("connectTransport", async (data: ConnectTransportRequest, callback) => {
+    socket.on("connectTransport", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.connectTransport, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -120,10 +126,12 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const transport = peer.transports.get(data.transportId);
+        const transport = peer.transports.get(parsed.data.transportId);
         if (!transport) throw new Error("Transport not found");
 
-        await transport.connect({ dtlsParameters: data.dtlsParameters });
+        await transport.connect({
+          dtlsParameters: parsed.data.dtlsParameters,
+        } as Parameters<typeof transport.connect>[0]);
 
         callback({ success: true });
       } catch (error) {
@@ -133,8 +141,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── produce ──
-    socket.on("produce", async (data: ProduceRequest, callback) => {
+    socket.on("produce", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.produce, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -144,14 +155,14 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const transport = peer.transports.get(data.transportId);
+        const transport = peer.transports.get(parsed.data.transportId);
         if (!transport) throw new Error("Transport not found");
 
         const producer = await createProducer(
           transport,
-          data.kind,
-          data.rtpParameters,
-          data.appData,
+          parsed.data.kind,
+          parsed.data.rtpParameters as Parameters<typeof createProducer>[2],
+          parsed.data.appData,
         );
 
         peer.producers.set(producer.id, producer);
@@ -176,8 +187,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── consume ──
-    socket.on("consume", async (data: ConsumeRequest, callback) => {
+    socket.on("consume", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.consume, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -199,7 +213,7 @@ export function setupSignaling(io: SocketIOServer): void {
         let producerPeerId = "";
         let producerDisplayName = "";
         for (const [, roomPeer] of room.peers) {
-          if (roomPeer.producers.has(data.producerId)) {
+          if (roomPeer.producers.has(parsed.data.producerId)) {
             producerPeerId = roomPeer.id;
             producerDisplayName = roomPeer.displayName;
             break;
@@ -209,7 +223,7 @@ export function setupSignaling(io: SocketIOServer): void {
         const consumer = await createConsumer(
           room.router,
           transport,
-          data.producerId,
+          parsed.data.producerId,
           peerData.rtpCapabilities,
         );
 
@@ -221,13 +235,13 @@ export function setupSignaling(io: SocketIOServer): void {
 
         consumer.on("producerclose", () => {
           peer.consumers.delete(consumer.id);
-          socket.emit("producerClosed", { producerId: data.producerId });
+          socket.emit("producerClosed", { producerId: parsed.data.producerId });
         });
 
         callback({
           success: true,
           id: consumer.id,
-          producerId: data.producerId,
+          producerId: parsed.data.producerId,
           kind: consumer.kind,
           rtpParameters: consumer.rtpParameters,
           peerId: producerPeerId,
@@ -240,8 +254,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── resumeConsumer ──
-    socket.on("resumeConsumer", async (data: ResumeConsumerRequest, callback) => {
+    socket.on("resumeConsumer", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.resumeConsumer, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -251,7 +268,7 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const consumer = peer.consumers.get(data.consumerId);
+        const consumer = peer.consumers.get(parsed.data.consumerId);
         if (!consumer) throw new Error("Consumer not found");
 
         await consumer.resume();
@@ -263,8 +280,11 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── closeProducer ──
-    socket.on("closeProducer", async (data: CloseProducerRequest, callback) => {
+    socket.on("closeProducer", async (data: unknown, callback) => {
       try {
+        const parsed = validatePayload(schemas.closeProducer, data);
+        if (!parsed.success) return callback({ success: false, error: parsed.error });
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -274,15 +294,15 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer = room.peers.get(socket.id);
         if (!peer) throw new Error("Peer not found");
 
-        const producer = peer.producers.get(data.producerId);
+        const producer = peer.producers.get(parsed.data.producerId);
         if (!producer) throw new Error("Producer not found");
 
         producer.close();
-        peer.producers.delete(data.producerId);
+        peer.producers.delete(parsed.data.producerId);
 
         // Notify other peers
         socket.to(roomId).emit("producerClosed", {
-          producerId: data.producerId,
+          producerId: parsed.data.producerId,
         });
 
         callback({ success: true });
@@ -293,8 +313,10 @@ export function setupSignaling(io: SocketIOServer): void {
     });
 
     // ── getProducers ──
-    socket.on("getProducers", async (_data: unknown, callback) => {
+    socket.on("getProducers", async (data: unknown, callback) => {
       try {
+        validatePayload(schemas.getProducers, data);
+
         const roomId = socketRoomMap.get(socket.id);
         if (!roomId) throw new Error("Not in a room");
 
@@ -347,7 +369,6 @@ export function setupSignaling(io: SocketIOServer): void {
         socketRoomMap.delete(socket.id);
         socketPeerMap.delete(socket.id);
       }
-
     });
   });
 }

--- a/realtime/src/validation.ts
+++ b/realtime/src/validation.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+// ── Shared field schemas ──
+
+const roomId = z.string().min(1).max(100);
+const transportId = z.string().min(1).max(100);
+const producerId = z.string().min(1).max(100);
+const consumerId = z.string().min(1).max(100);
+const displayName = z.string().min(1).max(50);
+
+// Mediasoup-opaque objects: validate shape exists, don't deep-validate internals
+const rtpCapabilities = z.record(z.string(), z.unknown());
+const dtlsParameters = z.record(z.string(), z.unknown());
+const rtpParameters = z.record(z.string(), z.unknown());
+
+// ── Event payload schemas ──
+
+export const schemas = {
+  getRouterRtpCapabilities: z.object({
+    roomId,
+  }),
+
+  joinRoom: z.object({
+    roomId,
+    displayName,
+    rtpCapabilities,
+  }),
+
+  createWebRtcTransport: z.object({
+    direction: z.enum(["send", "recv"]),
+  }),
+
+  connectTransport: z.object({
+    transportId,
+    dtlsParameters,
+  }),
+
+  produce: z.object({
+    transportId,
+    kind: z.enum(["audio", "video"]),
+    rtpParameters,
+    appData: z.record(z.string(), z.unknown()).optional(),
+  }),
+
+  consume: z.object({
+    producerId,
+  }),
+
+  resumeConsumer: z.object({
+    consumerId,
+  }),
+
+  closeProducer: z.object({
+    producerId,
+  }),
+
+  getProducers: z.unknown(),
+} as const;
+
+// ── Validation helper ──
+
+export type ValidationResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export function validatePayload<T>(
+  schema: z.ZodType<T>,
+  data: unknown,
+): ValidationResult<T> {
+  const result = schema.safeParse(data);
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+  const message = result.error.issues
+    .map((i) => `${i.path.join(".")}: ${i.message}`)
+    .join("; ");
+  return { success: false, error: `Invalid payload: ${message}` };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['__tests__/**/*.test.ts'],
+    include: ['__tests__/**/*.test.{ts,tsx}'],
     exclude: ['tests/**', 'node_modules/**', '__tests__/sfu/**'],
   },
   resolve: {


### PR DESCRIPTION
## Summary

Closes #17

- **AudienceQueue + Vote** Prisma models with `kick_threshold` on Session
- **Queue server actions**: joinQueue, leaveQueue, getQueue, promoteFromQueue with FIFO ordering by `added_at`
- **Kick-vote server actions**: castKickVote (threshold: `ceil(audienceCount * threshold / 100)`), removeKickVote, getKickVotes — all within serializable transactions
- **Debate engine**: replaced hardcoded `% 2` with `% debater_order.length`; Expert vs Crowd challenger rotation from queue on turn end
- **Auto-promotion** on debater leave/kick via transactional `doPromoteFromQueue` helper
- **Real-time hooks**: `useQueueChannel` + `useKickVoteChannel` with Supabase Realtime + 500ms debounce
- **UI**: Speaker Queue section with join/leave/position, kick-vote progress bar on debater cards, Expert vs Crowd badges (EXPERT/CHALLENGER), kick threshold config on create page
- **Tests**: 29 new queue tests + updated debate/session tests (129 total, all passing)

## Test plan

- [x] `npx prisma db push` succeeds
- [x] `npm run build` passes
- [x] `npm run test:unit` — 129/129 tests pass
- [ ] Manual: create session, join as audience, join queue, verify position
- [ ] Manual: kick-vote threshold triggers auto-kick + promotion
- [ ] Manual: Expert vs Crowd challenger rotation from queue
- [ ] Manual: real-time queue/vote updates across browser tabs

**Note:** After merge, run in Supabase SQL editor:
```sql
ALTER PUBLICATION supabase_realtime ADD TABLE "AudienceQueue";
ALTER PUBLICATION supabase_realtime ADD TABLE "Vote";
```