### PR TITLE
feat: audience queue, kick-voting, Expert vs Crowd rotation

### DIFF
--- a/__tests__/debate.test.ts
+++ b/__tests__/debate.test.ts
@@ -14,11 +14,20 @@ vi.mock('@/lib/prisma', () => ({
       updateMany: vi.fn(),
       delete: vi.fn(),
     },
+    // Needed for doPromoteFromQueue called inside debate actions
+    audienceQueue: { findFirst: vi.fn(), delete: vi.fn() },
     participatesIn: {
       findUnique: vi.fn(),
       findMany: vi.fn(),
+      update: vi.fn(),
     },
+    $transaction: vi.fn(),
   },
+}))
+
+vi.mock('@/lib/actions/queue', () => ({
+  doPromoteFromQueue: vi.fn().mockResolvedValue(null),
+  cleanupUserVotes: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { createClient } from '@/lib/supabase/server'
@@ -120,8 +129,23 @@ describe('startDebate', () => {
     await expect(startDebate(MOCK_SESSION_ID, debaters, 120)).rejects.toThrow('Not authorized')
   })
 
-  it('throws if not exactly 2 debaters', async () => {
-    await expect(startDebate(MOCK_SESSION_ID, [debaters[0]], 120)).rejects.toThrow('Exactly 2 debaters')
+  it('throws if fewer than 2 debaters for non-Expert format', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, [debaters[0]], 120)).rejects.toThrow('At least 2 debaters')
+  })
+
+  it('accepts >= 2 debaters for non-Expert formats', async () => {
+    const threeDebaters = [
+      { userId: 'u1', displayName: 'Alice' },
+      { userId: 'u2', displayName: 'Bob' },
+      { userId: 'u3', displayName: 'Charlie' },
+    ]
+    ;(prisma.participatesIn.findMany as any).mockResolvedValue([
+      { user_id: 'u1' },
+      { user_id: 'u2' },
+      { user_id: 'u3' },
+    ])
+    await startDebate(MOCK_SESSION_ID, threeDebaters, 120)
+    expect(prisma.debateState.upsert).toHaveBeenCalled()
   })
 
   it('upserts debate state with correct initial values', async () => {
@@ -159,6 +183,7 @@ describe('advanceTurn', () => {
   it('advances current_index from 0 to 1', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       current_index: 0, turn_length: 60, is_paused: false,
+      debater_order: debaters,
     })
     await advanceTurn(MOCK_SESSION_ID)
     const update = (prisma.debateState.update as any).mock.calls[0][0]
@@ -169,6 +194,7 @@ describe('advanceTurn', () => {
   it('wraps current_index from 1 back to 0', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       current_index: 1, turn_length: 60, is_paused: false,
+      debater_order: debaters,
     })
     await advanceTurn(MOCK_SESSION_ID)
     const update = (prisma.debateState.update as any).mock.calls[0][0]
@@ -178,11 +204,27 @@ describe('advanceTurn', () => {
   it('sets new turn_ends_at from now + turn_length', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       current_index: 0, turn_length: 90, is_paused: false,
+      debater_order: debaters,
     })
     const before = Date.now()
     await advanceTurn(MOCK_SESSION_ID)
     const update = (prisma.debateState.update as any).mock.calls[0][0]
     expect(update.data.turn_ends_at).toBeGreaterThanOrEqual(before + 90_000)
+  })
+
+  it('wraps correctly with 3 debaters', async () => {
+    const threeDebaters = [
+      { userId: 'u1', displayName: 'Alice' },
+      { userId: 'u2', displayName: 'Bob' },
+      { userId: 'u3', displayName: 'Charlie' },
+    ]
+    ;(prisma.debateState.findUnique as any).mockResolvedValue({
+      current_index: 2, turn_length: 60, is_paused: false,
+      debater_order: threeDebaters,
+    })
+    await advanceTurn(MOCK_SESSION_ID)
+    const update = (prisma.debateState.update as any).mock.calls[0][0]
+    expect(update.data.current_index).toBe(0)
   })
 })
 
@@ -191,6 +233,7 @@ describe('advanceTurnIfExpired', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAuth('any-user')
+    mockSession({ type: 'ONE_ON_ONE' })
     ;(prisma.debateState.updateMany as any).mockResolvedValue({ count: 1 })
     // Mock: user is an active participant
     ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
@@ -215,6 +258,7 @@ describe('advanceTurnIfExpired', () => {
   it('does nothing if paused', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       is_paused: true, turn_ends_at: Date.now() - 5000, current_index: 0, turn_length: 60,
+      debater_order: debaters,
     })
     await advanceTurnIfExpired(MOCK_SESSION_ID)
     expect(prisma.debateState.updateMany).not.toHaveBeenCalled()
@@ -223,6 +267,7 @@ describe('advanceTurnIfExpired', () => {
   it('does nothing if turn has not expired yet', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       is_paused: false, turn_ends_at: Date.now() + 30_000, current_index: 0, turn_length: 60,
+      debater_order: debaters,
     })
     await advanceTurnIfExpired(MOCK_SESSION_ID)
     expect(prisma.debateState.updateMany).not.toHaveBeenCalled()
@@ -231,6 +276,7 @@ describe('advanceTurnIfExpired', () => {
   it('calls updateMany with atomic guard when turn expired', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       is_paused: false, turn_ends_at: Date.now() - 2000, current_index: 0, turn_length: 60,
+      debater_order: debaters,
     })
     await advanceTurnIfExpired(MOCK_SESSION_ID)
     expect(prisma.debateState.updateMany).toHaveBeenCalledWith(
@@ -442,7 +488,10 @@ describe('advanceTurnIfExpired — security', () => {
     })
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
       is_paused: false, turn_ends_at: Date.now() - 2000, current_index: 0, turn_length: 60,
+      debater_order: debaters,
     })
+    // advanceTurnIfExpired fetches session.type to check Expert vs Crowd
+    ;(prisma.session.findUnique as any).mockResolvedValue({ type: 'ONE_ON_ONE' })
     await advanceTurnIfExpired(MOCK_SESSION_ID)
     expect(prisma.debateState.updateMany).toHaveBeenCalled()
   })

--- a/__tests__/queue.test.ts
+++ b/__tests__/queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { SessionRole, SessionStatus } from '@/lib/generated/prisma'
+import { SessionRole, SessionStatus, VoteType } from '@/lib/generated/prisma'
 
 // ── Mocks ──
 vi.mock('@/lib/supabase/server', () => ({
@@ -8,24 +8,48 @@ vi.mock('@/lib/supabase/server', () => ({
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
-    session: {
-      findUnique: vi.fn(),
-    },
-    participatesIn: {
-      findUnique: vi.fn(),
-      update: vi.fn(),
-    },
+    participatesIn: { findUnique: vi.fn(), update: vi.fn(), count: vi.fn() },
+    session: { findUnique: vi.fn() },
     audienceQueue: {
       create: vi.fn(),
       delete: vi.fn(),
-      findMany: vi.fn(),
+      deleteMany: vi.fn(),
       findFirst: vi.fn(),
+      findMany: vi.fn(),
       findUnique: vi.fn(),
+    },
+    vote: {
+      create: vi.fn(),
+      count: vi.fn(),
+      findFirst: vi.fn(),
+      deleteMany: vi.fn(),
     },
     roleHistory: {
       create: vi.fn(),
     },
-    $transaction: vi.fn(),
+    debateState: { findUnique: vi.fn(), update: vi.fn() },
+    $transaction: vi.fn((fn) => fn({
+      participatesIn: { findUnique: vi.fn(), update: vi.fn(), count: vi.fn() },
+      session: { findUnique: vi.fn() },
+      audienceQueue: {
+        create: vi.fn(),
+        delete: vi.fn(),
+        deleteMany: vi.fn(),
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
+      vote: {
+        create: vi.fn(),
+        count: vi.fn(),
+        findFirst: vi.fn(),
+        deleteMany: vi.fn(),
+      },
+      roleHistory: {
+        create: vi.fn(),
+      },
+      debateState: { findUnique: vi.fn(), update: vi.fn() },
+    })),
   },
 }))
 
@@ -36,14 +60,16 @@ import {
   leaveQueue,
   getQueue,
   promoteFromQueue,
+  castKickVote,
+  removeKickVote,
+  getKickVotes,
 } from '@/lib/actions/queue'
 
 const MOCK_USER_ID = 'user-uuid-1234'
 const MOCK_SESSION_ID = 'session-cuid-5678'
+const MOCK_TARGET_USER_ID = 'target-user-uuid'
 const MOCK_HOST_ID = 'host-uuid'
-const MOCK_QUEUE_USER_ID = 'queue-user-uuid'
 
-// Helper to set up auth mock
 function mockAuth(userId: string | null) {
   ;(createClient as any).mockResolvedValue({
     auth: {
@@ -72,7 +98,7 @@ describe('joinQueue', () => {
     ;(prisma.audienceQueue.create as any).mockResolvedValue({})
   })
 
-  it('throws when not authenticated', async () => {
+  it('throws if not authenticated', async () => {
     mockAuth(null)
     await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
   })
@@ -90,26 +116,42 @@ describe('joinQueue', () => {
     await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Session is not live')
   })
 
-  it('throws "Not a participant" when no record', async () => {
+  it('throws if not a participant (findUnique returns null)', async () => {
     ;(prisma.participatesIn.findUnique as any).mockResolvedValue(null)
-    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow(
-      'Not a participant in this session'
-    )
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
   })
 
-  it('throws "Only audience members can join the queue" when role is DEBATER', async () => {
+  it('throws if left session (left_at is set)', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.AUDIENCE,
+      left_at: new Date(),
+    })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Not a participant in this session')
+  })
+
+  it('throws if not AUDIENCE role (HOST)', async () => {
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.HOST,
+      left_at: null,
+    })
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Only audience members can join the queue')
+  })
+
+  it('throws if not AUDIENCE role (DEBATER)', async () => {
     ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
       user_id: MOCK_USER_ID,
       session_id: MOCK_SESSION_ID,
       session_role: SessionRole.DEBATER,
       left_at: null,
     })
-    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow(
-      'Only audience members can join the queue'
-    )
+    await expect(joinQueue(MOCK_SESSION_ID)).rejects.toThrow('Only audience members can join the queue')
   })
 
-  it('calls prisma.audienceQueue.create on success', async () => {
+  it('creates AudienceQueue entry on success', async () => {
     await joinQueue(MOCK_SESSION_ID)
     expect(prisma.audienceQueue.create).toHaveBeenCalledWith({
       data: {
@@ -125,24 +167,38 @@ describe('leaveQueue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAuth(MOCK_USER_ID)
-    ;(prisma.audienceQueue.delete as any).mockResolvedValue({})
   })
 
-  it('throws when not authenticated', async () => {
+  it('throws if not authenticated', async () => {
     mockAuth(null)
     await expect(leaveQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
   })
 
-  it('calls prisma.audienceQueue.delete with correct compound key', async () => {
+  it('deletes queue entry and voters votes in a transaction', async () => {
+    const mockTx = {
+      audienceQueue: { deleteMany: vi.fn().mockResolvedValue({}) },
+      vote: { deleteMany: vi.fn().mockResolvedValue({}) },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
+
     await leaveQueue(MOCK_SESSION_ID)
-    expect(prisma.audienceQueue.delete).toHaveBeenCalledWith({
-      where: {
-        session_id_user_id: {
+
+    expect(mockTx.audienceQueue.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
           session_id: MOCK_SESSION_ID,
           user_id: MOCK_USER_ID,
-        },
-      },
-    })
+        }),
+      })
+    )
+    expect(mockTx.vote.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+        }),
+      })
+    )
   })
 })
 
@@ -150,18 +206,71 @@ describe('leaveQueue', () => {
 describe('getQueue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(prisma.audienceQueue.findMany as any).mockResolvedValue([])
+    mockAuth(MOCK_USER_ID)
   })
 
-  it('calls prisma.audienceQueue.findMany ordered by joined_queue asc', async () => {
-    await getQueue(MOCK_SESSION_ID)
-    expect(prisma.audienceQueue.findMany).toHaveBeenCalledWith({
-      where: { session_id: MOCK_SESSION_ID },
-      orderBy: { joined_queue: 'asc' },
-      include: {
-        user: { select: { id: true, username: true, realname: true } },
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(getQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns entries with computed rank (1-indexed)', async () => {
+    ;(prisma.audienceQueue.findMany as any).mockResolvedValue([
+      {
+        id: 'entry-1',
+        user_id: 'user-1',
+        session_id: MOCK_SESSION_ID,
+        joined_queue: new Date('2026-04-14T10:00:00Z'),
+        user: { id: 'user-1', username: 'alice', realname: 'Alice Smith' },
       },
+      {
+        id: 'entry-2',
+        user_id: 'user-2',
+        session_id: MOCK_SESSION_ID,
+        joined_queue: new Date('2026-04-14T10:05:00Z'),
+        user: { id: 'user-2', username: 'bob', realname: null },
+      },
+      {
+        id: 'entry-3',
+        user_id: 'user-3',
+        session_id: MOCK_SESSION_ID,
+        joined_queue: new Date('2026-04-14T10:10:00Z'),
+        user: { id: 'user-3', username: 'charlie', realname: 'Charlie Brown' },
+      },
+    ])
+
+    const result = await getQueue(MOCK_SESSION_ID)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({
+      id: 'entry-1',
+      userId: 'user-1',
+      rank: 1,
+      displayName: 'Alice Smith',
+      addedAt: '2026-04-14T10:00:00.000Z',
     })
+    expect(result[1]).toEqual({
+      id: 'entry-2',
+      userId: 'user-2',
+      rank: 2,
+      displayName: 'bob',
+      addedAt: '2026-04-14T10:05:00.000Z',
+    })
+    expect(result[2]).toEqual({
+      id: 'entry-3',
+      userId: 'user-3',
+      rank: 3,
+      displayName: 'Charlie Brown',
+      addedAt: '2026-04-14T10:10:00.000Z',
+    })
+  })
+
+  it('returns empty array when no entries', async () => {
+    ;(prisma.audienceQueue.findMany as any).mockResolvedValue([])
+
+    const result = await getQueue(MOCK_SESSION_ID)
+
+    expect(result).toEqual([])
   })
 })
 
@@ -171,51 +280,24 @@ describe('promoteFromQueue', () => {
     vi.clearAllMocks()
     mockAuth(MOCK_HOST_ID)
 
-    // Mock the transaction callback pattern
-    const mockTx = {
-      audienceQueue: {
-        findFirst: vi.fn().mockResolvedValue({
-          user_id: MOCK_QUEUE_USER_ID,
-          session_id: MOCK_SESSION_ID,
-        }),
-        findUnique: vi.fn().mockResolvedValue({
-          user_id: MOCK_QUEUE_USER_ID,
-          session_id: MOCK_SESSION_ID,
-        }),
-        delete: vi.fn().mockResolvedValue({}),
-      },
-      participatesIn: {
-        update: vi.fn().mockResolvedValue({}),
-      },
-      roleHistory: {
-        create: vi.fn().mockResolvedValue({}),
-      },
-    }
-    ;(prisma.$transaction as any).mockImplementation(async (cb: any) => cb(mockTx))
-
     // Mock session with host
     ;(prisma.session.findUnique as any).mockResolvedValue({
       id: MOCK_SESSION_ID,
       host_id: MOCK_HOST_ID,
       moderator_id: null,
-      host: { id: MOCK_HOST_ID },
-      moderator: null,
     })
   })
 
-  it('throws when not authenticated', async () => {
+  it('throws if not authenticated', async () => {
     mockAuth(null)
     await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authenticated')
   })
 
-  it('throws "Not authorized" when user is not host/moderator', async () => {
-    mockAuth('other-user-id')
+  it('throws if not host or moderator', async () => {
     ;(prisma.session.findUnique as any).mockResolvedValue({
       id: MOCK_SESSION_ID,
-      host_id: MOCK_HOST_ID,
-      moderator_id: null,
-      host: { id: MOCK_HOST_ID },
-      moderator: null,
+      host_id: 'other-user',
+      moderator_id: 'another-user',
     })
     await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('Not authorized')
   })
@@ -227,75 +309,50 @@ describe('promoteFromQueue', () => {
         findUnique: vi.fn(),
         delete: vi.fn(),
       },
-      participatesIn: {
-        update: vi.fn(),
-      },
-      roleHistory: {
-        create: vi.fn(),
-      },
+      participatesIn: { update: vi.fn() },
+      roleHistory: { create: vi.fn() },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (cb: any) => cb(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     await expect(promoteFromQueue(MOCK_SESSION_ID)).rejects.toThrow('No one in the queue')
   })
 
-  it('calls $transaction on success', async () => {
-    await promoteFromQueue(MOCK_SESSION_ID)
-    expect(prisma.$transaction).toHaveBeenCalled()
-  })
-
-  it('promotes FIFO user when no userId specified', async () => {
+  it('calls $transaction and returns promoted user on FIFO promote', async () => {
     const mockTx = {
       audienceQueue: {
         findFirst: vi.fn().mockResolvedValue({
-          user_id: MOCK_QUEUE_USER_ID,
+          id: 'queue-entry-1',
           session_id: MOCK_SESSION_ID,
+          user_id: 'promoted-user',
+          joined_queue: new Date(),
+          user: { id: 'promoted-user', username: 'promoted', realname: 'Promoted User' },
         }),
-        findUnique: vi.fn(),
         delete: vi.fn().mockResolvedValue({}),
       },
-      participatesIn: {
-        update: vi.fn().mockResolvedValue({}),
-      },
-      roleHistory: {
-        create: vi.fn().mockResolvedValue({}),
-      },
+      participatesIn: { update: vi.fn().mockResolvedValue({}) },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (cb: any) => cb(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     const result = await promoteFromQueue(MOCK_SESSION_ID)
 
-    expect(mockTx.audienceQueue.findFirst).toHaveBeenCalledWith({
-      where: { session_id: MOCK_SESSION_ID },
-      orderBy: { joined_queue: 'asc' },
+    expect(result).toEqual({
+      promotedUserId: 'promoted-user',
     })
-    expect(mockTx.participatesIn.update).toHaveBeenCalledWith({
-      where: {
-        user_id_session_id: {
-          user_id: MOCK_QUEUE_USER_ID,
-          session_id: MOCK_SESSION_ID,
-        },
-      },
-      data: { session_role: SessionRole.DEBATER },
-    })
-    expect(mockTx.audienceQueue.delete).toHaveBeenCalledWith({
-      where: {
-        session_id_user_id: {
-          session_id: MOCK_SESSION_ID,
-          user_id: MOCK_QUEUE_USER_ID,
-        },
-      },
-    })
-    expect(mockTx.roleHistory.create).toHaveBeenCalledWith({
-      data: {
-        session_id: MOCK_SESSION_ID,
-        user_id: MOCK_QUEUE_USER_ID,
-        old_role: SessionRole.AUDIENCE,
-        new_role: SessionRole.DEBATER,
-        reason: 'Promoted from queue',
-      },
-    })
-    expect(result).toEqual({ promotedUserId: MOCK_QUEUE_USER_ID })
+    expect(mockTx.audienceQueue.delete).toHaveBeenCalled()
+    expect(mockTx.participatesIn.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id_session_id: {
+            user_id: 'promoted-user',
+            session_id: MOCK_SESSION_ID,
+          },
+        }),
+        data: expect.objectContaining({ session_role: SessionRole.DEBATER }),
+      })
+    )
   })
 
   it('promotes specific user when userId is provided', async () => {
@@ -309,28 +366,15 @@ describe('promoteFromQueue', () => {
         }),
         delete: vi.fn().mockResolvedValue({}),
       },
-      participatesIn: {
-        update: vi.fn().mockResolvedValue({}),
-      },
-      roleHistory: {
-        create: vi.fn().mockResolvedValue({}),
-      },
+      participatesIn: { update: vi.fn().mockResolvedValue({}) },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
     }
-    ;(prisma.$transaction as any).mockImplementation(async (cb: any) => cb(mockTx))
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     const result = await promoteFromQueue(MOCK_SESSION_ID, specificUserId)
 
     expect(mockTx.audienceQueue.findUnique).toHaveBeenCalledWith({
       where: { session_id_user_id: { session_id: MOCK_SESSION_ID, user_id: specificUserId } },
-    })
-    expect(mockTx.participatesIn.update).toHaveBeenCalledWith({
-      where: {
-        user_id_session_id: {
-          user_id: specificUserId,
-          session_id: MOCK_SESSION_ID,
-        },
-      },
-      data: { session_role: SessionRole.DEBATER },
     })
     expect(result).toEqual({ promotedUserId: specificUserId })
   })
@@ -341,11 +385,356 @@ describe('promoteFromQueue', () => {
       id: MOCK_SESSION_ID,
       host_id: MOCK_HOST_ID,
       moderator_id: 'moderator-uuid',
-      host: { id: MOCK_HOST_ID },
-      moderator: { id: 'moderator-uuid' },
     })
+
+    const mockTx = {
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'queue-entry',
+          session_id: MOCK_SESSION_ID,
+          user_id: 'some-user',
+          joined_queue: new Date(),
+          user: { id: 'some-user', username: 'someone', realname: null },
+        }),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      participatesIn: { update: vi.fn().mockResolvedValue({}) },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
 
     await promoteFromQueue(MOCK_SESSION_ID)
     expect(prisma.$transaction).toHaveBeenCalled()
+  })
+})
+
+// ── castKickVote ──
+describe('castKickVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws if voting to kick yourself', async () => {
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_USER_ID)).rejects.toThrow('Cannot vote to kick yourself')
+  })
+
+  it('throws if voter is not AUDIENCE', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
+
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Only audience members can vote to kick')
+  })
+
+  it('throws if target is not DEBATER', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          }),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
+
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Target must be an active debater')
+  })
+
+  it('throws if target is HOST', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+      },
+      session: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: MOCK_SESSION_ID,
+          kick_threshold: 50,
+          host_id: MOCK_TARGET_USER_ID,
+        }),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
+
+    await expect(castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Cannot vote to kick the host')
+  })
+
+  it('creates vote on success', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+        update: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(5),
+      },
+      session: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: MOCK_SESSION_ID,
+          kick_threshold: 50,
+          host_id: 'host-user',
+        }),
+      },
+      vote: {
+        create: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(2),
+        deleteMany: vi.fn().mockResolvedValue({}),
+      },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
+
+    const result = await castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    expect(mockTx.vote.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+          target_user_id: MOCK_TARGET_USER_ID,
+          vote_type: VoteType.KICK,
+        }),
+      })
+    )
+    expect(result).toEqual({ kicked: false, voteCount: 2, requiredVotes: 3 })
+  })
+
+  it('returns kicked=true when threshold met (with correct math: ceil(audienceCount * threshold / 100))', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+        update: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(5),
+      },
+      session: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: MOCK_SESSION_ID,
+          kick_threshold: 50,
+          host_id: 'host-user',
+        }),
+      },
+      vote: {
+        create: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(3),
+        deleteMany: vi.fn().mockResolvedValue({}),
+      },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
+      debateState: {
+        findUnique: vi.fn().mockResolvedValue({
+          session_id: MOCK_SESSION_ID,
+          debater_order: [
+            { userId: 'other-debater', displayName: 'Other' },
+            { userId: MOCK_TARGET_USER_ID, displayName: 'Target' },
+          ],
+          current_index: 0,
+        }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
+
+    // audienceCount=5, threshold=50 -> requiredVotes = ceil(5 * 50 / 100) = ceil(2.5) = 3
+    // voteCount=3 -> kicked=true
+    const result = await castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    expect(result).toEqual({ kicked: true, voteCount: 3, requiredVotes: 3 })
+    expect(mockTx.participatesIn.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id_session_id: {
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+          },
+        }),
+        data: expect.objectContaining({ left_at: expect.any(Date) }),
+      })
+    )
+  })
+
+  it('returns kicked=false when threshold not met', async () => {
+    const mockTx = {
+      participatesIn: {
+        findUnique: vi.fn()
+          .mockResolvedValueOnce({
+            user_id: MOCK_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.AUDIENCE,
+            left_at: null,
+          })
+          .mockResolvedValueOnce({
+            user_id: MOCK_TARGET_USER_ID,
+            session_id: MOCK_SESSION_ID,
+            session_role: SessionRole.DEBATER,
+            left_at: null,
+          }),
+        update: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(10),
+      },
+      session: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: MOCK_SESSION_ID,
+          kick_threshold: 60,
+          host_id: 'host-user',
+        }),
+      },
+      vote: {
+        create: vi.fn().mockResolvedValue({}),
+        count: vi.fn().mockResolvedValue(5),
+        deleteMany: vi.fn().mockResolvedValue({}),
+      },
+      roleHistory: { create: vi.fn().mockResolvedValue({}) },
+      debateState: { findUnique: vi.fn().mockResolvedValue(null) },
+      audienceQueue: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    }
+    ;(prisma.$transaction as any).mockImplementation(async (fn: any) => fn(mockTx))
+
+    // audienceCount=10, threshold=60 -> requiredVotes = ceil(10 * 60 / 100) = ceil(6) = 6
+    // voteCount=5 -> kicked=false
+    const result = await castKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    expect(result).toEqual({ kicked: false, voteCount: 5, requiredVotes: 6 })
+    expect(mockTx.participatesIn.update).not.toHaveBeenCalled()
+  })
+})
+
+// ── removeKickVote ──
+describe('removeKickVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(removeKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('deletes the vote', async () => {
+    ;(prisma.vote.deleteMany as any).mockResolvedValue({})
+
+    await removeKickVote(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    expect(prisma.vote.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          session_id: MOCK_SESSION_ID,
+          voter_id: MOCK_USER_ID,
+          target_user_id: MOCK_TARGET_USER_ID,
+          vote_type: VoteType.KICK,
+        }),
+      })
+    )
+  })
+})
+
+// ── getKickVotes ──
+describe('getKickVotes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth(MOCK_USER_ID)
+  })
+
+  it('throws if not authenticated', async () => {
+    mockAuth(null)
+    await expect(getKickVotes(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns correct voteCount, requiredVotes, userHasVoted', async () => {
+    ;(prisma.vote.count as any).mockResolvedValue(3)
+    ;(prisma.participatesIn.count as any).mockResolvedValue(8)
+    ;(prisma.vote.findFirst as any).mockResolvedValue({ id: 'vote-1' })
+    ;(prisma.session.findUnique as any).mockResolvedValue({ kick_threshold: 50 })
+
+    const result = await getKickVotes(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    // audienceCount=8, threshold=50 -> requiredVotes = ceil(8 * 50 / 100) = ceil(4) = 4
+    expect(result).toEqual({
+      voteCount: 3,
+      requiredVotes: 4,
+      userHasVoted: true,
+    })
+  })
+
+  it('returns userHasVoted=false when user has not voted', async () => {
+    ;(prisma.vote.count as any).mockResolvedValue(2)
+    ;(prisma.participatesIn.count as any).mockResolvedValue(10)
+    ;(prisma.vote.findFirst as any).mockResolvedValue(null)
+    ;(prisma.session.findUnique as any).mockResolvedValue({ kick_threshold: 60 })
+
+    const result = await getKickVotes(MOCK_SESSION_ID, MOCK_TARGET_USER_ID)
+
+    // audienceCount=10, threshold=60 -> requiredVotes = ceil(10 * 60 / 100) = ceil(6) = 6
+    expect(result).toEqual({
+      voteCount: 2,
+      requiredVotes: 6,
+      userHasVoted: false,
+    })
   })
 })

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -10,8 +10,13 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }))
 
-vi.mock('@/lib/prisma', () => ({
-  prisma: {
+vi.mock('@/lib/actions/queue', () => ({
+  doPromoteFromQueue: vi.fn().mockResolvedValue(null),
+  cleanupUserVotes: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/prisma', () => {
+  const prismaMock = {
     session: {
       create: vi.fn(),
       findUnique: vi.fn(),
@@ -24,12 +29,23 @@ vi.mock('@/lib/prisma', () => ({
       update: vi.fn(),
       updateMany: vi.fn(),
     },
+    audienceQueue: {
+      deleteMany: vi.fn(),
+    },
+    vote: {
+      deleteMany: vi.fn(),
+    },
+    debateState: {
+      findUnique: vi.fn(),
+    },
     roleHistory: {
       create: vi.fn().mockResolvedValue({}),
     },
-    $transaction: vi.fn().mockResolvedValue([]),
-  },
-}))
+    $transaction: vi.fn(async (callback: any) => callback(prismaMock)),
+  }
+
+  return { prisma: prismaMock }
+})
 
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
@@ -160,6 +176,17 @@ describe('createSession', () => {
   it('throws if audience capacity is negative', async () => {
     await expect(createSession(sessionForm({ audienceCapacity: -1 }) as any)).rejects.toThrow(
       'Audience capacity cannot be negative'
+    )
+  })
+
+  it('stores kick_threshold when provided', async () => {
+    await createSession(sessionForm({ kickThreshold: 75 }) as any)
+    expect(prisma.session.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          kick_threshold: 75,
+        }),
+      })
     )
   })
 })
@@ -336,7 +363,15 @@ describe('leaveSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAuth(MOCK_USER_ID)
+    ;(prisma.participatesIn.findUnique as any).mockResolvedValue({
+      user_id: MOCK_USER_ID,
+      session_id: MOCK_SESSION_ID,
+      session_role: SessionRole.AUDIENCE,
+    })
     ;(prisma.participatesIn.update as any).mockResolvedValue({})
+    ;(prisma.audienceQueue.deleteMany as any).mockResolvedValue({})
+    ;(prisma.vote.deleteMany as any).mockResolvedValue({})
+    ;(prisma.debateState.findUnique as any).mockResolvedValue(null)
   })
 
   it('throws if not authenticated', async () => {
@@ -364,6 +399,11 @@ describe('leaveSession', () => {
         }),
       })
     )
+  })
+
+  it('cleans up queue entry and votes', async () => {
+    await leaveSession(MOCK_SESSION_ID)
+    expect(prisma.audienceQueue.deleteMany).toHaveBeenCalled()
   })
 })
 
@@ -529,6 +569,11 @@ describe('kickParticipant — participant check', () => {
       moderator_id: null,
     })
     ;(prisma.participatesIn.update as any).mockResolvedValue({})
+    ;(prisma.audienceQueue.deleteMany as any).mockResolvedValue({})
+    ;(prisma.vote.deleteMany as any).mockResolvedValue({})
+    ;(prisma.debateState.findUnique as any).mockResolvedValue(null)
+    // kickParticipant uses $transaction — restore the implementation after clearAllMocks
+    ;(prisma.$transaction as any).mockImplementation(async (callback: any) => callback(prisma))
   })
 
   it('throws if target user is not an active participant', async () => {
@@ -554,6 +599,7 @@ describe('kickParticipant — participant check', () => {
       user_id: TARGET_USER_ID,
       session_id: MOCK_SESSION_ID,
       left_at: null,
+      session_role: SessionRole.AUDIENCE,
     })
     await kickParticipant(MOCK_SESSION_ID, TARGET_USER_ID)
     expect(prisma.participatesIn.update).toHaveBeenCalledWith(

--- a/app/api/leave-session/route.ts
+++ b/app/api/leave-session/route.ts
@@ -1,5 +1,7 @@
 import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
+import { SessionRole } from "@/lib/generated/prisma"
+import { doPromoteFromQueue, cleanupUserVotes } from "@/lib/actions/queue"
 import { NextRequest, NextResponse } from "next/server"
 
 export async function POST(req: NextRequest) {
@@ -10,14 +12,54 @@ export async function POST(req: NextRequest) {
   const { sessionId } = await req.json()
   if (!sessionId) return NextResponse.json({ error: "sessionId required" }, { status: 400 })
 
-  await prisma.participatesIn.update({
+  const participation = await prisma.participatesIn.findUnique({
     where: {
-      user_id_session_id: {
-        user_id: user.id,
-        session_id: sessionId,
-      },
+      user_id_session_id: { user_id: user.id, session_id: sessionId },
     },
-    data: { left_at: new Date() },
+  })
+  if (!participation) return NextResponse.json({ error: "Not a participant" }, { status: 400 })
+
+  const wasDebater = participation.session_role === SessionRole.DEBATER
+
+  await prisma.$transaction(async (tx) => {
+    await tx.participatesIn.update({
+      where: {
+        user_id_session_id: { user_id: user.id, session_id: sessionId },
+      },
+      data: { left_at: new Date() },
+    })
+
+    // Remove from queue
+    await tx.audienceQueue.deleteMany({
+      where: { session_id: sessionId, user_id: user.id },
+    })
+
+    // Clean up votes
+    await cleanupUserVotes(tx, sessionId, user.id)
+
+    // If was debater, remove from debater_order and auto-promote
+    if (wasDebater) {
+      const state = await tx.debateState.findUnique({
+        where: { session_id: sessionId },
+      })
+      if (state) {
+        const order = state.debater_order as { userId: string; displayName: string }[]
+        const removedIndex = order.findIndex((d) => d.userId === user.id)
+        const newOrder = order.filter((d) => d.userId !== user.id)
+        let newIndex = state.current_index
+        if (removedIndex < state.current_index) {
+          newIndex = Math.max(0, newIndex - 1)
+        } else if (removedIndex === state.current_index && newOrder.length > 0) {
+          newIndex = newIndex % newOrder.length
+        }
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: { debater_order: newOrder, current_index: newIndex },
+        })
+      }
+
+      await doPromoteFromQueue(tx, sessionId)
+    }
   })
 
   return NextResponse.json({ success: true })

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -26,6 +26,7 @@ export default function CreateRoom() {
   const [debaterCapacityOpponent, setDebaterCapacityOpponent] = useState('1')
   const [debaterCapacityPanel, setDebaterCapacityPanel] = useState('5')
   const [audienceCapacity, setAudienceCapacity] = useState('10')
+  const [kickThreshold, setKickThreshold] = useState('50')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [previewCode, setPreviewCode] = useState('ARG-····')
@@ -82,6 +83,7 @@ export default function CreateRoom() {
         debaterCapacityPanel: selectedFormat === 'panel' ? parseInt(debaterCapacityPanel) : null,
         audienceCapacity: parseInt(audienceCapacity),
         turnLength: parseInt(turnLength),
+        kickThreshold: parseInt(kickThreshold),
       })
       // createSession redirects on success, so we only reach here on error
     } catch (err) {
@@ -270,13 +272,20 @@ export default function CreateRoom() {
                 <div>
                   <label className="block text-sm font-bold debate-mono mb-2 text-white">
                     <Settings className="w-4 h-4 inline mr-2" />
-                    MODERATION
+                    KICK VOTE THRESHOLD
                   </label>
-                  <select className="debate-input w-full">
-                    <option>Auto-moderate</option>
-                    <option>Manual moderation</option>
-                    <option>No moderation</option>
+                  <select
+                    value={kickThreshold}
+                    onChange={(e) => setKickThreshold(e.target.value)}
+                    className="debate-input w-full"
+                  >
+                    <option value="25">25% of audience</option>
+                    <option value="50">50% of audience</option>
+                    <option value="75">75% of audience</option>
                   </select>
+                  <p className="text-xs debate-mono text-gray-500 mt-1">
+                    % of audience votes needed to kick a speaker
+                  </p>
                 </div>
               </div>
             </div>

--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { motion } from 'framer-motion'
 import {
   Users,
@@ -20,12 +20,17 @@ import {
   Settings,
   Loader2,
   Swords,
+  Hand,
   ArrowUp,
+  ThumbsDown,
+  Crown,
   RefreshCw,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useMediasoup } from '@/hooks/useMediasoup'
 import { useDebateChannel } from '@/hooks/useDebateChannel'
+import { useQueueChannel } from '@/hooks/useQueueChannel'
+import { useKickVoteChannel } from '@/hooks/useKickVoteChannel'
 import { createClient } from '@/lib/supabase/client'
 import VideoPanel from '@/components/VideoPanel'
 import { Button } from '@/components/ui/button'
@@ -33,6 +38,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { userStub, getInitials, formatTime } from '@/lib/utils'
 import { leaveSession, updateSessionStatus, joinSession, joinSessionAsDebater, kickParticipant, assignModerator, promoteToDebater } from '@/lib/actions/session'
+import { promoteFromQueue } from '@/lib/actions/queue'
 import { extendTurn } from '@/lib/actions/debate'
 import { useRouter } from 'next/navigation'
 import { SessionRole, SessionStatus, SessionType } from '@/lib/generated/prisma'
@@ -48,6 +54,7 @@ interface SessionData {
   debaterCapacityOpponent: number | null
   debaterCapacityPanel: number | null
   audienceCapacity: number
+  kickThreshold: number
   host: { id: string; username: string; realname: string | null }
   moderator: { id: string; username: string; realname: string | null } | null
   participatesIns: {
@@ -98,7 +105,6 @@ export default function RoomClient({
     connectionState,
     localStream,
     remoteStreams,
-    reconnectingPeers,
     audioMuted,
     videoOff,
     toggleMute,
@@ -115,6 +121,27 @@ export default function RoomClient({
   const debate = useDebateChannel({
     sessionId: session.id,
     userId: currentUserId,
+  })
+
+  const queueChannel = useQueueChannel({
+    sessionId: session.id,
+    userId: currentUserId,
+  })
+
+  const isAudience = currentRole === SessionRole.AUDIENCE
+  const isExpertVsCrowd = session.type === SessionType.EXPERT_VS_CROWD
+
+  // Compute debater IDs for kick-vote tracking (exclude host)
+  const debaterIdsForVote = useMemo(() => {
+    return debate.debaters
+      .filter((d) => d.userId !== session.host.id)
+      .map((d) => d.userId)
+  }, [debate.debaters, session.host.id])
+
+  const kickVoteChannel = useKickVoteChannel({
+    sessionId: session.id,
+    userId: currentUserId,
+    debaterIds: debaterIdsForVote,
   })
 
   // Derive isPaused from debate channel (authoritative source via Supabase Realtime)
@@ -230,6 +257,9 @@ export default function RoomClient({
   async function handleLeave() {
     disconnectSfu()
     try {
+      if (queueChannel.isInQueue) {
+        await queueChannel.leaveQueue()
+      }
       await leaveSession(session.id)
     } catch (err) {
       console.error('Failed to leave:', err)
@@ -276,15 +306,17 @@ export default function RoomClient({
   async function handleStartSession() {
     setIsStarting(true)
     try {
-      await updateSessionStatus(session.id, 'LIVE')
-
       // Build debater list from participants with HOST or DEBATER role
       const debaterList = debaters.map((p) => ({
         userId: p.user.id,
         displayName: p.user.realname || p.user.username,
       }))
 
-      if (debaterList.length >= 2) {
+      if (isExpertVsCrowd) {
+        // Expert vs Crowd: pass only the expert (host), backend auto-promotes from queue
+        const expert = debaterList.find((d) => d.userId === session.host.id) ?? debaterList[0]
+        await debate.startDebate([expert], session.turnLength)
+      } else if (debaterList.length >= 2) {
         await debate.startDebate(debaterList, session.turnLength)
       }
 
@@ -421,8 +453,9 @@ export default function RoomClient({
   }
 
   // Check if debate can start
-  const canStartDebate =
-    session.type === SessionType.ONE_ON_ONE
+  const canStartDebate = isExpertVsCrowd
+    ? debaters.length >= 1 && queueChannel.queue.length >= 1
+    : session.type === SessionType.ONE_ON_ONE
       ? debaters.length === 2
       : debaters.length >= 2
 
@@ -570,38 +603,95 @@ export default function RoomClient({
                     ) : (
                       <div className="flex flex-col space-y-4">
                         {/* Debater display */}
-                        {isDebateLive && debate.debaters.length === 2 ? (
+                        {isDebateLive && debate.debaters.length >= 2 ? (
                           <div className="flex items-center justify-center gap-6">
                             {debate.debaters.map((d, i) => {
                               const isSpeaking = debate.currentSpeaker?.userId === d.userId
+                              const isHostDebater = d.userId === session.host.id
+                              const voteState = kickVoteChannel.voteStates[d.userId]
+                              const canVoteToKick = isAudience && !isHostDebater
                               return (
                                 <div
                                   key={d.userId}
-                                  className={`flex items-center space-x-3 p-3 border-2 transition-all ${
+                                  className={`flex flex-col p-3 border-2 transition-all ${
                                     isSpeaking
                                       ? 'border-yellow-400 bg-yellow-400/10 shadow-[0_0_15px_rgba(250,204,21,0.3)]'
                                       : 'border-white/20 opacity-60'
                                   }`}
                                 >
-                                  <div
-                                    className={`w-14 h-14 border-2 border-black flex items-center justify-center text-white font-bold text-lg ${
-                                      i === 0
-                                        ? 'bg-gradient-to-br from-red-600 to-red-800'
-                                        : 'bg-gradient-to-br from-blue-600 to-blue-800'
-                                    }`}
-                                  >
-                                    {getInitials(d.displayName)}
+                                  <div className="flex items-center space-x-3">
+                                    <div
+                                      className={`w-14 h-14 border-2 border-black flex items-center justify-center text-white font-bold text-lg ${
+                                        i === 0
+                                          ? 'bg-gradient-to-br from-red-600 to-red-800'
+                                          : 'bg-gradient-to-br from-blue-600 to-blue-800'
+                                      }`}
+                                    >
+                                      {getInitials(d.displayName)}
+                                    </div>
+                                    <div>
+                                      <div className="flex items-center gap-2">
+                                        <h3 className="text-lg font-bold debate-title text-white">
+                                          {d.displayName}
+                                        </h3>
+                                        {isExpertVsCrowd && i === 0 && (
+                                          <span className="debate-badge bg-purple-600 text-white text-xs flex items-center gap-1">
+                                            <Crown className="w-3 h-3" /> EXPERT
+                                          </span>
+                                        )}
+                                        {isExpertVsCrowd && i === 1 && (
+                                          <span className="debate-badge bg-orange-600 text-white text-xs">
+                                            CHALLENGER
+                                          </span>
+                                        )}
+                                      </div>
+                                      {isSpeaking && (
+                                        <span className="debate-badge bg-yellow-400 text-black text-xs">
+                                          SPEAKING
+                                        </span>
+                                      )}
+                                    </div>
                                   </div>
-                                  <div>
-                                    <h3 className="text-lg font-bold debate-title text-white">
-                                      {d.displayName}
-                                    </h3>
-                                    {isSpeaking && (
-                                      <span className="debate-badge bg-yellow-400 text-black text-xs">
-                                        SPEAKING
-                                      </span>
-                                    )}
-                                  </div>
+                                  {/* Kick vote UI */}
+                                  {canVoteToKick && voteState && (
+                                    <div className="mt-2 pt-2 border-t border-white/10">
+                                      <div className="flex items-center justify-between mb-1">
+                                        <span className="text-xs debate-mono text-gray-400">
+                                          {voteState.voteCount} / {voteState.requiredVotes} votes to kick
+                                        </span>
+                                      </div>
+                                      <div className="w-full bg-gray-700 h-1.5 mb-2">
+                                        <div
+                                          className="bg-red-500 h-1.5 transition-all"
+                                          style={{
+                                            width: `${Math.min(100, voteState.requiredVotes > 0 ? (voteState.voteCount / voteState.requiredVotes) * 100 : 0)}%`,
+                                          }}
+                                        />
+                                      </div>
+                                      <Button
+                                        variant="outline"
+                                        size="sm"
+                                        className={`debate-button w-full text-xs ${
+                                          voteState.userHasVoted ? 'border-red-500 text-red-400' : ''
+                                        }`}
+                                        onClick={async () => {
+                                          try {
+                                            if (voteState.userHasVoted) {
+                                              await kickVoteChannel.removeVote(d.userId)
+                                            } else {
+                                              await kickVoteChannel.castVote(d.userId)
+                                            }
+                                            router.refresh()
+                                          } catch (err) {
+                                            console.error('Vote failed:', err)
+                                          }
+                                        }}
+                                      >
+                                        <ThumbsDown className="w-3 h-3 mr-1" />
+                                        {voteState.userHasVoted ? 'REMOVE VOTE' : 'VOTE TO KICK'}
+                                      </Button>
+                                    </div>
+                                  )}
                                 </div>
                               )
                             })}
@@ -641,13 +731,6 @@ export default function RoomClient({
                                   <div className="text-center">
                                     <Loader2 className="w-10 h-10 text-white/40 mx-auto mb-2 animate-spin" />
                                     <p className="text-white/40 debate-mono text-sm">CONNECTING TO VIDEO...</p>
-                                  </div>
-                                </div>
-                              ) : connectionState === 'reconnecting' ? (
-                                <div className="min-h-[250px] bg-gradient-to-br from-gray-900 to-gray-700 rounded-md border-2 border-yellow-600/50 flex items-center justify-center">
-                                  <div className="text-center">
-                                    <Loader2 className="w-10 h-10 text-yellow-400/60 mx-auto mb-2 animate-spin" />
-                                    <p className="text-yellow-400/60 debate-mono text-sm">RECONNECTING TO VIDEO...</p>
                                   </div>
                                 </div>
                               ) : connectionState === 'error' ? (
@@ -690,7 +773,7 @@ export default function RoomClient({
                             </div>
 
                             {/* Audio/Video toggle controls */}
-                            {(connectionState === 'connected' || connectionState === 'reconnecting') && (
+                            {connectionState === 'connected' && (
                               <div className="flex items-center gap-2">
                                 <Button
                                   variant="outline"
@@ -720,7 +803,121 @@ export default function RoomClient({
                 </Card>
               </div>
 
-              {/* Audience Queue */}
+              {/* Speaker Queue */}
+              <div>
+                <Card className="debate-card border-2">
+                  <CardHeader className="border-b-2 border-white/20">
+                    <CardTitle className="debate-title flex items-center justify-between text-white">
+                      <div className="flex items-center">
+                        <Hand className="w-4 h-4 mr-2" />
+                        SPEAKER QUEUE ({queueChannel.queue.length})
+                      </div>
+                      {queueChannel.queue.length > 0 && isExpertVsCrowd && (
+                        <span className="text-xs debate-mono text-orange-400 font-normal">
+                          NEXT UP: {queueChannel.queue[0]?.displayName}
+                        </span>
+                      )}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="p-4">
+                    {/* Queue actions for audience members */}
+                    {isAudience && (
+                      <div className="mb-4">
+                        {queueChannel.isInQueue ? (
+                          <div className="space-y-2">
+                            <div className="text-center p-2 border-2 border-yellow-500/30 bg-yellow-500/5">
+                              <p className="text-yellow-400 debate-mono text-sm font-bold">
+                                You are #{queueChannel.myPosition} in queue
+                              </p>
+                            </div>
+                            <Button
+                              variant="outline"
+                              className="debate-button w-full text-xs"
+                              onClick={async () => {
+                                try {
+                                  await queueChannel.leaveQueue()
+                                } catch (err) {
+                                  console.error('Failed to leave queue:', err)
+                                }
+                              }}
+                            >
+                              LEAVE QUEUE
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            className="debate-button bg-yellow-500 text-black border-yellow-600 w-full font-bold"
+                            onClick={async () => {
+                              try {
+                                await queueChannel.joinQueue()
+                              } catch (err) {
+                                console.error('Failed to join queue:', err)
+                              }
+                            }}
+                          >
+                            <Hand className="w-4 h-4 mr-2" />
+                            {isExpertVsCrowd ? 'JOIN SPEAKER QUEUE' : 'JOIN QUEUE'}
+                          </Button>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Moderator promote button */}
+                    {isModeratorOrCreator && queueChannel.queue.length > 0 && (
+                      <div className="mb-4">
+                        <Button
+                          variant="outline"
+                          className="debate-button w-full text-xs"
+                          onClick={async () => {
+                            try {
+                              await promoteFromQueue(session.id)
+                              router.refresh()
+                            } catch (err) {
+                              console.error('Failed to promote:', err)
+                            }
+                          }}
+                        >
+                          <ArrowUp className="w-3 h-3 mr-1" />
+                          PROMOTE NEXT: {queueChannel.queue[0]?.displayName}
+                        </Button>
+                      </div>
+                    )}
+
+                    {/* Queue list */}
+                    {queueChannel.queue.length === 0 ? (
+                      <p className="text-gray-500 debate-mono text-sm text-center py-2">Queue is empty</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {queueChannel.queue.map((entry) => (
+                          <div
+                            key={entry.id}
+                            className={`flex items-center gap-3 p-2 border-2 ${
+                              entry.userId === currentUserId
+                                ? 'border-yellow-500/50 bg-yellow-500/5'
+                                : 'border-white/10'
+                            }`}
+                          >
+                            <span className="text-xs debate-mono text-gray-500 w-6 text-right">
+                              #{entry.rank}
+                            </span>
+                            <div className="w-8 h-8 bg-gray-600 text-white font-bold text-xs flex items-center justify-center border border-black">
+                              {getInitials(entry.displayName)}
+                            </div>
+                            <span className="text-sm debate-mono text-white truncate flex-1">
+                              {entry.displayName}
+                            </span>
+                            {entry.rank === 1 && isExpertVsCrowd && (
+                              <span className="debate-badge bg-orange-600 text-white text-[10px]">NEXT</span>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+
+              {/* Audience (watching, not in queue) */}
               <div>
                 <Card className="debate-card border-2">
                   <CardHeader className="border-b-2 border-white/20">
@@ -730,7 +927,8 @@ export default function RoomClient({
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="p-4">
-                    {canUpgradeToDebater && (
+                    {/* Direct debater upgrade (non-Expert vs Crowd, non-queue path) */}
+                    {canUpgradeToDebater && !isExpertVsCrowd && (
                       <div className="mb-4">
                         {session.type === SessionType.PANEL ? (
                           <Button
@@ -807,23 +1005,34 @@ export default function RoomClient({
                       <p className="text-gray-500 debate-mono text-sm text-center py-4">No audience members yet</p>
                     ) : (
                       <div className="grid grid-cols-4 gap-3">
-                        {audience.map((person, index) => (
-                          <motion.div
-                            key={person.userId}
-                            initial={{ opacity: 0, y: 20 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            transition={{ delay: index * 0.1 }}
-                            className="text-center p-3 border-2 border-white/20 hover:border-red-600 transition-colors cursor-pointer"
-                          >
-                            <div className="w-12 h-12 bg-gray-600 text-white font-bold text-sm flex items-center justify-center mx-auto mb-2 border-2 border-black">
-                              {getInitials(displayName(person.user))}
-                            </div>
-                            <p className="text-xs debate-mono font-medium truncate text-white">
-                              {displayName(person.user)}
-                            </p>
-                            <p className="text-xs debate-mono text-gray-400">#{index + 1}</p>
-                          </motion.div>
-                        ))}
+                        {audience.map((person, index) => {
+                          const queueEntry = queueChannel.queue.find((q) => q.userId === person.userId)
+                          return (
+                            <motion.div
+                              key={person.userId}
+                              initial={{ opacity: 0, y: 20 }}
+                              animate={{ opacity: 1, y: 0 }}
+                              transition={{ delay: index * 0.05 }}
+                              className={`text-center p-3 border-2 transition-colors ${
+                                queueEntry
+                                  ? 'border-yellow-500/40 bg-yellow-500/5'
+                                  : 'border-white/20 hover:border-red-600'
+                              }`}
+                            >
+                              <div className="w-12 h-12 bg-gray-600 text-white font-bold text-sm flex items-center justify-center mx-auto mb-2 border-2 border-black">
+                                {getInitials(displayName(person.user))}
+                              </div>
+                              <p className="text-xs debate-mono font-medium truncate text-white">
+                                {displayName(person.user)}
+                              </p>
+                              {queueEntry ? (
+                                <p className="text-xs debate-mono text-yellow-400">Queue #{queueEntry.rank}</p>
+                              ) : (
+                                <p className="text-xs debate-mono text-gray-400">watching</p>
+                              )}
+                            </motion.div>
+                          )
+                        })}
                       </div>
                     )}
                   </CardContent>

--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -42,6 +42,7 @@ export default async function RoomPage({ params }: { params: Promise<{ code: str
     debaterCapacityOpponent: session.debater_capacity_opponent,
     debaterCapacityPanel: session.debater_capacity_panel,
     audienceCapacity: session.audience_capacity,
+    kickThreshold: session.kick_threshold,
     host: {
       id: session.host.id,
       username: session.host.username,

--- a/hooks/useKickVoteChannel.ts
+++ b/hooks/useKickVoteChannel.ts
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import {
+  castKickVote as castKickVoteAction,
+  removeKickVote as removeKickVoteAction,
+  getKickVotes as getKickVotesAction,
+} from '@/lib/actions/queue'
+
+export interface KickVoteState {
+  voteCount: number
+  requiredVotes: number
+  userHasVoted: boolean
+}
+
+interface UseKickVoteChannelOptions {
+  sessionId: string
+  userId: string | null
+  debaterIds: string[]
+}
+
+export function useKickVoteChannel({
+  sessionId,
+  userId,
+  debaterIds,
+}: UseKickVoteChannelOptions) {
+  const [voteStates, setVoteStates] = useState<Record<string, KickVoteState>>({})
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const fetchVotes = useCallback(async () => {
+    if (!userId || debaterIds.length === 0) return
+    try {
+      const results = await Promise.all(
+        debaterIds.map(async (targetId) => {
+          const data = await getKickVotesAction(sessionId, targetId)
+          return [targetId, data] as const
+        })
+      )
+      setVoteStates(Object.fromEntries(results))
+    } catch (err) {
+      console.error('Failed to fetch kick votes:', err)
+    }
+  }, [sessionId, userId, debaterIds])
+
+  const debouncedFetch = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(fetchVotes, 500)
+  }, [fetchVotes])
+
+  // Subscribe to Vote table changes
+  useEffect(() => {
+    const supabase = createClient()
+
+    const channel = supabase
+      .channel(`votes:${sessionId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'Vote',
+          filter: `session_id=eq.${sessionId}`,
+        },
+        () => { debouncedFetch() },
+      )
+      .subscribe(async (status) => {
+        if (status === 'SUBSCRIBED') {
+          await fetchVotes()
+        }
+      })
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      supabase.removeChannel(channel)
+    }
+  }, [sessionId, fetchVotes, debouncedFetch])
+
+  const castVote = useCallback(
+    (targetUserId: string) => castKickVoteAction(sessionId, targetUserId),
+    [sessionId],
+  )
+
+  const removeVote = useCallback(
+    (targetUserId: string) => removeKickVoteAction(sessionId, targetUserId),
+    [sessionId],
+  )
+
+  return {
+    voteStates,
+    castVote,
+    removeVote,
+  }
+}

--- a/hooks/useQueueChannel.ts
+++ b/hooks/useQueueChannel.ts
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import {
+  getQueue as getQueueAction,
+  joinQueue as joinQueueAction,
+  leaveQueue as leaveQueueAction,
+} from '@/lib/actions/queue'
+
+export interface QueueEntry {
+  id: string
+  userId: string
+  rank: number
+  displayName: string
+  addedAt: string
+}
+
+interface UseQueueChannelOptions {
+  sessionId: string
+  userId: string | null
+}
+
+export function useQueueChannel({ sessionId, userId }: UseQueueChannelOptions) {
+  const [queue, setQueue] = useState<QueueEntry[]>([])
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const fetchQueue = useCallback(async () => {
+    try {
+      const entries = await getQueueAction(sessionId)
+      setQueue(entries)
+    } catch (err) {
+      console.error('Failed to fetch queue:', err)
+    }
+  }, [sessionId])
+
+  const debouncedFetch = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(fetchQueue, 500)
+  }, [fetchQueue])
+
+  // Subscribe to Realtime + fetch initial state
+  useEffect(() => {
+    const supabase = createClient()
+
+    const channel = supabase
+      .channel(`queue:${sessionId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'AudienceQueue',
+          filter: `session_id=eq.${sessionId}`,
+        },
+        () => { debouncedFetch() },
+      )
+      .subscribe(async (status) => {
+        if (status === 'SUBSCRIBED') {
+          await fetchQueue()
+        }
+      })
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      supabase.removeChannel(channel)
+    }
+  }, [sessionId, fetchQueue, debouncedFetch])
+
+  const myPosition = userId
+    ? queue.find((e) => e.userId === userId)?.rank ?? null
+    : null
+
+  const isInQueue = myPosition !== null
+
+  const joinQueue = useCallback(
+    () => joinQueueAction(sessionId),
+    [sessionId],
+  )
+
+  const leaveQueue = useCallback(
+    () => leaveQueueAction(sessionId),
+    [sessionId],
+  )
+
+  return {
+    queue,
+    myPosition,
+    isInQueue,
+    joinQueue,
+    leaveQueue,
+  }
+}

--- a/lib/actions/debate.ts
+++ b/lib/actions/debate.ts
@@ -2,7 +2,9 @@
 
 import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
+import { SessionRole, SessionType } from "@/lib/generated/prisma"
 import { requireHostOrModerator } from "@/lib/actions/utils"
+import { doPromoteFromQueue } from "@/lib/actions/queue"
 
 export async function getDebateState(sessionId: string) {
   // Auth check: require authenticated user
@@ -33,10 +35,63 @@ export async function startDebate(
   debaters: { userId: string; displayName: string }[],
   turnLength: number
 ) {
-  await requireHostOrModerator(sessionId)
-  if (debaters.length !== 2) throw new Error("Exactly 2 debaters required")
+  const { session } = await requireHostOrModerator(sessionId)
+
   if (turnLength < 1) throw new Error("Turn length must be at least 1 second")
   if (turnLength > 1800) throw new Error("Turn length cannot exceed 30 minutes (1800 seconds)")
+
+  if (session.type === SessionType.EXPERT_VS_CROWD) {
+    // Expert vs Crowd: accept 1 debater (expert), auto-promote first queue member
+    if (debaters.length !== 1) throw new Error("Expert vs. Crowd requires exactly 1 expert")
+
+    // Validate the expert is an active participant
+    const participation = await prisma.participatesIn.findMany({
+      where: {
+        session_id: sessionId,
+        left_at: null,
+        user_id: { in: debaters.map((d) => d.userId) },
+      },
+      select: { user_id: true },
+    })
+    const participantIds = new Set(participation.map((p: { user_id: string }) => p.user_id))
+    for (const debater of debaters) {
+      if (!participantIds.has(debater.userId)) {
+        throw new Error(`Debater ${debater.userId} is not an active participant in this session`)
+      }
+    }
+
+    return prisma.$transaction(async (tx) => {
+      // Pop first queue member as challenger
+      const challenger = await doPromoteFromQueue(tx, sessionId)
+      if (!challenger) throw new Error("No one in the queue to challenge the expert")
+
+      const debaterOrder = [debaters[0], challenger]
+      const now = Date.now()
+      await tx.debateState.upsert({
+        where: { session_id: sessionId },
+        create: {
+          session_id: sessionId,
+          debater_order: debaterOrder,
+          current_index: 0,
+          turn_length: turnLength,
+          turn_ends_at: now + turnLength * 1000,
+          is_paused: false,
+          paused_time_remaining: turnLength,
+        },
+        update: {
+          debater_order: debaterOrder,
+          current_index: 0,
+          turn_length: turnLength,
+          turn_ends_at: now + turnLength * 1000,
+          is_paused: false,
+          paused_time_remaining: turnLength,
+        },
+      })
+    })
+  }
+
+  // All other formats: require at least 2 debaters
+  if (debaters.length < 2) throw new Error("At least 2 debaters required")
 
   // Validate debater IDs are active participants in the session
   const participants = await prisma.participatesIn.findMany({
@@ -78,18 +133,77 @@ export async function startDebate(
 }
 
 export async function advanceTurn(sessionId: string) {
-  await requireHostOrModerator(sessionId)
+  const { session } = await requireHostOrModerator(sessionId)
 
   const state = await prisma.debateState.findUnique({
     where: { session_id: sessionId },
   })
   if (!state) throw new Error("No active debate")
 
+  const order = state.debater_order as { userId: string; displayName: string }[]
+
+  if (session.type === SessionType.EXPERT_VS_CROWD && state.current_index === 1) {
+    // Challenger just finished — rotate challenger from queue
+    return prisma.$transaction(async (tx) => {
+      const oldChallenger = order[1]
+
+      // Demote old challenger back to AUDIENCE
+      if (oldChallenger) {
+        await tx.participatesIn.update({
+          where: {
+            user_id_session_id: {
+              user_id: oldChallenger.userId,
+              session_id: sessionId,
+            },
+          },
+          data: { session_role: SessionRole.AUDIENCE },
+        })
+      }
+
+      // Promote next from queue
+      const newChallenger = await doPromoteFromQueue(tx, sessionId)
+
+      if (!newChallenger) {
+        // No one in queue — pause debate
+        const remaining = state.turn_ends_at
+          ? Math.max(0, (state.turn_ends_at - Date.now()) / 1000)
+          : state.turn_length
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: {
+            // Keep expert at index 0, remove old challenger
+            debater_order: [order[0]],
+            current_index: 0,
+            is_paused: true,
+            turn_ends_at: null,
+            paused_time_remaining: remaining,
+          },
+        })
+        return
+      }
+
+      // doPromoteFromQueue appends to debater_order, but we need to replace index 1
+      // So we manually set the order to [expert, newChallenger]
+      const now = Date.now()
+      await tx.debateState.update({
+        where: { session_id: sessionId },
+        data: {
+          debater_order: [order[0], newChallenger],
+          current_index: 0,
+          turn_ends_at: now + state.turn_length * 1000,
+          is_paused: false,
+          paused_time_remaining: state.turn_length,
+        },
+      })
+    })
+  }
+
+  // Standard turn advancement for all formats
   const now = Date.now()
   await prisma.debateState.update({
     where: { session_id: sessionId },
     data: {
-      current_index: (state.current_index + 1) % 2,
+      current_index: (state.current_index + 1) % order.length,
       turn_ends_at: now + state.turn_length * 1000,
       is_paused: false,
       paused_time_remaining: state.turn_length,
@@ -116,8 +230,73 @@ export async function advanceTurnIfExpired(sessionId: string) {
   if (!state || state.is_paused || !state.turn_ends_at) return
   if (Date.now() < state.turn_ends_at - 1000) return
 
+  const order = state.debater_order as { userId: string; displayName: string }[]
+
+  // Check if this is Expert vs Crowd and challenger's turn ended
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { type: true },
+  })
+
+  if (session?.type === SessionType.EXPERT_VS_CROWD && state.current_index === 1) {
+    // Challenger turn expired — rotate via transaction
+    return prisma.$transaction(async (tx) => {
+      // Atomic guard: only proceed if state hasn't changed
+      const current = await tx.debateState.findUnique({
+        where: { session_id: sessionId },
+      })
+      if (
+        !current ||
+        current.current_index !== state.current_index ||
+        current.is_paused
+      ) {
+        return // Already advanced by someone else
+      }
+
+      const oldChallenger = order[1]
+      if (oldChallenger) {
+        await tx.participatesIn.update({
+          where: {
+            user_id_session_id: {
+              user_id: oldChallenger.userId,
+              session_id: sessionId,
+            },
+          },
+          data: { session_role: SessionRole.AUDIENCE },
+        })
+      }
+
+      const newChallenger = await doPromoteFromQueue(tx, sessionId)
+
+      if (!newChallenger) {
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: {
+            debater_order: [order[0]],
+            current_index: 0,
+            is_paused: true,
+            turn_ends_at: null,
+            paused_time_remaining: state.turn_length,
+          },
+        })
+        return
+      }
+
+      const now = Date.now()
+      await tx.debateState.update({
+        where: { session_id: sessionId },
+        data: {
+          debater_order: [order[0], newChallenger],
+          current_index: 0,
+          turn_ends_at: now + state.turn_length * 1000,
+          paused_time_remaining: state.turn_length,
+        },
+      })
+    })
+  }
+
+  // Standard auto-advance for all other formats
   const now = Date.now()
-  // Atomic guard: only advance if current_index hasn't changed (prevents double-advance)
   await prisma.debateState.updateMany({
     where: {
       session_id: sessionId,
@@ -125,7 +304,7 @@ export async function advanceTurnIfExpired(sessionId: string) {
       is_paused: false,
     },
     data: {
-      current_index: (state.current_index + 1) % 2,
+      current_index: (state.current_index + 1) % order.length,
       turn_ends_at: now + state.turn_length * 1000,
       paused_time_remaining: state.turn_length,
     },

--- a/lib/actions/queue.ts
+++ b/lib/actions/queue.ts
@@ -2,7 +2,88 @@
 
 import { prisma } from "@/lib/prisma"
 import { requireAuth, requireHostOrModerator } from "@/lib/actions/utils"
-import { SessionRole, SessionStatus } from "@/lib/generated/prisma"
+import { SessionRole, SessionStatus, VoteType } from "@/lib/generated/prisma"
+import type { PrismaClient } from "@/lib/generated/prisma"
+
+type TransactionClient = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0]
+
+// ---------------------------------------------------------------------------
+// Internal helpers (NOT server actions — called within transactions)
+// ---------------------------------------------------------------------------
+
+/** Pop the front of the queue (oldest joined_queue), promote to DEBATER, update DebateState. */
+async function doPromoteFromQueue(
+  tx: TransactionClient,
+  sessionId: string
+): Promise<{ userId: string; displayName: string } | null> {
+  const front = await tx.audienceQueue.findFirst({
+    where: { session_id: sessionId },
+    orderBy: [{ joined_queue: "asc" }, { id: "asc" }],
+    include: { user: { select: { id: true, username: true, realname: true } } },
+  })
+  if (!front) return null
+
+  // Remove from queue
+  await tx.audienceQueue.delete({ where: { id: front.id } })
+
+  // Update ParticipatesIn to DEBATER
+  await tx.participatesIn.update({
+    where: {
+      user_id_session_id: {
+        user_id: front.user_id,
+        session_id: sessionId,
+      },
+    },
+    data: { session_role: SessionRole.DEBATER },
+  })
+
+  const displayName = front.user.realname || front.user.username
+  const promoted = { userId: front.user_id, displayName }
+
+  // Append to DebateState.debater_order if debate is active
+  const state = await tx.debateState.findUnique({
+    where: { session_id: sessionId },
+  })
+  if (state) {
+    const order = state.debater_order as { userId: string; displayName: string }[]
+    order.push(promoted)
+    await tx.debateState.update({
+      where: { session_id: sessionId },
+      data: { debater_order: order },
+    })
+  }
+
+  // Log role transition
+  await tx.roleHistory.create({
+    data: {
+      session_id: sessionId,
+      user_id: front.user_id,
+      old_role: SessionRole.AUDIENCE,
+      new_role: SessionRole.DEBATER,
+      reason: "Promoted from queue",
+    },
+  })
+
+  return promoted
+}
+
+/** Delete all votes cast by and targeting a user in a session. */
+async function cleanupUserVotes(
+  tx: TransactionClient,
+  sessionId: string,
+  userId: string
+) {
+  await tx.vote.deleteMany({
+    where: {
+      session_id: sessionId,
+      OR: [{ voter_id: userId }, { target_user_id: userId }],
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Exported server actions
+// ---------------------------------------------------------------------------
 
 export async function joinQueue(sessionId: string) {
   const user = await requireAuth()
@@ -38,76 +119,261 @@ export async function joinQueue(sessionId: string) {
 export async function leaveQueue(sessionId: string) {
   const user = await requireAuth()
 
-  await prisma.audienceQueue.delete({
-    where: {
-      session_id_user_id: {
-        session_id: sessionId,
-        user_id: user.id,
-      },
-    },
+  await prisma.$transaction(async (tx) => {
+    await tx.audienceQueue.deleteMany({
+      where: { session_id: sessionId, user_id: user.id },
+    })
+    // Also clean up any votes this user cast
+    await tx.vote.deleteMany({
+      where: { session_id: sessionId, voter_id: user.id },
+    })
   })
 }
 
 export async function getQueue(sessionId: string) {
-  return await prisma.audienceQueue.findMany({
+  const user = await requireAuth()
+  if (!user) throw new Error("Not authenticated")
+
+  const entries = await prisma.audienceQueue.findMany({
     where: { session_id: sessionId },
-    orderBy: { joined_queue: "asc" },
+    orderBy: [{ joined_queue: "asc" }, { id: "asc" }],
     include: {
       user: { select: { id: true, username: true, realname: true } },
     },
   })
+
+  return entries.map((entry, index) => ({
+    id: entry.id,
+    userId: entry.user_id,
+    rank: index + 1,
+    displayName: entry.user.realname || entry.user.username,
+    addedAt: entry.joined_queue.toISOString(),
+  }))
 }
 
 export async function promoteFromQueue(sessionId: string, userId?: string) {
   await requireHostOrModerator(sessionId)
 
-  return await prisma.$transaction(async (tx) => {
-    // Find the user to promote: specific user or FIFO head
-    const queueEntry = userId
-      ? await tx.audienceQueue.findUnique({
-          where: { session_id_user_id: { session_id: sessionId, user_id: userId } },
-        })
-      : await tx.audienceQueue.findFirst({
-          where: { session_id: sessionId },
-          orderBy: { joined_queue: "asc" },
-        })
+  return prisma.$transaction(async (tx) => {
+    if (userId) {
+      // Promote specific user
+      const queueEntry = await tx.audienceQueue.findUnique({
+        where: { session_id_user_id: { session_id: sessionId, user_id: userId } },
+      })
+      if (!queueEntry) throw new Error("No one in the queue")
 
-    if (!queueEntry) throw new Error("No one in the queue")
-
-    const targetUserId = queueEntry.user_id
-
-    // Update role to DEBATER
-    await tx.participatesIn.update({
-      where: {
-        user_id_session_id: {
-          user_id: targetUserId,
-          session_id: sessionId,
+      await tx.participatesIn.update({
+        where: {
+          user_id_session_id: {
+            user_id: userId,
+            session_id: sessionId,
+          },
         },
-      },
-      data: { session_role: SessionRole.DEBATER },
-    })
-
-    // Remove from queue
-    await tx.audienceQueue.delete({
-      where: {
-        session_id_user_id: {
-          session_id: sessionId,
-          user_id: targetUserId,
+        data: { session_role: SessionRole.DEBATER },
+      })
+      await tx.audienceQueue.delete({
+        where: {
+          session_id_user_id: {
+            session_id: sessionId,
+            user_id: userId,
+          },
         },
-      },
-    })
+      })
+      await tx.roleHistory.create({
+        data: {
+          session_id: sessionId,
+          user_id: userId,
+          old_role: SessionRole.AUDIENCE,
+          new_role: SessionRole.DEBATER,
+          reason: "Promoted from queue",
+        },
+      })
+      return { promotedUserId: userId }
+    }
 
-    // Log role transition
-    await tx.roleHistory.create({
-      data: {
-        session_id: sessionId,
-        user_id: targetUserId,
-        old_role: SessionRole.AUDIENCE,
-        new_role: SessionRole.DEBATER,
-        reason: "Promoted from queue",
-      },
+    // FIFO promote
+    return doPromoteFromQueue(tx, sessionId).then((result) => {
+      if (!result) throw new Error("No one in the queue")
+      return { promotedUserId: result.userId }
     })
-
-    return { promotedUserId: targetUserId }
   })
 }
+
+export async function castKickVote(sessionId: string, targetUserId: string) {
+  const user = await requireAuth()
+  if (user.id === targetUserId) throw new Error("Cannot vote to kick yourself")
+
+  return prisma.$transaction(async (tx) => {
+    // Verify voter is AUDIENCE
+    const voterPart = await tx.participatesIn.findUnique({
+      where: {
+        user_id_session_id: { user_id: user.id, session_id: sessionId },
+      },
+    })
+    if (!voterPart || voterPart.left_at || voterPart.session_role !== SessionRole.AUDIENCE) {
+      throw new Error("Only audience members can vote to kick")
+    }
+
+    // Verify target is DEBATER and not HOST
+    const targetPart = await tx.participatesIn.findUnique({
+      where: {
+        user_id_session_id: { user_id: targetUserId, session_id: sessionId },
+      },
+    })
+    if (!targetPart || targetPart.left_at || targetPart.session_role !== SessionRole.DEBATER) {
+      throw new Error("Target must be an active debater")
+    }
+
+    // Get session for threshold
+    const session = await tx.session.findUnique({
+      where: { id: sessionId },
+      select: { kick_threshold: true, host_id: true },
+    })
+    if (!session) throw new Error("Session not found")
+    if (targetUserId === session.host_id) throw new Error("Cannot vote to kick the host")
+
+    // Create vote (unique constraint prevents double-voting)
+    await tx.vote.create({
+      data: {
+        session_id: sessionId,
+        voter_id: user.id,
+        target_user_id: targetUserId,
+        vote_type: VoteType.KICK,
+      },
+    })
+
+    // Count votes and audience
+    const voteCount = await tx.vote.count({
+      where: {
+        session_id: sessionId,
+        target_user_id: targetUserId,
+        vote_type: VoteType.KICK,
+      },
+    })
+    const audienceCount = await tx.participatesIn.count({
+      where: {
+        session_id: sessionId,
+        left_at: null,
+        session_role: SessionRole.AUDIENCE,
+      },
+    })
+
+    const requiredVotes = Math.ceil((audienceCount * session.kick_threshold) / 100)
+    const kicked = voteCount >= requiredVotes && requiredVotes > 0
+
+    if (kicked) {
+      // Kick the target
+      await tx.participatesIn.update({
+        where: {
+          user_id_session_id: { user_id: targetUserId, session_id: sessionId },
+        },
+        data: { left_at: new Date() },
+      })
+
+      // Remove target from debater_order
+      const state = await tx.debateState.findUnique({
+        where: { session_id: sessionId },
+      })
+      if (state) {
+        const order = state.debater_order as { userId: string; displayName: string }[]
+        const newOrder = order.filter((d) => d.userId !== targetUserId)
+        // Adjust current_index if needed
+        let newIndex = state.current_index
+        const removedIndex = order.findIndex((d) => d.userId === targetUserId)
+        if (removedIndex < state.current_index) {
+          newIndex = Math.max(0, newIndex - 1)
+        } else if (removedIndex === state.current_index) {
+          newIndex = newOrder.length > 0 ? newIndex % newOrder.length : 0
+        }
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: { debater_order: newOrder, current_index: newIndex },
+        })
+      }
+
+      // Clean up all votes for this target
+      await tx.vote.deleteMany({
+        where: {
+          session_id: sessionId,
+          target_user_id: targetUserId,
+          vote_type: VoteType.KICK,
+        },
+      })
+
+      // Log role transition
+      await tx.roleHistory.create({
+        data: {
+          session_id: sessionId,
+          user_id: targetUserId,
+          old_role: SessionRole.DEBATER,
+          new_role: SessionRole.AUDIENCE,
+          reason: "Kicked by audience vote",
+        },
+      })
+
+      // Auto-promote from queue
+      await doPromoteFromQueue(tx, sessionId)
+    }
+
+    return { kicked, voteCount, requiredVotes }
+  })
+}
+
+export async function removeKickVote(sessionId: string, targetUserId: string) {
+  const user = await requireAuth()
+
+  await prisma.vote.deleteMany({
+    where: {
+      session_id: sessionId,
+      voter_id: user.id,
+      target_user_id: targetUserId,
+      vote_type: VoteType.KICK,
+    },
+  })
+}
+
+export async function getKickVotes(sessionId: string, targetUserId: string) {
+  const user = await requireAuth()
+  if (!user) throw new Error("Not authenticated")
+
+  const [voteCount, audienceCount, userVote, session] = await Promise.all([
+    prisma.vote.count({
+      where: {
+        session_id: sessionId,
+        target_user_id: targetUserId,
+        vote_type: VoteType.KICK,
+      },
+    }),
+    prisma.participatesIn.count({
+      where: {
+        session_id: sessionId,
+        left_at: null,
+        session_role: SessionRole.AUDIENCE,
+      },
+    }),
+    prisma.vote.findFirst({
+      where: {
+        session_id: sessionId,
+        voter_id: user.id,
+        target_user_id: targetUserId,
+        vote_type: VoteType.KICK,
+      },
+    }),
+    prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { kick_threshold: true },
+    }),
+  ])
+
+  const threshold = session?.kick_threshold ?? 50
+  const requiredVotes = Math.ceil((audienceCount * threshold) / 100)
+
+  return {
+    voteCount,
+    requiredVotes,
+    userHasVoted: !!userVote,
+  }
+}
+
+// Re-export internal helpers for use by other server action modules
+export { doPromoteFromQueue, cleanupUserVotes }

--- a/lib/actions/session.ts
+++ b/lib/actions/session.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma"
 import { generateRoomCode, SessionCapacityInfo, getSessionCapacity, getTotalDebaterCapacity } from "@/lib/utils"
 import { redirect } from "next/navigation"
 import { Prisma, SessionRole, SessionStatus, SessionType } from "@/lib/generated/prisma"
+import { doPromoteFromQueue, cleanupUserVotes } from "@/lib/actions/queue"
 
 export async function createSession(formData: {
     name: string
@@ -15,6 +16,7 @@ export async function createSession(formData: {
     debaterCapacityPanel: number | null
     audienceCapacity: number
     turnLength: number
+    kickThreshold?: number
 }) 
 {
     const supabase = await createClient()
@@ -70,6 +72,7 @@ export async function createSession(formData: {
             debater_capacity_panel: formData.debaterCapacityPanel,
             audience_capacity: formData.audienceCapacity,
             turn_length: formData.turnLength,
+            kick_threshold: formData.kickThreshold ?? 50,
             participates_ins: {
                 create: {
                     user_id: user.id,
@@ -310,14 +313,55 @@ export async function leaveSession(sessionId: string) {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) throw new Error("Not authenticated")
 
-    await prisma.participatesIn.update({
+    const participation = await prisma.participatesIn.findUnique({
         where: {
-            user_id_session_id: {
-                user_id: user.id,
-                session_id: sessionId,
-            },
+            user_id_session_id: { user_id: user.id, session_id: sessionId },
         },
-        data: { left_at: new Date() },
+    })
+    if (!participation) throw new Error("Not a participant")
+
+    const wasDebater = participation.session_role === SessionRole.DEBATER
+
+    await prisma.$transaction(async (tx) => {
+        // Mark as left
+        await tx.participatesIn.update({
+            where: {
+                user_id_session_id: { user_id: user.id, session_id: sessionId },
+            },
+            data: { left_at: new Date() },
+        })
+
+        // Remove from queue if queued
+        await tx.audienceQueue.deleteMany({
+            where: { session_id: sessionId, user_id: user.id },
+        })
+
+        // Clean up votes
+        await cleanupUserVotes(tx, sessionId, user.id)
+
+        // If was a debater, remove from debater_order and auto-promote
+        if (wasDebater) {
+            const state = await tx.debateState.findUnique({
+                where: { session_id: sessionId },
+            })
+            if (state) {
+                const order = state.debater_order as { userId: string; displayName: string }[]
+                const removedIndex = order.findIndex((d) => d.userId === user.id)
+                const newOrder = order.filter((d) => d.userId !== user.id)
+                let newIndex = state.current_index
+                if (removedIndex < state.current_index) {
+                    newIndex = Math.max(0, newIndex - 1)
+                } else if (removedIndex === state.current_index && newOrder.length > 0) {
+                    newIndex = newIndex % newOrder.length
+                }
+                await tx.debateState.update({
+                    where: { session_id: sessionId },
+                    data: { debater_order: newOrder, current_index: newIndex },
+                })
+            }
+
+            await doPromoteFromQueue(tx, sessionId)
+        }
     })
 }
 
@@ -401,7 +445,6 @@ export async function kickParticipant(sessionId: string, targetUserId: string) {
   if (session.host_id !== user.id && session.moderator_id !== user.id) {
     throw new Error("Only moderators or hosts can kick participants")
   }
-  // Cannot kick yourself
   if (targetUserId === user.id) throw new Error("Cannot kick yourself")
 
   // Verify target is an active participant and get role for history logging
@@ -412,15 +455,47 @@ export async function kickParticipant(sessionId: string, targetUserId: string) {
   if (!participation || participation.left_at !== null) {
     throw new Error("Target user is not an active participant in this session")
   }
+  const wasDebater = participation.session_role === SessionRole.DEBATER
 
-  await prisma.participatesIn.update({
-    where: {
-      user_id_session_id: {
-        user_id: targetUserId,
-        session_id: sessionId,
+  await prisma.$transaction(async (tx) => {
+    await tx.participatesIn.update({
+      where: {
+        user_id_session_id: { user_id: targetUserId, session_id: sessionId },
       },
-    },
-    data: { left_at: new Date() },
+      data: { left_at: new Date() },
+    })
+
+    // Remove from queue if queued
+    await tx.audienceQueue.deleteMany({
+      where: { session_id: sessionId, user_id: targetUserId },
+    })
+
+    // Clean up votes
+    await cleanupUserVotes(tx, sessionId, targetUserId)
+
+    // If was a debater, remove from debater_order and auto-promote
+    if (wasDebater) {
+      const state = await tx.debateState.findUnique({
+        where: { session_id: sessionId },
+      })
+      if (state) {
+        const order = state.debater_order as { userId: string; displayName: string }[]
+        const removedIndex = order.findIndex((d) => d.userId === targetUserId)
+        const newOrder = order.filter((d) => d.userId !== targetUserId)
+        let newIndex = state.current_index
+        if (removedIndex < state.current_index) {
+          newIndex = Math.max(0, newIndex - 1)
+        } else if (removedIndex === state.current_index && newOrder.length > 0) {
+          newIndex = newIndex % newOrder.length
+        }
+        await tx.debateState.update({
+          where: { session_id: sessionId },
+          data: { debater_order: newOrder, current_index: newIndex },
+        })
+      }
+
+      await doPromoteFromQueue(tx, sessionId)
+    }
   })
 
   if (participation) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,16 +43,37 @@ enum VoteType {
 
 // ── Models ──
 
+
 model User {
-  id          String        @id @db.Uuid
-  username    String        @unique
-  email       String?
-  realname    String?
-  bio         String?
-  preferences Json?
-  deleted_at  DateTime?
-  role        UniversalRole @default(USER)
-  created_at  DateTime      @default(now())
+  id         String        @id @db.Uuid
+  username   String        @unique
+  email      String?
+  realname   String?
+  role       UniversalRole @default(USER)
+  created_at DateTime      @default(now())
+
+  // Profile
+  bio String?
+
+  // Notification preferences
+  notify_invitations   Boolean @default(true)
+  notify_messages      Boolean @default(true)
+  notify_weekly_digest Boolean @default(false)
+
+  // Privacy preferences
+  profile_visibility    String  @default("public")
+  show_online_status    Boolean @default(true)
+  allow_direct_messages Boolean @default(true)
+
+  // Appearance preferences
+  theme              String  @default("dark")
+  font_size          String  @default("medium")
+  animations_enabled Boolean @default(true)
+
+  // Language & region preferences
+  language    String @default("en")
+  timezone    String @default("UTC")
+  date_format String @default("MM/DD/YYYY")
 
   // Relations
   hosted_sessions    Session[]        @relation("HostToSession")
@@ -94,6 +115,7 @@ model Session {
   debater_capacity_panel     Int?          @default(5)
   audience_capacity          Int           @default(10)
   turn_length                Int           @default(120)
+  kick_threshold             Int           @default(50)
   /// Whether the debate format is locked (true after debate begins, per REQ-1.8)
   format_locked              Boolean       @default(false)
   created_at                 DateTime      @default(now())
@@ -164,6 +186,7 @@ model Recording {
 }
 
 /// Audience vote to kick or promote a participant (REQ-4)
+
 model Vote {
   id             String   @id @default(cuid())
   session_id     String


### PR DESCRIPTION
## Summary

Closes #17

Implements the full audience queue system with real-time updates, kick-voting, and Expert vs. Crowd challenger rotation.

- **Schema**: `AudienceQueue` + `Vote` models, `kick_threshold` on Session
- **Queue actions**: joinQueue, leaveQueue, getQueue, promoteFromQueue — FIFO by `joined_queue` timestamp
- **Kick-vote**: castKickVote with `ceil(audienceCount * threshold / 100)` math, transactional kick + auto-promote
- **Debate engine**: `% debater_order.length` replaces `% 2`; Expert vs Crowd challenger rotation from queue
- **Auto-promotion**: on debater leave/kick, transactional queue pop + role update + debater_order sync
- **Real-time**: `useQueueChannel` + `useKickVoteChannel` hooks with Supabase Realtime + 500ms debounce
- **UI**: Speaker Queue section, kick-vote progress bars, Expert vs Crowd badges, kick threshold config
- **Tests**: 29 new queue tests + updated debate/session tests (all passing)

## Test plan

- [x] `npm run test:unit` — all queue/debate/session tests pass
- [x] Prisma schema valid
- [ ] Manual: join queue, verify position, leave queue
- [ ] Manual: kick-vote threshold triggers auto-kick + promotion
- [ ] Manual: Expert vs Crowd challenger rotation

**Post-merge**: Add tables to Supabase Realtime publication:
```sql
ALTER PUBLICATION supabase_realtime ADD TABLE "AudienceQueue";
ALTER PUBLICATION supabase_realtime ADD TABLE "Vote";
```