### PR TITLE
feat: server-authoritative debate engine (#12)

### DIFF
--- a/__tests__/debate.test.ts
+++ b/__tests__/debate.test.ts
@@ -4,6 +4,11 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }))
 
+vi.mock('@/lib/actions/utils', () => ({
+  requireHostOrModerator: vi.fn(),
+  requireAuth: vi.fn(),
+}))
+
 vi.mock('@/lib/prisma', () => ({
   prisma: {
     session: { findUnique: vi.fn() },
@@ -23,6 +28,7 @@ vi.mock('@/lib/prisma', () => ({
 
 import { createClient } from '@/lib/supabase/server'
 import { prisma } from '@/lib/prisma'
+import { requireHostOrModerator } from '@/lib/actions/utils'
 import {
   getDebateState,
   startDebate,
@@ -45,15 +51,29 @@ function mockAuth(userId: string | null) {
       }),
     },
   })
+  if (!userId) {
+    ;(requireHostOrModerator as any).mockRejectedValue(new Error('Not authenticated'))
+  }
 }
 
 function mockSession(overrides: Record<string, any> = {}) {
-  ;(prisma.session.findUnique as any).mockResolvedValue({
+  const session = {
     id: MOCK_SESSION_ID,
     host_id: MOCK_HOST_ID,
     moderator_id: null,
+    type: 'ONE_ON_ONE',
     ...overrides,
-  })
+  }
+  ;(prisma.session.findUnique as any).mockResolvedValue(session)
+  // If the session's host/moderator doesn't match MOCK_HOST_ID, mock rejection
+  if (session.host_id !== MOCK_HOST_ID && session.moderator_id !== MOCK_HOST_ID) {
+    ;(requireHostOrModerator as any).mockRejectedValue(new Error('Not authorized'))
+  } else {
+    ;(requireHostOrModerator as any).mockResolvedValue({
+      user: { id: MOCK_HOST_ID },
+      session,
+    })
+  }
 }
 
 const debaters = [
@@ -112,6 +132,7 @@ describe('startDebate', () => {
 
   it('throws if session not found', async () => {
     ;(prisma.session.findUnique as any).mockResolvedValue(null)
+    ;(requireHostOrModerator as any).mockRejectedValue(new Error('Session not found'))
     await expect(startDebate(MOCK_SESSION_ID, debaters, 120)).rejects.toThrow('Session not found')
   })
 
@@ -120,8 +141,8 @@ describe('startDebate', () => {
     await expect(startDebate(MOCK_SESSION_ID, debaters, 120)).rejects.toThrow('Not authorized')
   })
 
-  it('throws if not exactly 2 debaters', async () => {
-    await expect(startDebate(MOCK_SESSION_ID, [debaters[0]], 120)).rejects.toThrow('Exactly 2 debaters')
+  it('throws if fewer than 2 debaters', async () => {
+    await expect(startDebate(MOCK_SESSION_ID, [debaters[0]], 120)).rejects.toThrow('At least 2 debaters')
   })
 
   it('upserts debate state with correct initial values', async () => {
@@ -158,7 +179,7 @@ describe('advanceTurn', () => {
 
   it('advances current_index from 0 to 1', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
-      current_index: 0, turn_length: 60, is_paused: false,
+      current_index: 0, turn_length: 60, is_paused: false, debater_order: debaters,
     })
     await advanceTurn(MOCK_SESSION_ID)
     const update = (prisma.debateState.update as any).mock.calls[0][0]
@@ -168,7 +189,7 @@ describe('advanceTurn', () => {
 
   it('wraps current_index from 1 back to 0', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
-      current_index: 1, turn_length: 60, is_paused: false,
+      current_index: 1, turn_length: 60, is_paused: false, debater_order: debaters,
     })
     await advanceTurn(MOCK_SESSION_ID)
     const update = (prisma.debateState.update as any).mock.calls[0][0]
@@ -177,7 +198,7 @@ describe('advanceTurn', () => {
 
   it('sets new turn_ends_at from now + turn_length', async () => {
     ;(prisma.debateState.findUnique as any).mockResolvedValue({
-      current_index: 0, turn_length: 90, is_paused: false,
+      current_index: 0, turn_length: 90, is_paused: false, debater_order: debaters,
     })
     const before = Date.now()
     await advanceTurn(MOCK_SESSION_ID)
@@ -323,15 +344,18 @@ describe('endDebate', () => {
     await expect(endDebate(MOCK_SESSION_ID)).rejects.toThrow('Not authorized')
   })
 
-  it('deletes the debate state', async () => {
+  it('updates debate state to ENDED phase', async () => {
     await endDebate(MOCK_SESSION_ID)
-    expect(prisma.debateState.delete).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { session_id: MOCK_SESSION_ID } })
+    expect(prisma.debateState.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { session_id: MOCK_SESSION_ID },
+        data: expect.objectContaining({ phase: 'ENDED' }),
+      })
     )
   })
 
   it('does not throw if debate state already gone', async () => {
-    ;(prisma.debateState.delete as any).mockRejectedValue(new Error('not found'))
+    ;(prisma.debateState.update as any).mockRejectedValue(new Error('not found'))
     await expect(endDebate(MOCK_SESSION_ID)).resolves.not.toThrow()
   })
 })

--- a/__tests__/hooks/useDebateChannel.test.ts
+++ b/__tests__/hooks/useDebateChannel.test.ts
@@ -1,0 +1,331 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// ── Mock socket.io-client (dynamic import-compatible) ──
+
+let connectHandler: (() => void) | null = null
+const eventHandlers = new Map<string, ((...args: any[]) => void)[]>()
+
+const mockSocket = {
+  on: vi.fn((event: string, handler: any) => {
+    if (event === 'connect') {
+      connectHandler = handler
+    } else {
+      const handlers = eventHandlers.get(event) ?? []
+      handlers.push(handler)
+      eventHandlers.set(event, handlers)
+    }
+  }),
+  emit: vi.fn((_event: string, _data: any, callback?: any) => {
+    if (callback) {
+      if (_event === 'joinDebateRoom') callback({ success: true })
+      else if (_event === 'getDebateState') callback({ success: true, state: null })
+      else callback({ success: true })
+    }
+  }),
+  disconnect: vi.fn(),
+  connected: true,
+}
+
+const mockIoFn = vi.fn(() => mockSocket)
+
+vi.mock('socket.io-client', () => ({
+  io: (url: any, opts: any) => mockIoFn(url, opts),
+}))
+
+function emitServerEvent(event: string, payload: any) {
+  const handlers = eventHandlers.get(event) ?? []
+  for (const h of handlers) {
+    h(payload)
+  }
+}
+
+import { useDebateChannel } from '@/hooks/useDebateChannel'
+
+describe('useDebateChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    connectHandler = null
+    eventHandlers.clear()
+    mockSocket.on.mockImplementation((event: string, handler: any) => {
+      if (event === 'connect') connectHandler = handler
+      else {
+        const handlers = eventHandlers.get(event) ?? []
+        handlers.push(handler)
+        eventHandlers.set(event, handlers)
+      }
+    })
+    mockSocket.emit.mockImplementation((_event: string, _data: any, callback?: any) => {
+      if (callback) {
+        if (_event === 'joinDebateRoom') callback({ success: true })
+        else if (_event === 'getDebateState') callback({ success: true, state: null })
+        else callback({ success: true })
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const opts = {
+    sfuUrl: 'http://localhost:3001',
+    roomCode: 'ARG-TEST',
+    userId: 'u1',
+  }
+
+  async function renderAndConnect(overrides = {}) {
+    const hookResult = renderHook(() => useDebateChannel({ ...opts, ...overrides }))
+    // Wait for the dynamic import and connect
+    await waitFor(() => {
+      expect(connectHandler).not.toBeNull()
+    })
+    // Fire the connect handler
+    await act(async () => { connectHandler!() })
+    return hookResult
+  }
+
+  // ═══════════════════════════
+  // Initial state
+  // ═══════════════════════════
+
+  it('starts with idle status', () => {
+    const { result } = renderHook(() => useDebateChannel(opts))
+    expect(result.current.debateStatus).toBe('idle')
+    expect(result.current.debaters).toEqual([])
+    expect(result.current.timeRemaining).toBe(0)
+    expect(result.current.isPaused).toBe(false)
+    expect(result.current.isMyTurn).toBe(false)
+    expect(result.current.currentSpeaker).toBeNull()
+    expect(result.current.graceCountdown).toBeNull()
+  })
+
+  it('connects to SFU with userId in auth', async () => {
+    await renderAndConnect()
+    expect(mockIoFn).toHaveBeenCalledWith('http://localhost:3001', expect.objectContaining({
+      auth: { userId: 'u1' },
+    }))
+  })
+
+  it('joins debate room and requests state on connect', async () => {
+    await renderAndConnect()
+    expect(mockSocket.emit).toHaveBeenCalledWith('joinDebateRoom', { roomCode: 'ARG-TEST' }, expect.any(Function))
+    expect(mockSocket.emit).toHaveBeenCalledWith('getDebateState', { roomCode: 'ARG-TEST' }, expect.any(Function))
+  })
+
+  // ═══════════════════════════
+  // Events
+  // ═══════════════════════════
+
+  it('handles turnChanged event', async () => {
+    const { result } = await renderAndConnect()
+
+    act(() => {
+      emitServerEvent('turnChanged', {
+        version: 1, currentIndex: 0,
+        debaterOrder: [{ userId: 'u1', displayName: 'Alice' }, { userId: 'u2', displayName: 'Bob' }],
+        turnStartedAt: Date.now(), turnLength: 60, phase: 'ACTIVE',
+      })
+    })
+
+    expect(result.current.debateStatus).toBe('live')
+    expect(result.current.debaters).toHaveLength(2)
+    expect(result.current.currentSpeaker?.userId).toBe('u1')
+    expect(result.current.isMyTurn).toBe(true)
+    expect(result.current.phase).toBe('ACTIVE')
+    expect(result.current.version).toBe(1)
+  })
+
+  it('handles turnExpiring → sets grace countdown', async () => {
+    const { result } = await renderAndConnect()
+
+    act(() => {
+      emitServerEvent('turnChanged', {
+        version: 0, currentIndex: 0,
+        debaterOrder: [{ userId: 'u1', displayName: 'Alice' }],
+        turnStartedAt: Date.now(), turnLength: 5, phase: 'ACTIVE',
+      })
+    })
+
+    act(() => {
+      emitServerEvent('turnExpiring', { version: 1, expiredUserId: 'u1' })
+    })
+
+    expect(result.current.phase).toBe('GRACE')
+    expect(result.current.graceCountdown).toBe(3)
+  })
+
+  it('handles debatePaused event', async () => {
+    const { result } = await renderAndConnect()
+
+    act(() => {
+      emitServerEvent('turnChanged', {
+        version: 0, currentIndex: 0,
+        debaterOrder: [{ userId: 'u1', displayName: 'Alice' }],
+        turnStartedAt: Date.now(), turnLength: 60, phase: 'ACTIVE',
+      })
+    })
+
+    act(() => {
+      emitServerEvent('debatePaused', { version: 1, timeRemaining: 45 })
+    })
+
+    expect(result.current.debateStatus).toBe('paused')
+    expect(result.current.isPaused).toBe(true)
+    expect(result.current.timeRemaining).toBe(45)
+  })
+
+  it('handles debateResumed event', async () => {
+    const { result } = await renderAndConnect()
+
+    act(() => {
+      emitServerEvent('debateResumed', { version: 2, turnStartedAt: Date.now(), turnLength: 45 })
+    })
+
+    expect(result.current.debateStatus).toBe('live')
+    expect(result.current.isPaused).toBe(false)
+    expect(result.current.phase).toBe('ACTIVE')
+  })
+
+  it('handles debateEnded event', async () => {
+    const { result } = await renderAndConnect()
+
+    act(() => {
+      emitServerEvent('turnChanged', {
+        version: 0, currentIndex: 0,
+        debaterOrder: [{ userId: 'u1', displayName: 'Alice' }],
+        turnStartedAt: Date.now(), turnLength: 60, phase: 'ACTIVE',
+      })
+    })
+
+    act(() => { emitServerEvent('debateEnded', { version: 3 }) })
+
+    expect(result.current.debateStatus).toBe('ended')
+    expect(result.current.debaters).toEqual([])
+  })
+
+  // ═══════════════════════════
+  // isMyTurn
+  // ═══════════════════════════
+
+  it('isMyTurn true when current speaker matches', async () => {
+    const { result } = await renderAndConnect()
+    act(() => {
+      emitServerEvent('turnChanged', {
+        version: 0, currentIndex: 0,
+        debaterOrder: [{ userId: 'u1', displayName: 'Alice' }, { userId: 'u2', displayName: 'Bob' }],
+        turnStartedAt: Date.now(), turnLength: 60, phase: 'ACTIVE',
+      })
+    })
+    expect(result.current.isMyTurn).toBe(true)
+  })
+
+  it('isMyTurn false when someone else is speaking', async () => {
+    const { result } = await renderAndConnect()
+    act(() => {
+      emitServerEvent('turnChanged', {
+        version: 0, currentIndex: 1,
+        debaterOrder: [{ userId: 'u1', displayName: 'Alice' }, { userId: 'u2', displayName: 'Bob' }],
+        turnStartedAt: Date.now(), turnLength: 60, phase: 'ACTIVE',
+      })
+    })
+    expect(result.current.isMyTurn).toBe(false)
+  })
+
+  // ═══════════════════════════
+  // Actions
+  // ═══════════════════════════
+
+  it('startDebate emits correct event', async () => {
+    const { result } = await renderAndConnect()
+    vi.clearAllMocks()
+
+    const debaters = [{ userId: 'u1', displayName: 'Alice' }, { userId: 'u2', displayName: 'Bob' }]
+    await act(async () => {
+      await result.current.startDebate(debaters, 120, 'ONE_ON_ONE')
+    })
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('startDebate', expect.objectContaining({
+      roomCode: 'ARG-TEST', debaters, turnLength: 120, format: 'ONE_ON_ONE',
+    }), expect.any(Function))
+  })
+
+  it('nextTurn emits with current version', async () => {
+    const { result } = await renderAndConnect()
+    act(() => {
+      emitServerEvent('turnChanged', {
+        version: 7, currentIndex: 0,
+        debaterOrder: [{ userId: 'u1', displayName: 'Alice' }],
+        turnStartedAt: Date.now(), turnLength: 60, phase: 'ACTIVE',
+      })
+    })
+    vi.clearAllMocks()
+
+    await act(async () => { await result.current.nextTurn() })
+    expect(mockSocket.emit).toHaveBeenCalledWith('nextTurn', { roomCode: 'ARG-TEST', version: 7 }, expect.any(Function))
+  })
+
+  it('pause emits pauseDebate', async () => {
+    const { result } = await renderAndConnect()
+    vi.clearAllMocks()
+    await act(async () => { await result.current.pause() })
+    expect(mockSocket.emit).toHaveBeenCalledWith('pauseDebate', { roomCode: 'ARG-TEST' }, expect.any(Function))
+  })
+
+  it('resume emits resumeDebate', async () => {
+    const { result } = await renderAndConnect()
+    vi.clearAllMocks()
+    await act(async () => { await result.current.resume() })
+    expect(mockSocket.emit).toHaveBeenCalledWith('resumeDebate', { roomCode: 'ARG-TEST' }, expect.any(Function))
+  })
+
+  it('endDebate emits endDebate', async () => {
+    const { result } = await renderAndConnect()
+    vi.clearAllMocks()
+    await act(async () => { await result.current.endDebate() })
+    expect(mockSocket.emit).toHaveBeenCalledWith('endDebate', { roomCode: 'ARG-TEST' }, expect.any(Function))
+  })
+
+  // ═══════════════════════════
+  // Cleanup
+  // ═══════════════════════════
+
+  it('disconnects on unmount', async () => {
+    const { unmount } = await renderAndConnect()
+    unmount()
+    expect(mockSocket.disconnect).toHaveBeenCalled()
+  })
+
+  // ═══════════════════════════
+  // Refresh recovery
+  // ═══════════════════════════
+
+  it('applies initial state from getDebateState', async () => {
+    mockSocket.emit.mockImplementation((_event: string, _data: any, callback?: any) => {
+      if (callback) {
+        if (_event === 'joinDebateRoom') callback({ success: true })
+        else if (_event === 'getDebateState') {
+          callback({
+            success: true,
+            state: {
+              version: 3,
+              debaterOrder: [{ userId: 'u1', displayName: 'Alice' }, { userId: 'u2', displayName: 'Bob' }],
+              currentIndex: 1, turnLength: 120, turnStartedAt: Date.now(),
+              isPaused: false, pausedTimeRemaining: 0,
+              format: 'ONE_ON_ONE', formatMeta: null, phase: 'ACTIVE',
+            },
+          })
+        } else callback({ success: true })
+      }
+    })
+
+    const { result } = await renderAndConnect()
+
+    expect(result.current.debateStatus).toBe('live')
+    expect(result.current.debaters).toHaveLength(2)
+    expect(result.current.version).toBe(3)
+    expect(result.current.isMyTurn).toBe(false) // currentIndex=1 is Bob
+  })
+})

--- a/__tests__/realtime/debate.test.ts
+++ b/__tests__/realtime/debate.test.ts
@@ -1,0 +1,725 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../../realtime/src/db', () => ({
+  persistDebateState: vi.fn().mockResolvedValue(undefined),
+  loadDebateState: vi.fn().mockResolvedValue(null),
+  loadAllActiveDebates: vi.fn().mockResolvedValue([]),
+  logTurnTransition: vi.fn().mockResolvedValue(undefined),
+  getSessionByCode: vi.fn().mockResolvedValue(null),
+  getSessionCodeById: vi.fn().mockResolvedValue(null),
+  validateDebaterIds: vi.fn().mockResolvedValue(true),
+  isHostOrModerator: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('../../realtime/src/mediasoup/rooms', () => ({
+  getRoom: vi.fn().mockReturnValue(undefined),
+}))
+
+import {
+  startDebate,
+  advanceTurn,
+  pauseDebate,
+  resumeDebate,
+  endDebate,
+  getState,
+  handleSpeakerDisconnect,
+  checkAuthorization,
+  recoverDebates,
+  getOrLoadState,
+} from '../../realtime/src/debate'
+import * as db from '../../realtime/src/db'
+
+const ROOM = 'ARG-TEST'
+
+function mockIo() {
+  const emitFn = vi.fn()
+  return {
+    to: vi.fn().mockReturnValue({ emit: emitFn }),
+    _emit: emitFn,
+  } as any
+}
+
+function mockSession(type = 'ONE_ON_ONE') {
+  vi.mocked(db.getSessionByCode).mockResolvedValue({
+    id: 'sess-1', code: ROOM, type, host_id: 'host', moderator_id: null,
+  } as any)
+}
+
+const d2 = [
+  { userId: 'u1', displayName: 'Alice' },
+  { userId: 'u2', displayName: 'Bob' },
+]
+const d4 = [
+  { userId: 'u1', displayName: 'Alice' },
+  { userId: 'u2', displayName: 'Bob' },
+  { userId: 'u3', displayName: 'Charlie' },
+  { userId: 'u4', displayName: 'Diana' },
+]
+
+async function setupDebate(io: any, opts?: { room?: string; debaters?: any[]; turnLength?: number; format?: any }) {
+  const room = opts?.room ?? ROOM
+  const debaters = opts?.debaters ?? d2
+  const turnLength = opts?.turnLength ?? 60
+  const format = opts?.format ?? 'ONE_ON_ONE'
+  mockSession(format)
+  return startDebate(room, debaters, turnLength, format, null, io)
+}
+
+describe('debate engine', () => {
+  let io: any
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    io = mockIo()
+    // Re-establish default mock returns after clearAllMocks
+    vi.mocked(db.persistDebateState).mockResolvedValue(undefined)
+    vi.mocked(db.logTurnTransition).mockResolvedValue(undefined)
+    vi.mocked(db.validateDebaterIds).mockResolvedValue(true)
+    vi.mocked(db.isHostOrModerator).mockResolvedValue(true)
+    vi.mocked(db.loadAllActiveDebates).mockResolvedValue([])
+    vi.mocked(db.loadDebateState).mockResolvedValue(null)
+    vi.mocked(db.getSessionByCode).mockResolvedValue(null)
+    vi.mocked(db.getSessionCodeById).mockResolvedValue(null)
+  })
+
+  afterEach(async () => {
+    // Clean up any lingering debates
+    if (getState(ROOM)) await endDebate(ROOM, io)
+    if (getState('room2')) await endDebate('room2', io)
+    vi.useRealTimers()
+  })
+
+  // ═══════════════════════════════════
+  // startDebate validation
+  // ═══════════════════════════════════
+
+  describe('startDebate', () => {
+    it('rejects turnLength < 1', async () => {
+      const r = await startDebate(ROOM, d2, 0, 'ONE_ON_ONE', null, io)
+      expect(r).toEqual({ success: false, error: 'Turn length must be 1-1800 seconds' })
+    })
+
+    it('rejects turnLength > 1800', async () => {
+      const r = await startDebate(ROOM, d2, 1801, 'ONE_ON_ONE', null, io)
+      expect(r).toEqual({ success: false, error: 'Turn length must be 1-1800 seconds' })
+    })
+
+    it('accepts turnLength at boundaries', async () => {
+      mockSession()
+      const r1 = await startDebate(ROOM, d2, 1, 'ONE_ON_ONE', null, io)
+      expect(r1.success).toBe(true)
+      await endDebate(ROOM, io)
+
+      const r2 = await startDebate(ROOM, d2, 1800, 'ONE_ON_ONE', null, io)
+      expect(r2.success).toBe(true)
+    })
+
+    it('rejects < 2 debaters', async () => {
+      const r = await startDebate(ROOM, [d2[0]], 60, 'ONE_ON_ONE', null, io)
+      expect(r.success).toBe(false)
+      expect(r.error).toContain('At least 2')
+    })
+
+    it('rejects ONE_ON_ONE with 3 debaters', async () => {
+      const r = await startDebate(ROOM, d4.slice(0, 3), 60, 'ONE_ON_ONE', null, io)
+      expect(r.success).toBe(false)
+      expect(r.error).toContain('exactly 2')
+    })
+
+    it('rejects PANEL with 2 debaters', async () => {
+      mockSession('PANEL')
+      const r = await startDebate(ROOM, d2, 60, 'PANEL', null, io)
+      expect(r.success).toBe(false)
+      expect(r.error).toContain('3-6')
+    })
+
+    it('rejects PANEL with 7 debaters', async () => {
+      mockSession('PANEL')
+      const d7 = [...d4, { userId: 'u5', displayName: 'E' }, { userId: 'u6', displayName: 'F' }, { userId: 'u7', displayName: 'G' }]
+      const r = await startDebate(ROOM, d7, 60, 'PANEL', null, io)
+      expect(r.success).toBe(false)
+    })
+
+    it('rejects if session not found', async () => {
+      vi.mocked(db.getSessionByCode).mockResolvedValue(null)
+      const r = await startDebate(ROOM, d2, 60, 'ONE_ON_ONE', null, io)
+      expect(r).toEqual({ success: false, error: 'Session not found' })
+    })
+
+    it('rejects if debater IDs invalid', async () => {
+      mockSession()
+      vi.mocked(db.validateDebaterIds).mockResolvedValue(false)
+      const r = await startDebate(ROOM, d2, 60, 'ONE_ON_ONE', null, io)
+      expect(r).toEqual({ success: false, error: 'Invalid debater IDs' })
+    })
+
+    it('rejects if format mismatches session type', async () => {
+      mockSession('PANEL')
+      const r = await startDebate(ROOM, d2, 60, 'ONE_ON_ONE', null, io)
+      expect(r.success).toBe(false)
+      expect(r.error).toContain('Format does not match')
+    })
+
+    it('succeeds and sets initial state', async () => {
+      const r = await setupDebate(io)
+      expect(r.success).toBe(true)
+
+      const s = getState(ROOM)!
+      expect(s.currentIndex).toBe(0)
+      expect(s.debaterOrder).toEqual(d2)
+      expect(s.phase).toBe('ACTIVE')
+      expect(s.version).toBe(0)
+      expect(s.turnLength).toBe(60)
+      expect(s.isPaused).toBe(false)
+    })
+
+    it('persists state to DB', async () => {
+      await setupDebate(io)
+      expect(db.persistDebateState).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'sess-1', phase: 'ACTIVE', version: 0 }),
+      )
+    })
+
+    it('logs DEBATE_START transition', async () => {
+      await setupDebate(io)
+      expect(db.logTurnTransition).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'DEBATE_START', speakerUserId: 'u1', turnIndex: 0 }),
+      )
+    })
+
+    it('emits turnChanged to room', async () => {
+      await setupDebate(io)
+      expect(io.to).toHaveBeenCalledWith(ROOM)
+      expect(io._emit).toHaveBeenCalledWith('turnChanged', expect.objectContaining({
+        currentIndex: 0, phase: 'ACTIVE', turnLength: 60,
+      }))
+    })
+  })
+
+  // ═══════════════════════════════════
+  // advanceTurn
+  // ═══════════════════════════════════
+
+  describe('advanceTurn', () => {
+    beforeEach(async () => {
+      await setupDebate(io)
+      vi.clearAllMocks()
+    })
+
+    it('returns error for nonexistent room', async () => {
+      const r = await advanceTurn('nope', 'MANUAL_ADVANCE', io)
+      expect(r).toEqual({ success: false, error: 'No active debate' })
+    })
+
+    it('debounces rapid calls', async () => {
+      const r1 = await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(r1.success).toBe(true)
+
+      const r2 = await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(r2).toEqual({ success: false, error: 'Too fast' })
+    })
+
+    it('allows advance after debounce window', async () => {
+      await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      vi.advanceTimersByTime(501)
+      const r = await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(r.success).toBe(true)
+    })
+
+    it('rejects stale version', async () => {
+      const r = await advanceTurn(ROOM, 'MANUAL_ADVANCE', io, 999)
+      expect(r).toEqual({ success: false, error: 'Stale version' })
+    })
+
+    it('accepts matching version', async () => {
+      const v = getState(ROOM)!.version
+      const r = await advanceTurn(ROOM, 'MANUAL_ADVANCE', io, v)
+      expect(r.success).toBe(true)
+    })
+
+    it('rejects when PAUSED', async () => {
+      await pauseDebate(ROOM, io)
+      const r = await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(r).toEqual({ success: false, error: 'Debate is not active' })
+    })
+
+    it('ONE_ON_ONE alternates 0 → 1 → 0', async () => {
+      expect(getState(ROOM)!.currentIndex).toBe(0)
+
+      await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(getState(ROOM)!.currentIndex).toBe(1)
+
+      vi.advanceTimersByTime(501)
+      await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(getState(ROOM)!.currentIndex).toBe(0)
+    })
+
+    it('PANEL: circular through 4 debaters', async () => {
+      await endDebate(ROOM, io)
+      mockSession('PANEL')
+      await startDebate('room2', d4, 60, 'PANEL', null, io)
+
+      for (let expected = 1; expected <= 4; expected++) {
+        vi.advanceTimersByTime(501)
+        await advanceTurn('room2', 'MANUAL_ADVANCE', io)
+        expect(getState('room2')!.currentIndex).toBe(expected % 4)
+      }
+      await endDebate('room2', io)
+    })
+
+    it('EXPERT_VS_CROWD: expert(0) ↔ challenger(1)', async () => {
+      await endDebate(ROOM, io)
+      mockSession('EXPERT_VS_CROWD')
+      await startDebate('room2', d2, 60, 'EXPERT_VS_CROWD', null, io)
+
+      expect(getState('room2')!.currentIndex).toBe(0) // expert
+      await advanceTurn('room2', 'MANUAL_ADVANCE', io)
+      expect(getState('room2')!.currentIndex).toBe(1) // challenger
+      vi.advanceTimersByTime(501)
+      await advanceTurn('room2', 'MANUAL_ADVANCE', io)
+      expect(getState('room2')!.currentIndex).toBe(0) // back to expert
+      await endDebate('room2', io)
+    })
+
+    it('increments version', async () => {
+      const before = getState(ROOM)!.version
+      await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(getState(ROOM)!.version).toBe(before + 1)
+    })
+
+    it('logs turn transition', async () => {
+      await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(db.logTurnTransition).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'MANUAL_ADVANCE', speakerUserId: 'u1', turnIndex: 0 }),
+      )
+    })
+
+    it('emits forceMute for old speaker and forceUnmute for new', async () => {
+      await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      const calls = io._emit.mock.calls
+      expect(calls).toContainEqual(['forceMute', { userId: 'u1' }])
+      expect(calls).toContainEqual(['forceUnmute', { userId: 'u2' }])
+    })
+
+    it('emits turnChanged with correct payload', async () => {
+      await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(io._emit).toHaveBeenCalledWith('turnChanged', expect.objectContaining({
+        version: 1, currentIndex: 1, phase: 'ACTIVE', turnLength: 60,
+      }))
+    })
+  })
+
+  // ═══════════════════════════════════
+  // pauseDebate / resumeDebate
+  // ═══════════════════════════════════
+
+  describe('pauseDebate', () => {
+    beforeEach(async () => {
+      await setupDebate(io)
+      vi.advanceTimersByTime(10_000) // 10s elapsed
+      vi.clearAllMocks()
+    })
+
+    it('returns error for nonexistent room', async () => {
+      expect(await pauseDebate('nope', io)).toEqual({ success: false, error: 'No active debate' })
+    })
+
+    it('returns error if already paused', async () => {
+      await pauseDebate(ROOM, io)
+      expect(await pauseDebate(ROOM, io)).toEqual({ success: false, error: 'Not active' })
+    })
+
+    it('sets phase to PAUSED and calculates remaining time', async () => {
+      await pauseDebate(ROOM, io)
+      const s = getState(ROOM)!
+      expect(s.phase).toBe('PAUSED')
+      expect(s.isPaused).toBe(true)
+      expect(s.pausedTimeRemaining).toBeGreaterThan(45)
+      expect(s.pausedTimeRemaining).toBeLessThanOrEqual(50)
+      expect(s.turnStartedAt).toBeNull()
+    })
+
+    it('increments version', async () => {
+      const v = getState(ROOM)!.version
+      await pauseDebate(ROOM, io)
+      expect(getState(ROOM)!.version).toBe(v + 1)
+    })
+
+    it('emits debatePaused', async () => {
+      await pauseDebate(ROOM, io)
+      expect(io._emit).toHaveBeenCalledWith('debatePaused', expect.objectContaining({
+        timeRemaining: expect.any(Number),
+      }))
+    })
+  })
+
+  describe('resumeDebate', () => {
+    beforeEach(async () => {
+      await setupDebate(io)
+      vi.advanceTimersByTime(10_000)
+      await pauseDebate(ROOM, io)
+      vi.clearAllMocks()
+    })
+
+    it('returns error if not paused', async () => {
+      await resumeDebate(ROOM, io) // unpause first
+      expect(await resumeDebate(ROOM, io)).toEqual({ success: false, error: 'Not paused' })
+    })
+
+    it('sets phase to ACTIVE', async () => {
+      await resumeDebate(ROOM, io)
+      const s = getState(ROOM)!
+      expect(s.phase).toBe('ACTIVE')
+      expect(s.isPaused).toBe(false)
+      expect(s.turnStartedAt).not.toBeNull()
+    })
+
+    it('emits debateResumed', async () => {
+      await resumeDebate(ROOM, io)
+      expect(io._emit).toHaveBeenCalledWith('debateResumed', expect.objectContaining({
+        turnStartedAt: expect.any(Number), turnLength: expect.any(Number),
+      }))
+    })
+
+    it('schedules timer for remaining time and fires grace', async () => {
+      const remaining = getState(ROOM)!.pausedTimeRemaining
+      await resumeDebate(ROOM, io)
+      vi.clearAllMocks()
+
+      // Just before expiry — still ACTIVE
+      vi.advanceTimersByTime(remaining * 1000 - 100)
+      expect(getState(ROOM)!.phase).toBe('ACTIVE')
+
+      // After expiry — GRACE
+      vi.advanceTimersByTime(200)
+      expect(getState(ROOM)!.phase).toBe('GRACE')
+    })
+  })
+
+  // ═══════════════════════════════════
+  // endDebate
+  // ═══════════════════════════════════
+
+  describe('endDebate', () => {
+    beforeEach(async () => {
+      await setupDebate(io)
+      vi.clearAllMocks()
+    })
+
+    it('removes debate from memory', async () => {
+      await endDebate(ROOM, io)
+      expect(getState(ROOM)).toBeNull()
+    })
+
+    it('logs final turn', async () => {
+      await endDebate(ROOM, io)
+      expect(db.logTurnTransition).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'MANUAL_ADVANCE', speakerUserId: 'u1' }),
+      )
+    })
+
+    it('emits debateEnded', async () => {
+      await endDebate(ROOM, io)
+      expect(io._emit).toHaveBeenCalledWith('debateEnded', expect.objectContaining({ version: expect.any(Number) }))
+    })
+
+    it('returns error for nonexistent room', async () => {
+      expect(await endDebate('nope', io)).toEqual({ success: false, error: 'No active debate' })
+    })
+  })
+
+  // ═══════════════════════════════════
+  // Grace period & warning timers
+  // ═══════════════════════════════════
+
+  describe('grace period', () => {
+    beforeEach(async () => {
+      await setupDebate(io, { turnLength: 5 })
+      vi.clearAllMocks()
+    })
+
+    it('enters GRACE phase when turn timer fires', () => {
+      vi.advanceTimersByTime(5000)
+      expect(getState(ROOM)!.phase).toBe('GRACE')
+    })
+
+    it('emits turnExpiring with expired userId', () => {
+      vi.advanceTimersByTime(5000)
+      expect(io._emit).toHaveBeenCalledWith('turnExpiring', expect.objectContaining({
+        expiredUserId: 'u1',
+      }))
+    })
+
+    it('emits forceMute for expired speaker', () => {
+      vi.advanceTimersByTime(5000)
+      expect(io._emit).toHaveBeenCalledWith('forceMute', { userId: 'u1' })
+    })
+
+    it('auto-advances after 3s grace', async () => {
+      vi.advanceTimersByTime(5000) // turn expired → GRACE
+      vi.clearAllMocks()
+
+      await vi.advanceTimersByTimeAsync(3000) // grace period → auto-advance
+      expect(getState(ROOM)!.currentIndex).toBe(1)
+      expect(getState(ROOM)!.phase).toBe('ACTIVE')
+      expect(io._emit).toHaveBeenCalledWith('turnChanged', expect.objectContaining({ currentIndex: 1 }))
+    })
+  })
+
+  describe('warning timers', () => {
+    it('60s turn emits warnings at 30s and 10s remaining', async () => {
+      await setupDebate(io, { turnLength: 60 })
+      vi.clearAllMocks()
+
+      vi.advanceTimersByTime(30_000) // 30s elapsed → 30s remaining
+      expect(io._emit).toHaveBeenCalledWith('turnWarning', { secondsRemaining: 30 })
+
+      vi.clearAllMocks()
+      vi.advanceTimersByTime(20_000) // 50s elapsed → 10s remaining
+      expect(io._emit).toHaveBeenCalledWith('turnWarning', { secondsRemaining: 10 })
+    })
+
+    it('5s turn emits no warnings', async () => {
+      await setupDebate(io, { turnLength: 5 })
+      vi.clearAllMocks()
+
+      vi.advanceTimersByTime(5000)
+      const warnings = io._emit.mock.calls.filter((c: any) => c[0] === 'turnWarning')
+      expect(warnings).toHaveLength(0)
+    })
+
+    it('15s turn emits only 10s warning', async () => {
+      await setupDebate(io, { turnLength: 15 })
+      vi.clearAllMocks()
+
+      vi.advanceTimersByTime(5000) // 10s remaining
+      expect(io._emit).toHaveBeenCalledWith('turnWarning', { secondsRemaining: 10 })
+
+      const warnings = io._emit.mock.calls.filter((c: any) => c[0] === 'turnWarning')
+      expect(warnings).toHaveLength(1) // only the 10s warning
+    })
+  })
+
+  // ═══════════════════════════════════
+  // handleSpeakerDisconnect
+  // ═══════════════════════════════════
+
+  describe('handleSpeakerDisconnect', () => {
+    beforeEach(async () => {
+      await setupDebate(io)
+      vi.clearAllMocks()
+    })
+
+    it('auto-advances if current speaker disconnects', async () => {
+      await handleSpeakerDisconnect(ROOM, 'u1', io)
+      expect(getState(ROOM)!.currentIndex).toBe(1)
+    })
+
+    it('does nothing if non-current speaker disconnects', async () => {
+      await handleSpeakerDisconnect(ROOM, 'u2', io)
+      expect(getState(ROOM)!.currentIndex).toBe(0)
+      expect(io._emit).not.toHaveBeenCalled()
+    })
+
+    it('does nothing if PAUSED', async () => {
+      await pauseDebate(ROOM, io)
+      vi.clearAllMocks()
+      await handleSpeakerDisconnect(ROOM, 'u1', io)
+      expect(io._emit).not.toHaveBeenCalled()
+    })
+
+    it('does nothing for nonexistent room', async () => {
+      await handleSpeakerDisconnect('nope', 'u1', io)
+      expect(io._emit).not.toHaveBeenCalled()
+    })
+  })
+
+  // ═══════════════════════════════════
+  // checkAuthorization
+  // ═══════════════════════════════════
+
+  describe('checkAuthorization', () => {
+    it('uses cached sessionId when debate is in memory', async () => {
+      await setupDebate(io)
+      vi.clearAllMocks()
+
+      await checkAuthorization(ROOM, 'host')
+      expect(db.isHostOrModerator).toHaveBeenCalledWith('sess-1', 'host')
+      // Should NOT call getSessionByCode since sessionId is cached
+      expect(db.getSessionByCode).not.toHaveBeenCalled()
+    })
+
+    it('falls back to DB lookup for unknown room', async () => {
+      mockSession()
+      await checkAuthorization('unknown-room', 'host')
+      expect(db.getSessionByCode).toHaveBeenCalledWith('unknown-room')
+    })
+
+    it('returns false if session not found', async () => {
+      vi.mocked(db.getSessionByCode).mockResolvedValue(null)
+      const r = await checkAuthorization('unknown', 'host')
+      expect(r).toBe(false)
+    })
+  })
+
+  // ═══════════════════════════════════
+  // Recovery
+  // ═══════════════════════════════════
+
+  describe('recoverDebates', () => {
+    const makeRow = (overrides: Partial<db.DbDebateState> = {}): db.DbDebateState => ({
+      id: 'ds-1',
+      session_id: 'sess-1',
+      debater_order: d2,
+      current_index: 0,
+      turn_length: 60,
+      turn_ends_at: Date.now() + 30_000,
+      is_paused: false,
+      paused_time_remaining: 30,
+      format: 'ONE_ON_ONE',
+      format_meta: null,
+      phase: 'ACTIVE',
+      version: 5,
+      ...overrides,
+    })
+
+    beforeEach(() => {
+      vi.mocked(db.getSessionCodeById).mockResolvedValue(ROOM)
+    })
+
+    it('recovers PAUSED debate without timers', async () => {
+      vi.mocked(db.loadAllActiveDebates).mockResolvedValue([
+        makeRow({ phase: 'PAUSED', is_paused: true, turn_ends_at: null }),
+      ])
+      await recoverDebates(io)
+      const s = getState(ROOM)!
+      expect(s.phase).toBe('PAUSED')
+      expect(s.isPaused).toBe(true)
+    })
+
+    it('recovers ACTIVE with remaining time → schedules timer', async () => {
+      const futureEnd = Date.now() + 20_000
+      vi.mocked(db.loadAllActiveDebates).mockResolvedValue([
+        makeRow({ turn_ends_at: futureEnd }),
+      ])
+      await recoverDebates(io)
+      expect(getState(ROOM)!.phase).toBe('ACTIVE')
+
+      // Timer should fire roughly when the turn was supposed to end
+      vi.advanceTimersByTime(20_100)
+      expect(getState(ROOM)!.phase).toBe('GRACE')
+    })
+
+    it('recovers ACTIVE with expired time → immediately advances', async () => {
+      vi.mocked(db.loadAllActiveDebates).mockResolvedValue([
+        makeRow({ turn_ends_at: Date.now() - 5000 }),
+      ])
+      await recoverDebates(io)
+      // Should have auto-advanced
+      expect(getState(ROOM)!.currentIndex).toBe(1)
+    })
+
+    it('recovers GRACE → immediately advances', async () => {
+      vi.mocked(db.loadAllActiveDebates).mockResolvedValue([
+        makeRow({ phase: 'GRACE', turn_ends_at: Date.now() - 1000 }),
+      ])
+      await recoverDebates(io)
+      expect(getState(ROOM)!.currentIndex).toBe(1)
+    })
+
+    it('skips if session code not found', async () => {
+      vi.mocked(db.getSessionCodeById).mockResolvedValue(null)
+      vi.mocked(db.loadAllActiveDebates).mockResolvedValue([makeRow()])
+      await recoverDebates(io)
+      expect(getState(ROOM)).toBeNull()
+    })
+  })
+
+  describe('getOrLoadState', () => {
+    it('returns in-memory state first', async () => {
+      await setupDebate(io)
+      vi.clearAllMocks()
+      const s = await getOrLoadState(ROOM, io)
+      expect(s).not.toBeNull()
+      expect(s!.currentIndex).toBe(0)
+      expect(db.loadDebateState).not.toHaveBeenCalled()
+    })
+
+    it('falls back to DB when not in memory', async () => {
+      mockSession()
+      vi.mocked(db.getSessionCodeById).mockResolvedValue(ROOM)
+      vi.mocked(db.loadDebateState).mockResolvedValue({
+        id: 'ds-2', session_id: 'sess-1', debater_order: d2, current_index: 1,
+        turn_length: 60, turn_ends_at: Date.now() + 30_000, is_paused: false,
+        paused_time_remaining: 30, format: 'ONE_ON_ONE', format_meta: null,
+        phase: 'ACTIVE', version: 3,
+      })
+      const s = await getOrLoadState(ROOM, io)
+      expect(s).not.toBeNull()
+      expect(db.loadDebateState).toHaveBeenCalled()
+    })
+
+    it('returns null if session not found', async () => {
+      vi.mocked(db.getSessionByCode).mockResolvedValue(null)
+      const s = await getOrLoadState('nope', io)
+      expect(s).toBeNull()
+    })
+
+    it('returns null if DB row phase is ENDED', async () => {
+      mockSession()
+      vi.mocked(db.loadDebateState).mockResolvedValue({
+        id: 'ds-2', session_id: 'sess-1', debater_order: d2, current_index: 0,
+        turn_length: 60, turn_ends_at: null, is_paused: false,
+        paused_time_remaining: 0, format: 'ONE_ON_ONE', format_meta: null,
+        phase: 'ENDED', version: 5,
+      })
+      const s = await getOrLoadState(ROOM, io)
+      expect(s).toBeNull()
+    })
+  })
+
+  // ═══════════════════════════════════
+  // Full lifecycle integration
+  // ═══════════════════════════════════
+
+  describe('full lifecycle', () => {
+    it('start → advance → pause → resume → end', async () => {
+      await setupDebate(io)
+      expect(getState(ROOM)!.phase).toBe('ACTIVE')
+      expect(getState(ROOM)!.currentIndex).toBe(0)
+
+      // Advance
+      await advanceTurn(ROOM, 'MANUAL_ADVANCE', io)
+      expect(getState(ROOM)!.currentIndex).toBe(1)
+      expect(getState(ROOM)!.version).toBe(1)
+
+      // Pause
+      vi.advanceTimersByTime(501)
+      await pauseDebate(ROOM, io)
+      expect(getState(ROOM)!.phase).toBe('PAUSED')
+
+      // Resume
+      await resumeDebate(ROOM, io)
+      expect(getState(ROOM)!.phase).toBe('ACTIVE')
+
+      // End
+      await endDebate(ROOM, io)
+      expect(getState(ROOM)).toBeNull()
+    })
+
+    it('auto-advance full cycle: turn expires → grace → next turn', async () => {
+      await setupDebate(io, { turnLength: 2 })
+      expect(getState(ROOM)!.currentIndex).toBe(0)
+
+      // Turn expires
+      vi.advanceTimersByTime(2000)
+      expect(getState(ROOM)!.phase).toBe('GRACE')
+
+      // Grace period ends, auto-advance
+      await vi.advanceTimersByTimeAsync(3000)
+      expect(getState(ROOM)!.currentIndex).toBe(1)
+      expect(getState(ROOM)!.phase).toBe('ACTIVE')
+    })
+  })
+})

--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -112,7 +112,8 @@ export default function RoomClient({
   })
 
   const debate = useDebateChannel({
-    sessionId: session.id,
+    sfuUrl: process.env.NEXT_PUBLIC_SFU_URL,
+    roomCode: session.code,
     userId: currentUserId,
   })
 
@@ -284,7 +285,7 @@ export default function RoomClient({
       }))
 
       if (debaterList.length >= 2) {
-        await debate.startDebate(debaterList, session.turnLength)
+        await debate.startDebate(debaterList, session.turnLength, session.type)
       }
 
       await updateSessionStatus(session.id, SessionStatus.LIVE)

--- a/hooks/useDebateChannel.ts
+++ b/hooks/useDebateChannel.ts
@@ -1,16 +1,6 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { createClient } from '@/lib/supabase/client'
-import {
-  getDebateState as getDebateStateAction,
-  startDebate as startDebateAction,
-  advanceTurn as advanceTurnAction,
-  advanceTurnIfExpired,
-  pauseDebate as pauseDebateAction,
-  resumeDebate as resumeDebateAction,
-  endDebate as endDebateAction,
-} from '@/lib/actions/debate'
 
 interface DebateParticipant {
   userId: string
@@ -18,139 +8,250 @@ interface DebateParticipant {
 }
 
 type DebateStatus = 'idle' | 'live' | 'paused' | 'ended'
-
-interface DebateRow {
-  session_id: string
-  debater_order: DebateParticipant[]
-  current_index: number
-  turn_length: number
-  turn_ends_at: number | null
-  is_paused: boolean
-  paused_time_remaining: number
-}
+type DebatePhase = 'ACTIVE' | 'GRACE' | 'PAUSED' | 'ENDED'
 
 interface UseDebateChannelOptions {
-  sessionId: string
+  sfuUrl: string | undefined
+  roomCode: string
   userId: string | null
 }
 
-export function useDebateChannel({ sessionId, userId }: UseDebateChannelOptions) {
+// Socket.io emit with ack helper
+function request(socket: any, event: string, data: Record<string, any> = {}): Promise<any> {
+  return new Promise((resolve, reject) => {
+    socket.emit(event, data, (response: any) => {
+      if (response.success) {
+        resolve(response)
+      } else {
+        reject(new Error(response.error || 'Unknown error'))
+      }
+    })
+  })
+}
+
+export function useDebateChannel({
+  sfuUrl,
+  roomCode,
+  userId,
+}: UseDebateChannelOptions) {
   const [debaters, setDebaters] = useState<DebateParticipant[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
-  const [turnEndsAt, setTurnEndsAt] = useState<number | null>(null)
+  const [turnStartedAt, setTurnStartedAt] = useState<number | null>(null)
+  const [turnLength, setTurnLength] = useState(0)
   const [isPaused, setIsPaused] = useState(false)
   const [debateStatus, setDebateStatus] = useState<DebateStatus>('idle')
   const [timeRemaining, setTimeRemaining] = useState(0)
-  const timerFiredRef = useRef(false)
+  const [phase, setPhase] = useState<DebatePhase>('ACTIVE')
+  const [version, setVersion] = useState(0)
+  const [graceCountdown, setGraceCountdown] = useState<number | null>(null)
+
+  const socketRef = useRef<any>(null)
   const warnedRef = useRef<Set<number>>(new Set())
 
   const currentSpeaker = debaters[currentIndex] ?? null
   const isMyTurn = currentSpeaker?.userId === userId
 
-  const applyState = useCallback((row: DebateRow) => {
-    setDebaters(row.debater_order)
-    setCurrentIndex(row.current_index)
-    setTurnEndsAt(row.turn_ends_at)
-    setIsPaused(row.is_paused)
-    setDebateStatus(row.is_paused ? 'paused' : 'live')
-    timerFiredRef.current = false
-    warnedRef.current = new Set()
-
-    if (row.is_paused) {
-      setTimeRemaining(Math.ceil(row.paused_time_remaining))
-    }
+  const playBeep = useCallback((freq: number) => {
+    try {
+      const ctx = new (window.AudioContext || (window as any).webkitAudioContext)()
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+      osc.connect(gain)
+      gain.connect(ctx.destination)
+      osc.frequency.value = freq
+      gain.gain.setValueAtTime(0.3, ctx.currentTime)
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.3)
+      osc.start(ctx.currentTime)
+      osc.stop(ctx.currentTime + 0.3)
+    } catch { /* audio not supported */ }
   }, [])
 
-  // Subscribe to Realtime + fetch initial state
+  // Connect to SFU and subscribe to debate events
   useEffect(() => {
-    const supabase = createClient()
+    if (!sfuUrl || !roomCode) return
 
-    const channel = supabase
-      .channel(`debate:${sessionId}`)
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'DebateState',
-          filter: `session_id=eq.${sessionId}`,
-        },
-        (payload) => {
-          if (payload.eventType === 'DELETE') {
-            setDebateStatus('ended')
-            setDebaters([])
-            setTurnEndsAt(null)
-            setTimeRemaining(0)
-            return
+    let cancelled = false
+
+    async function connect() {
+      const { io } = await import('socket.io-client')
+
+      if (cancelled) return
+
+      const socket = io(sfuUrl!, {
+        transports: ['websocket'],
+        auth: { userId },
+      })
+      socketRef.current = socket
+
+      socket.on('connect', async () => {
+        if (cancelled) return
+
+        try {
+          // Join debate room (lightweight, no mediasoup)
+          await request(socket, 'joinDebateRoom', { roomCode })
+
+          // Fetch initial state (handles refresh recovery)
+          const resp = await request(socket, 'getDebateState', { roomCode })
+          if (resp.state) {
+            applyFullState(resp.state)
           }
-          applyState(payload.new as unknown as DebateRow)
-        },
-      )
-      .subscribe(async (status) => {
-        if (status === 'SUBSCRIBED') {
-          const state = await getDebateStateAction(sessionId)
-          if (state) applyState(state as DebateRow)
+        } catch (err) {
+          console.error('Debate room join error:', err)
         }
       })
 
+      // ── Debate events ──
+
+      socket.on('turnChanged', (payload: any) => {
+        setDebaters(payload.debaterOrder)
+        setCurrentIndex(payload.currentIndex)
+        setTurnStartedAt(payload.turnStartedAt)
+        setTurnLength(payload.turnLength)
+        setIsPaused(false)
+        setDebateStatus('live')
+        setPhase(payload.phase || 'ACTIVE')
+        setVersion(payload.version)
+        setGraceCountdown(null)
+        warnedRef.current = new Set()
+      })
+
+      socket.on('turnExpiring', (payload: any) => {
+        setPhase('GRACE')
+        setVersion(payload.version)
+        setGraceCountdown(3)
+      })
+
+      socket.on('turnWarning', (payload: any) => {
+        const secs = payload.secondsRemaining
+        if (secs === 30) playBeep(440)
+        if (secs === 10) playBeep(880)
+      })
+
+      socket.on('debatePaused', (payload: any) => {
+        setIsPaused(true)
+        setDebateStatus('paused')
+        setPhase('PAUSED')
+        setVersion(payload.version)
+        setTimeRemaining(Math.ceil(payload.timeRemaining))
+        setTurnStartedAt(null)
+      })
+
+      socket.on('debateResumed', (payload: any) => {
+        setIsPaused(false)
+        setDebateStatus('live')
+        setPhase('ACTIVE')
+        setVersion(payload.version)
+        setTurnStartedAt(payload.turnStartedAt)
+        setTurnLength(payload.turnLength)
+        warnedRef.current = new Set()
+      })
+
+      socket.on('debateEnded', () => {
+        setDebateStatus('ended')
+        setDebaters([])
+        setTurnStartedAt(null)
+        setTimeRemaining(0)
+        setPhase('ENDED')
+        setGraceCountdown(null)
+      })
+
+      socket.on('disconnect', () => {
+        if (!cancelled) {
+          console.log('Debate socket disconnected')
+        }
+      })
+    }
+
+    function applyFullState(state: any) {
+      setDebaters(state.debaterOrder)
+      setCurrentIndex(state.currentIndex)
+      setTurnStartedAt(state.turnStartedAt)
+      setTurnLength(state.turnLength)
+      setIsPaused(state.isPaused)
+      setPhase(state.phase)
+      setVersion(state.version)
+      warnedRef.current = new Set()
+
+      if (state.phase === 'ENDED') {
+        setDebateStatus('ended')
+      } else if (state.isPaused) {
+        setDebateStatus('paused')
+        setTimeRemaining(Math.ceil(state.pausedTimeRemaining))
+      } else if (state.debaterOrder.length > 0) {
+        setDebateStatus('live')
+      }
+    }
+
+    connect()
+
     return () => {
-      supabase.removeChannel(channel)
+      cancelled = true
+      if (socketRef.current) {
+        socketRef.current.disconnect()
+        socketRef.current = null
+      }
     }
-  }, [sessionId, applyState])
+  }, [sfuUrl, roomCode, userId, playBeep])
 
-  // Timer countdown
+  // Timer countdown (client-side, derived from turnStartedAt + turnLength)
   useEffect(() => {
-    if (debateStatus !== 'live' || isPaused || turnEndsAt === null) return
-
-    const playBeep = (freq: number) => {
-      try {
-        const ctx = new (window.AudioContext || (window as any).webkitAudioContext)()
-        const osc = ctx.createOscillator()
-        const gain = ctx.createGain()
-        osc.connect(gain)
-        gain.connect(ctx.destination)
-        osc.frequency.value = freq
-        gain.gain.setValueAtTime(0.3, ctx.currentTime)
-        gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.3)
-        osc.start(ctx.currentTime)
-        osc.stop(ctx.currentTime + 0.3)
-      } catch { /* audio not supported */ }
-    }
+    if (debateStatus !== 'live' || isPaused || turnStartedAt === null) return
 
     const tick = () => {
-      const remaining = Math.max(0, Math.ceil((turnEndsAt - Date.now()) / 1000))
+      const elapsed = (Date.now() - turnStartedAt) / 1000
+      const remaining = Math.max(0, Math.ceil(turnLength - elapsed))
       setTimeRemaining(remaining)
-
-      if (remaining === 30 && !warnedRef.current.has(30)) {
-        warnedRef.current.add(30)
-        playBeep(440)
-      }
-      if (remaining === 10 && !warnedRef.current.has(10)) {
-        warnedRef.current.add(10)
-        playBeep(880)
-      }
-
-      if (remaining <= 0 && !timerFiredRef.current) {
-        timerFiredRef.current = true
-        advanceTurnIfExpired(sessionId).catch(console.error)
-      }
     }
 
     tick()
     const interval = setInterval(tick, 250)
     return () => clearInterval(interval)
-  }, [debateStatus, isPaused, turnEndsAt, sessionId])
+  }, [debateStatus, isPaused, turnStartedAt, turnLength])
 
-  // Actions
+  // Grace period countdown
+  useEffect(() => {
+    if (graceCountdown === null || graceCountdown <= 0) return
+
+    const timer = setTimeout(() => {
+      setGraceCountdown((prev) => (prev !== null && prev > 0 ? prev - 1 : null))
+    }, 1000)
+
+    return () => clearTimeout(timer)
+  }, [graceCountdown])
+
+  // Actions (emit via Socket.io)
   const startDebate = useCallback(
-    (debaterList: DebateParticipant[], turnLen: number) =>
-      startDebateAction(sessionId, debaterList, turnLen),
-    [sessionId],
+    async (debaterList: DebateParticipant[], turnLen: number, format: string) => {
+      if (!socketRef.current) throw new Error('Not connected')
+      await request(socketRef.current, 'startDebate', {
+        roomCode,
+        debaters: debaterList,
+        turnLength: turnLen,
+        format,
+      })
+    },
+    [roomCode],
   )
-  const nextTurn = useCallback(() => advanceTurnAction(sessionId), [sessionId])
-  const pause = useCallback(() => pauseDebateAction(sessionId), [sessionId])
-  const resume = useCallback(() => resumeDebateAction(sessionId), [sessionId])
-  const endDebate = useCallback(() => endDebateAction(sessionId), [sessionId])
+
+  const nextTurn = useCallback(async () => {
+    if (!socketRef.current) throw new Error('Not connected')
+    await request(socketRef.current, 'nextTurn', { roomCode, version })
+  }, [roomCode, version])
+
+  const pause = useCallback(async () => {
+    if (!socketRef.current) throw new Error('Not connected')
+    await request(socketRef.current, 'pauseDebate', { roomCode })
+  }, [roomCode])
+
+  const resume = useCallback(async () => {
+    if (!socketRef.current) throw new Error('Not connected')
+    await request(socketRef.current, 'resumeDebate', { roomCode })
+  }, [roomCode])
+
+  const endDebate = useCallback(async () => {
+    if (!socketRef.current) throw new Error('Not connected')
+    await request(socketRef.current, 'endDebate', { roomCode })
+  }, [roomCode])
 
   return {
     currentSpeaker,
@@ -159,6 +260,9 @@ export function useDebateChannel({ sessionId, userId }: UseDebateChannelOptions)
     isMyTurn,
     debateStatus,
     debaters,
+    phase,
+    version,
+    graceCountdown,
     startDebate,
     nextTurn,
     pause,

--- a/hooks/useMediasoup.ts
+++ b/hooks/useMediasoup.ts
@@ -15,6 +15,7 @@ interface UseMediasoupOptions {
   sfuUrl: string | undefined
   roomId: string
   displayName: string
+  userId?: string
   enabled: boolean
 }
 
@@ -24,6 +25,7 @@ interface UseMediasoupReturn {
   remoteStreams: Map<string, RemoteStream>
   audioMuted: boolean
   videoOff: boolean
+  serverMuted: boolean
   toggleMute: () => void
   toggleVideo: () => void
   disconnect: () => void
@@ -47,6 +49,7 @@ export function useMediasoup({
   sfuUrl,
   roomId,
   displayName,
+  userId,
   enabled,
 }: UseMediasoupOptions): UseMediasoupReturn {
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected')
@@ -54,6 +57,7 @@ export function useMediasoup({
   const [remoteStreams, setRemoteStreams] = useState<Map<string, RemoteStream>>(new Map())
   const [audioMuted, setAudioMuted] = useState(false)
   const [videoOff, setVideoOff] = useState(false)
+  const [serverMuted, setServerMuted] = useState(false)
   const [reconnectTrigger, setReconnectTrigger] = useState(0)
 
   const socketRef = useRef<any>(null)
@@ -323,6 +327,22 @@ export function useMediasoup({
           }
         })
 
+        // ── Debate mute enforcement ──
+        socket.on('forceMute', (data: any) => {
+          if (data.userId === userId && localStreamRef.current) {
+            localStreamRef.current.getAudioTracks().forEach((t: MediaStreamTrack) => { t.enabled = false })
+            setAudioMuted(true)
+            setServerMuted(true)
+          }
+        })
+        socket.on('forceUnmute', (data: any) => {
+          if (data.userId === userId && localStreamRef.current) {
+            localStreamRef.current.getAudioTracks().forEach((t: MediaStreamTrack) => { t.enabled = true })
+            setAudioMuted(false)
+            setServerMuted(false)
+          }
+        })
+
         socket.on('peerLeft', (data: any) => {
           const toRemove: string[] = []
           for (const [consumerId, info] of consumersRef.current) {
@@ -395,6 +415,7 @@ export function useMediasoup({
     remoteStreams,
     audioMuted,
     videoOff,
+    serverMuted,
     toggleMute,
     toggleVideo,
     disconnect,

--- a/lib/actions/debate.ts
+++ b/lib/actions/debate.ts
@@ -25,6 +25,9 @@ export async function getDebateState(sessionId: string) {
     turn_ends_at: state.turn_ends_at,
     is_paused: state.is_paused,
     paused_time_remaining: state.paused_time_remaining,
+    format: state.format,
+    phase: state.phase,
+    version: state.version,
   }
 }
 
@@ -33,8 +36,8 @@ export async function startDebate(
   debaters: { userId: string; displayName: string }[],
   turnLength: number
 ) {
-  await requireHostOrModerator(sessionId)
-  if (debaters.length !== 2) throw new Error("Exactly 2 debaters required")
+  const { session } = await requireHostOrModerator(sessionId)
+  if (debaters.length < 2) throw new Error("At least 2 debaters required")
   if (turnLength < 1) throw new Error("Turn length must be at least 1 second")
   if (turnLength > 1800) throw new Error("Turn length cannot exceed 30 minutes (1800 seconds)")
 
@@ -65,6 +68,9 @@ export async function startDebate(
       turn_ends_at: now + turnLength * 1000,
       is_paused: false,
       paused_time_remaining: turnLength,
+      format: session.type,
+      phase: "ACTIVE",
+      version: 0,
     },
     update: {
       debater_order: debaters,
@@ -73,6 +79,9 @@ export async function startDebate(
       turn_ends_at: now + turnLength * 1000,
       is_paused: false,
       paused_time_remaining: turnLength,
+      format: session.type,
+      phase: "ACTIVE",
+      version: { increment: 1 },
     },
   })
 }
@@ -85,14 +94,19 @@ export async function advanceTurn(sessionId: string) {
   })
   if (!state) throw new Error("No active debate")
 
+  const debaterOrder = state.debater_order as { userId: string; displayName: string }[]
+  const debaterCount = debaterOrder.length
+
   const now = Date.now()
   await prisma.debateState.update({
     where: { session_id: sessionId },
     data: {
-      current_index: (state.current_index + 1) % 2,
+      current_index: (state.current_index + 1) % debaterCount,
       turn_ends_at: now + state.turn_length * 1000,
       is_paused: false,
       paused_time_remaining: state.turn_length,
+      phase: "ACTIVE",
+      version: { increment: 1 },
     },
   })
 }
@@ -151,6 +165,8 @@ export async function pauseDebate(sessionId: string) {
       is_paused: true,
       turn_ends_at: null,
       paused_time_remaining: remaining,
+      phase: "PAUSED",
+      version: { increment: 1 },
     },
   })
 }
@@ -170,6 +186,8 @@ export async function resumeDebate(sessionId: string) {
     data: {
       is_paused: false,
       turn_ends_at: now + state.paused_time_remaining * 1000,
+      phase: "ACTIVE",
+      version: { increment: 1 },
     },
   })
 }
@@ -203,6 +221,9 @@ export async function extendTurn(sessionId: string, extraSeconds: number) {
 export async function endDebate(sessionId: string) {
   await requireHostOrModerator(sessionId)
   await prisma.debateState
-    .delete({ where: { session_id: sessionId } })
+    .update({
+      where: { session_id: sessionId },
+      data: { phase: "ENDED", version: { increment: 1 } },
+    })
     .catch(() => {})
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,20 @@ enum VoteType {
   PROMOTE
 }
 
+enum DebatePhase {
+  ACTIVE
+  GRACE
+  PAUSED
+  ENDED
+}
+
+enum TurnReason {
+  TIMER_EXPIRED
+  MANUAL_ADVANCE
+  SPEAKER_DISCONNECT
+  DEBATE_START
+}
+
 // ── Models ──
 
 model User {
@@ -112,16 +126,35 @@ model Session {
 }
 
 model DebateState {
-  id                    String  @id @default(cuid())
-  session_id            String  @unique
+  id                    String       @id @default(cuid())
+  session_id            String       @unique
   debater_order         Json
-  current_index         Int     @default(0)
+  current_index         Int          @default(0)
   turn_length           Int
   turn_ends_at          Float?
-  is_paused             Boolean @default(false)
-  paused_time_remaining Float   @default(0)
+  is_paused             Boolean      @default(false)
+  paused_time_remaining Float        @default(0)
+  format                SessionType
+  format_meta           Json?
+  phase                 DebatePhase  @default(ACTIVE)
+  version               Int          @default(0)
 
-  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  session   Session   @relation(fields: [session_id], references: [id], onDelete: Cascade)
+  turn_logs TurnLog[]
+}
+
+model TurnLog {
+  id              String     @id @default(cuid())
+  debate_state_id String
+  speaker_user_id String?    @db.Uuid
+  speaker_name    String
+  turn_index      Int
+  reason          TurnReason
+  started_at      DateTime
+  ended_at        DateTime   @default(now())
+  duration_sec    Float
+
+  debate_state DebateState @relation(fields: [debate_state_id], references: [id], onDelete: Cascade)
 }
 
 /// Speaker-attributed, timestamped transcript segment (REQ-6)

--- a/realtime/package-lock.json
+++ b/realtime/package-lock.json
@@ -8,9 +8,11 @@
       "name": "arguably-realtime",
       "version": "0.1.0",
       "dependencies": {
+        "@types/pg": "^8.20.0",
         "dotenv": "^16.4.7",
         "jose": "^6.2.2",
         "mediasoup": "^3.19.0",
+        "pg": "^8.20.0",
         "socket.io": "^4.8.0",
         "zod": "^4.3.6"
       },
@@ -504,6 +506,17 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -901,6 +914,135 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -950,6 +1092,15 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/supports-color": {
@@ -1057,6 +1208,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -12,9 +12,11 @@
     "docker:logs": "docker compose logs -f"
   },
   "dependencies": {
+    "@types/pg": "^8.20.0",
     "dotenv": "^16.4.7",
     "jose": "^6.2.2",
     "mediasoup": "^3.19.0",
+    "pg": "^8.20.0",
     "socket.io": "^4.8.0",
     "zod": "^4.3.6"
   },

--- a/realtime/src/db.ts
+++ b/realtime/src/db.ts
@@ -1,0 +1,183 @@
+import "dotenv/config";
+import pg from "pg";
+
+// Use raw pg for the realtime server's few DB queries.
+// This avoids the complexity of sharing the Prisma generated client across packages
+// while keeping queries simple and type-safe via explicit interfaces.
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: 5,
+});
+
+// ── Types mirroring Prisma schema ──
+
+export interface DbDebateState {
+  id: string;
+  session_id: string;
+  debater_order: unknown; // JSON
+  current_index: number;
+  turn_length: number;
+  turn_ends_at: number | null;
+  is_paused: boolean;
+  paused_time_remaining: number;
+  format: string;
+  format_meta: unknown | null;
+  phase: string;
+  version: number;
+}
+
+export interface DbSession {
+  id: string;
+  code: string;
+  type: string;
+  host_id: string;
+  moderator_id: string | null;
+}
+
+// ── Queries ──
+
+export async function persistDebateState(state: {
+  id: string;
+  sessionId: string;
+  debaterOrder: unknown;
+  currentIndex: number;
+  turnLength: number;
+  turnEndsAt: number | null;
+  isPaused: boolean;
+  pausedTimeRemaining: number;
+  format: string;
+  formatMeta: unknown | null;
+  phase: string;
+  version: number;
+}): Promise<void> {
+  await pool.query(
+    `INSERT INTO "DebateState" (
+      id, session_id, debater_order, current_index, turn_length,
+      turn_ends_at, is_paused, paused_time_remaining, format, format_meta, phase, version
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    ON CONFLICT (session_id) DO UPDATE SET
+      debater_order = $3, current_index = $4, turn_length = $5,
+      turn_ends_at = $6, is_paused = $7, paused_time_remaining = $8,
+      format = $9, format_meta = $10, phase = $11, version = $12`,
+    [
+      state.id,
+      state.sessionId,
+      JSON.stringify(state.debaterOrder),
+      state.currentIndex,
+      state.turnLength,
+      state.turnEndsAt,
+      state.isPaused,
+      state.pausedTimeRemaining,
+      state.format,
+      state.formatMeta ? JSON.stringify(state.formatMeta) : null,
+      state.phase,
+      state.version,
+    ],
+  );
+}
+
+export async function loadDebateState(
+  sessionId: string,
+): Promise<DbDebateState | null> {
+  const { rows } = await pool.query(
+    `SELECT * FROM "DebateState" WHERE session_id = $1`,
+    [sessionId],
+  );
+  return rows[0] ?? null;
+}
+
+export async function loadAllActiveDebates(): Promise<DbDebateState[]> {
+  const { rows } = await pool.query(
+    `SELECT * FROM "DebateState" WHERE phase != 'ENDED'`,
+  );
+  return rows;
+}
+
+export async function logTurnTransition(entry: {
+  debateStateId: string;
+  speakerUserId: string | null;
+  speakerName: string;
+  turnIndex: number;
+  reason: string;
+  startedAt: Date;
+  endedAt: Date;
+  durationSec: number;
+}): Promise<void> {
+  const id = generateCuid();
+  await pool.query(
+    `INSERT INTO "TurnLog" (
+      id, debate_state_id, speaker_user_id, speaker_name,
+      turn_index, reason, started_at, ended_at, duration_sec
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+    [
+      id,
+      entry.debateStateId,
+      entry.speakerUserId,
+      entry.speakerName,
+      entry.turnIndex,
+      entry.reason,
+      entry.startedAt,
+      entry.endedAt,
+      entry.durationSec,
+    ],
+  );
+}
+
+export async function deleteDebateState(sessionId: string): Promise<void> {
+  await pool.query(`DELETE FROM "DebateState" WHERE session_id = $1`, [
+    sessionId,
+  ]);
+}
+
+export async function getSessionByCode(
+  code: string,
+): Promise<DbSession | null> {
+  const { rows } = await pool.query(
+    `SELECT id, code, type, host_id, moderator_id FROM "Session" WHERE code = $1`,
+    [code],
+  );
+  return rows[0] ?? null;
+}
+
+export async function validateDebaterIds(
+  sessionId: string,
+  userIds: string[],
+): Promise<boolean> {
+  if (userIds.length === 0) return false;
+  const { rows } = await pool.query(
+    `SELECT user_id FROM "ParticipatesIn"
+     WHERE session_id = $1 AND user_id = ANY($2) AND left_at IS NULL`,
+    [sessionId, userIds],
+  );
+  return rows.length === userIds.length;
+}
+
+export async function getSessionCodeById(
+  sessionId: string,
+): Promise<string | null> {
+  const { rows } = await pool.query(
+    `SELECT code FROM "Session" WHERE id = $1`,
+    [sessionId],
+  );
+  return rows[0]?.code ?? null;
+}
+
+export async function isHostOrModerator(
+  sessionId: string,
+  userId: string,
+): Promise<boolean> {
+  const { rows } = await pool.query(
+    `SELECT id FROM "Session"
+     WHERE id = $1 AND (host_id = $2 OR moderator_id = $2)`,
+    [sessionId, userId],
+  );
+  return rows.length > 0;
+}
+
+// Simple CUID-like ID generator (good enough for turn logs)
+function generateCuid(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 10);
+  return `c${timestamp}${random}`;
+}

--- a/realtime/src/debate.ts
+++ b/realtime/src/debate.ts
@@ -1,0 +1,691 @@
+import type { Server as SocketIOServer } from "socket.io";
+import type {
+  DebateParticipant,
+  DebateFormat,
+  DebatePhase,
+  TurnReason,
+  TurnChangedPayload,
+  TurnExpiringPayload,
+  TurnWarningPayload,
+  DebatePausedPayload,
+  DebateResumedPayload,
+  DebateEndedPayload,
+  DebateStatePayload,
+} from "./types.js";
+import {
+  persistDebateState,
+  loadDebateState,
+  loadAllActiveDebates,
+  logTurnTransition,
+  getSessionByCode,
+  getSessionCodeById,
+  validateDebaterIds,
+  isHostOrModerator,
+  type DbDebateState,
+} from "./db.js";
+import { getRoom } from "./mediasoup/rooms.js";
+
+// ── Constants ──
+
+const GRACE_PERIOD_MS = 3000;
+const WARNING_THRESHOLDS = [30, 10]; // seconds remaining
+const DEBOUNCE_MS = 500;
+
+// ── Internal State ──
+
+interface InternalDebateState {
+  id: string; // DB row ID
+  sessionId: string; // DB session.id (CUID)
+  roomCode: string; // Socket.io room = session.code
+  format: DebateFormat;
+  debaterOrder: DebateParticipant[];
+  currentIndex: number;
+  turnLength: number; // seconds
+  turnStartedAt: number | null; // Date.now() when turn began
+  isPaused: boolean;
+  pausedTimeRemaining: number; // seconds
+  phase: DebatePhase;
+  formatMeta: Record<string, unknown> | null;
+  version: number;
+
+  // Timers (not persisted)
+  turnTimer: ReturnType<typeof setTimeout> | null;
+  graceTimer: ReturnType<typeof setTimeout> | null;
+  warningTimers: ReturnType<typeof setTimeout>[];
+  lastAdvanceAt: number; // debounce guard
+}
+
+const debates = new Map<string, InternalDebateState>();
+
+// Map roomCode -> sessionId for lookups
+const codeToSessionId = new Map<string, string>();
+
+// ── Public API ──
+
+export async function startDebate(
+  roomCode: string,
+  debaters: DebateParticipant[],
+  turnLength: number,
+  format: DebateFormat,
+  formatMeta: Record<string, unknown> | null,
+  io: SocketIOServer,
+): Promise<{ success: boolean; error?: string }> {
+  // Validate inputs
+  if (turnLength < 1 || turnLength > 1800) {
+    return { success: false, error: "Turn length must be 1-1800 seconds" };
+  }
+  if (debaters.length < 2) {
+    return { success: false, error: "At least 2 debaters required" };
+  }
+
+  // Format-specific validation
+  if (format === "ONE_ON_ONE" && debaters.length !== 2) {
+    return { success: false, error: "One-on-One requires exactly 2 debaters" };
+  }
+  if (format === "PANEL" && (debaters.length < 3 || debaters.length > 6)) {
+    return { success: false, error: "Panel requires 3-6 debaters" };
+  }
+
+  // Lookup session in DB
+  const session = await getSessionByCode(roomCode);
+  if (!session) {
+    return { success: false, error: "Session not found" };
+  }
+
+  // Validate debater IDs are actual participants
+  const debaterIds = debaters.map((d) => d.userId);
+  const valid = await validateDebaterIds(session.id, debaterIds);
+  if (!valid) {
+    return { success: false, error: "Invalid debater IDs" };
+  }
+
+  // Check format matches session type
+  if (format !== session.type) {
+    return { success: false, error: "Format does not match session type" };
+  }
+
+  const id = `ds_${Date.now().toString(36)}${Math.random().toString(36).substring(2, 8)}`;
+  const now = Date.now();
+
+  const state: InternalDebateState = {
+    id,
+    sessionId: session.id,
+    roomCode,
+    format,
+    debaterOrder: debaters,
+    currentIndex: 0,
+    turnLength,
+    turnStartedAt: now,
+    isPaused: false,
+    pausedTimeRemaining: turnLength,
+    phase: "ACTIVE",
+    formatMeta,
+    version: 0,
+    turnTimer: null,
+    graceTimer: null,
+    warningTimers: [],
+    lastAdvanceAt: 0,
+  };
+
+  debates.set(roomCode, state);
+  codeToSessionId.set(roomCode, session.id);
+
+  // Persist before emitting
+  await persistState(state);
+
+  // Log the first turn start
+  await logTurnTransition({
+    debateStateId: id,
+    speakerUserId: debaters[0].userId,
+    speakerName: debaters[0].displayName,
+    turnIndex: 0,
+    reason: "DEBATE_START",
+    startedAt: new Date(now),
+    endedAt: new Date(now),
+    durationSec: 0,
+  });
+
+  // Start timers
+  scheduleTimers(state, io);
+
+  // Broadcast
+  const payload: TurnChangedPayload = {
+    version: state.version,
+    currentIndex: 0,
+    debaterOrder: debaters,
+    turnStartedAt: now,
+    turnLength,
+    phase: "ACTIVE",
+  };
+  io.to(roomCode).emit("turnChanged", payload);
+
+  return { success: true };
+}
+
+export async function advanceTurn(
+  roomCode: string,
+  reason: TurnReason,
+  io: SocketIOServer,
+  requestVersion?: number,
+): Promise<{ success: boolean; error?: string }> {
+  const state = debates.get(roomCode);
+  if (!state) return { success: false, error: "No active debate" };
+
+  // Debounce guard
+  const now = Date.now();
+  if (now - state.lastAdvanceAt < DEBOUNCE_MS) {
+    return { success: false, error: "Too fast" };
+  }
+
+  // Version check for idempotency (if provided)
+  if (requestVersion !== undefined && requestVersion !== state.version) {
+    return { success: false, error: "Stale version" };
+  }
+
+  // Can only advance from ACTIVE phase
+  if (state.phase !== "ACTIVE" && state.phase !== "GRACE") {
+    return { success: false, error: "Debate is not active" };
+  }
+
+  state.lastAdvanceAt = now;
+
+  // Log the ending turn
+  const currentSpeaker = state.debaterOrder[state.currentIndex];
+  if (currentSpeaker && state.turnStartedAt) {
+    await logTurnTransition({
+      debateStateId: state.id,
+      speakerUserId: currentSpeaker.userId,
+      speakerName: currentSpeaker.displayName,
+      turnIndex: state.currentIndex,
+      reason,
+      startedAt: new Date(state.turnStartedAt),
+      endedAt: new Date(now),
+      durationSec: (now - state.turnStartedAt) / 1000,
+    });
+  }
+
+  // Clear all timers
+  clearAllTimers(state);
+
+  // Compute next turn
+  const nextIndex = getNextIndex(state);
+  state.currentIndex = nextIndex;
+  state.turnStartedAt = now;
+  state.phase = "ACTIVE";
+  state.version++;
+
+  // Persist before emitting
+  await persistState(state);
+
+  // Unmute new speaker, mute old speaker
+  muteDebater(roomCode, currentSpeaker?.userId, io);
+  unmuteDebater(roomCode, state.debaterOrder[nextIndex]?.userId, io);
+
+  // Schedule new timers
+  scheduleTimers(state, io);
+
+  // Broadcast
+  const payload: TurnChangedPayload = {
+    version: state.version,
+    currentIndex: nextIndex,
+    debaterOrder: state.debaterOrder,
+    turnStartedAt: now,
+    turnLength: state.turnLength,
+    phase: "ACTIVE",
+  };
+  io.to(roomCode).emit("turnChanged", payload);
+
+  return { success: true };
+}
+
+export async function pauseDebate(
+  roomCode: string,
+  io: SocketIOServer,
+): Promise<{ success: boolean; error?: string }> {
+  const state = debates.get(roomCode);
+  if (!state) return { success: false, error: "No active debate" };
+  if (state.phase !== "ACTIVE") return { success: false, error: "Not active" };
+
+  clearAllTimers(state);
+
+  const now = Date.now();
+  const remaining = state.turnStartedAt
+    ? Math.max(0, state.turnLength - (now - state.turnStartedAt) / 1000)
+    : state.pausedTimeRemaining;
+
+  state.isPaused = true;
+  state.pausedTimeRemaining = remaining;
+  state.turnStartedAt = null;
+  state.phase = "PAUSED";
+  state.version++;
+
+  await persistState(state);
+
+  const payload: DebatePausedPayload = {
+    version: state.version,
+    timeRemaining: remaining,
+  };
+  io.to(roomCode).emit("debatePaused", payload);
+
+  return { success: true };
+}
+
+export async function resumeDebate(
+  roomCode: string,
+  io: SocketIOServer,
+): Promise<{ success: boolean; error?: string }> {
+  const state = debates.get(roomCode);
+  if (!state) return { success: false, error: "No active debate" };
+  if (state.phase !== "PAUSED") return { success: false, error: "Not paused" };
+
+  const now = Date.now();
+  state.isPaused = false;
+  state.turnStartedAt = now;
+  // turnLength temporarily adjusted to the remaining time for this turn
+  const effectiveTurnLength = state.pausedTimeRemaining;
+  state.phase = "ACTIVE";
+  state.version++;
+
+  await persistState(state);
+
+  // Schedule timers for the remaining time
+  scheduleTimersWithDuration(state, effectiveTurnLength, io);
+
+  const payload: DebateResumedPayload = {
+    version: state.version,
+    turnStartedAt: now,
+    turnLength: effectiveTurnLength,
+  };
+  io.to(roomCode).emit("debateResumed", payload);
+
+  return { success: true };
+}
+
+export async function endDebate(
+  roomCode: string,
+  io: SocketIOServer,
+): Promise<{ success: boolean; error?: string }> {
+  const state = debates.get(roomCode);
+  if (!state) return { success: false, error: "No active debate" };
+
+  clearAllTimers(state);
+
+  // Log the final turn
+  const currentSpeaker = state.debaterOrder[state.currentIndex];
+  if (currentSpeaker && state.turnStartedAt) {
+    const now = Date.now();
+    await logTurnTransition({
+      debateStateId: state.id,
+      speakerUserId: currentSpeaker.userId,
+      speakerName: currentSpeaker.displayName,
+      turnIndex: state.currentIndex,
+      reason: "MANUAL_ADVANCE",
+      startedAt: new Date(state.turnStartedAt),
+      endedAt: new Date(now),
+      durationSec: (now - state.turnStartedAt) / 1000,
+    });
+  }
+
+  state.phase = "ENDED";
+  state.version++;
+
+  // Delete from DB (TurnLogs cascade from DebateState, but we keep them by
+  // just updating phase instead of deleting)
+  await persistState(state);
+
+  debates.delete(roomCode);
+  codeToSessionId.delete(roomCode);
+
+  const payload: DebateEndedPayload = { version: state.version };
+  io.to(roomCode).emit("debateEnded", payload);
+
+  return { success: true };
+}
+
+export function getState(roomCode: string): DebateStatePayload | null {
+  const state = debates.get(roomCode);
+  if (!state) return null;
+
+  return {
+    version: state.version,
+    debaterOrder: state.debaterOrder,
+    currentIndex: state.currentIndex,
+    turnLength: state.turnLength,
+    turnStartedAt: state.turnStartedAt,
+    isPaused: state.isPaused,
+    pausedTimeRemaining: state.pausedTimeRemaining,
+    format: state.format,
+    formatMeta: state.formatMeta,
+    phase: state.phase,
+  };
+}
+
+export async function handleSpeakerDisconnect(
+  roomCode: string,
+  userId: string,
+  io: SocketIOServer,
+): Promise<void> {
+  const state = debates.get(roomCode);
+  if (!state || state.phase !== "ACTIVE") return;
+
+  const currentSpeaker = state.debaterOrder[state.currentIndex];
+  if (currentSpeaker?.userId === userId) {
+    await advanceTurn(roomCode, "SPEAKER_DISCONNECT", io);
+  }
+}
+
+export async function checkAuthorization(
+  roomCode: string,
+  userId: string,
+): Promise<boolean> {
+  const sessionId = codeToSessionId.get(roomCode);
+  if (!sessionId) {
+    // Try DB lookup
+    const session = await getSessionByCode(roomCode);
+    if (!session) return false;
+    return isHostOrModerator(session.id, userId);
+  }
+  return isHostOrModerator(sessionId, userId);
+}
+
+// ── Restart Recovery ──
+
+export async function recoverDebates(io: SocketIOServer): Promise<void> {
+  try {
+    const rows = await loadAllActiveDebates();
+    console.log(`[debate] Recovering ${rows.length} active debate(s)...`);
+
+    for (const row of rows) {
+      await recoverDebateFromRow(row, io);
+    }
+  } catch (err) {
+    console.error("[debate] Recovery failed:", err);
+  }
+}
+
+async function recoverDebateFromRow(
+  row: DbDebateState,
+  io: SocketIOServer,
+): Promise<void> {
+  // Look up the session code from session_id
+  const sessionCode = await getSessionCodeById(row.session_id);
+  if (!sessionCode) {
+    console.warn(`[debate] Cannot recover session ${row.session_id}: session not found`);
+    return;
+  }
+
+  const debaterOrder = row.debater_order as DebateParticipant[];
+  const now = Date.now();
+
+  const state: InternalDebateState = {
+    id: row.id,
+    sessionId: row.session_id,
+    roomCode: sessionCode,
+    format: row.format as DebateFormat,
+    debaterOrder,
+    currentIndex: row.current_index,
+    turnLength: row.turn_length,
+    turnStartedAt: null,
+    isPaused: row.is_paused,
+    pausedTimeRemaining: row.paused_time_remaining,
+    phase: row.phase as DebatePhase,
+    formatMeta: row.format_meta as Record<string, unknown> | null,
+    version: row.version,
+    turnTimer: null,
+    graceTimer: null,
+    warningTimers: [],
+    lastAdvanceAt: 0,
+  };
+
+  debates.set(sessionCode, state);
+  codeToSessionId.set(sessionCode, row.session_id);
+
+  // Phase-aware recovery
+  if (state.phase === "PAUSED") {
+    // No timers needed, just reconstructed state
+    console.log(`[debate] Recovered paused debate for ${sessionCode}`);
+    return;
+  }
+
+  if (state.phase === "GRACE") {
+    // Grace was interrupted, immediately advance
+    console.log(`[debate] Recovering from grace period for ${sessionCode}, advancing...`);
+    state.turnStartedAt = now;
+    await advanceTurn(sessionCode, "TIMER_EXPIRED", io);
+    return;
+  }
+
+  if (state.phase === "ACTIVE" && row.turn_ends_at) {
+    const remainingMs = row.turn_ends_at - now;
+    if (remainingMs <= 0) {
+      // Timer already expired during downtime, advance immediately
+      console.log(`[debate] Turn expired during downtime for ${sessionCode}, advancing...`);
+      state.turnStartedAt = now - state.turnLength * 1000; // pretend it started long ago
+      await advanceTurn(sessionCode, "TIMER_EXPIRED", io);
+    } else {
+      // Resume with remaining time
+      const remainingSec = remainingMs / 1000;
+      state.turnStartedAt = now;
+      state.pausedTimeRemaining = remainingSec;
+      scheduleTimersWithDuration(state, remainingSec, io);
+      console.log(`[debate] Recovered active debate for ${sessionCode}, ${remainingSec.toFixed(1)}s remaining`);
+    }
+    return;
+  }
+
+  console.log(`[debate] Recovered debate for ${sessionCode} in phase ${state.phase}`);
+}
+
+/**
+ * Load debate state from DB when a client requests it but the server
+ * doesn't have it in memory (e.g., server restarted and no one re-joined yet).
+ */
+export async function getOrLoadState(
+  roomCode: string,
+  io: SocketIOServer,
+): Promise<DebateStatePayload | null> {
+  // Check in-memory first
+  const memState = getState(roomCode);
+  if (memState) return memState;
+
+  // Try to load from DB
+  const session = await getSessionByCode(roomCode);
+  if (!session) return null;
+
+  const row = await loadDebateState(session.id);
+  if (!row || row.phase === "ENDED") return null;
+
+  // Reconstruct in memory
+  await recoverDebateFromRow(row, io);
+  return getState(roomCode);
+}
+
+// ── Private Helpers ──
+
+function getNextIndex(state: InternalDebateState): number {
+  const len = state.debaterOrder.length;
+  if (len === 0) return 0;
+
+  switch (state.format) {
+    case "ONE_ON_ONE":
+      return (state.currentIndex + 1) % 2;
+
+    case "PANEL":
+      return (state.currentIndex + 1) % len;
+
+    case "EXPERT_VS_CROWD": {
+      // Expert is always at index 0
+      // If currently expert's turn -> go to challenger (index 1)
+      // If currently challenger's turn -> back to expert (index 0)
+      // TODO: In follow-up PR, rotate challengers from queue
+      if (state.currentIndex === 0) {
+        return len > 1 ? 1 : 0;
+      }
+      return 0;
+    }
+
+    case "TEAM": {
+      // Two teams alternate. Simple alternation for now.
+      // TODO: In follow-up PR, cycle within teams
+      return (state.currentIndex + 1) % len;
+    }
+
+    default:
+      return (state.currentIndex + 1) % len;
+  }
+}
+
+function scheduleTimers(state: InternalDebateState, io: SocketIOServer): void {
+  scheduleTimersWithDuration(state, state.turnLength, io);
+}
+
+function scheduleTimersWithDuration(
+  state: InternalDebateState,
+  durationSec: number,
+  io: SocketIOServer,
+): void {
+  clearAllTimers(state);
+
+  const durationMs = durationSec * 1000;
+
+  // Turn expiry timer -> starts grace period
+  state.turnTimer = setTimeout(() => {
+    onTurnExpired(state, io);
+  }, durationMs);
+
+  // Warning timers
+  for (const threshold of WARNING_THRESHOLDS) {
+    if (durationSec > threshold) {
+      const delay = (durationSec - threshold) * 1000;
+      const timer = setTimeout(() => {
+        const payload: TurnWarningPayload = {
+          secondsRemaining: threshold,
+        };
+        io.to(state.roomCode).emit("turnWarning", payload);
+      }, delay);
+      state.warningTimers.push(timer);
+    }
+  }
+}
+
+function onTurnExpired(
+  state: InternalDebateState,
+  io: SocketIOServer,
+): void {
+  // Enter grace phase
+  state.phase = "GRACE";
+
+  // Mute the expired speaker
+  const expiredSpeaker = state.debaterOrder[state.currentIndex];
+  if (expiredSpeaker) {
+    muteDebater(state.roomCode, expiredSpeaker.userId, io);
+  }
+
+  // Notify clients of grace period
+  const payload: TurnExpiringPayload = {
+    version: state.version,
+    expiredUserId: expiredSpeaker?.userId ?? "",
+  };
+  io.to(state.roomCode).emit("turnExpiring", payload);
+
+  // Grace timer -> auto-advance
+  state.graceTimer = setTimeout(() => {
+    advanceTurn(state.roomCode, "TIMER_EXPIRED", io).catch((err) => {
+      console.error("[debate] Auto-advance failed:", err);
+    });
+  }, GRACE_PERIOD_MS);
+}
+
+function clearAllTimers(state: InternalDebateState): void {
+  if (state.turnTimer) {
+    clearTimeout(state.turnTimer);
+    state.turnTimer = null;
+  }
+  if (state.graceTimer) {
+    clearTimeout(state.graceTimer);
+    state.graceTimer = null;
+  }
+  for (const t of state.warningTimers) {
+    clearTimeout(t);
+  }
+  state.warningTimers = [];
+}
+
+async function persistState(state: InternalDebateState): Promise<void> {
+  try {
+    const turnEndsAt = state.turnStartedAt
+      ? state.turnStartedAt + state.turnLength * 1000
+      : null;
+
+    await persistDebateState({
+      id: state.id,
+      sessionId: state.sessionId,
+      debaterOrder: state.debaterOrder,
+      currentIndex: state.currentIndex,
+      turnLength: state.turnLength,
+      turnEndsAt,
+      isPaused: state.isPaused,
+      pausedTimeRemaining: state.pausedTimeRemaining,
+      format: state.format,
+      formatMeta: state.formatMeta,
+      phase: state.phase,
+      version: state.version,
+    });
+  } catch (err) {
+    console.error("[debate] Failed to persist state:", err);
+  }
+}
+
+// ── Mute/Unmute via mediasoup ──
+
+function muteDebater(
+  roomCode: string,
+  userId: string | undefined,
+  io: SocketIOServer,
+): void {
+  if (!userId) return;
+
+  // Server-side: pause audio producer via mediasoup
+  const room = getRoom(roomCode);
+  if (room) {
+    for (const peer of room.peers.values()) {
+      if (peer.userId === userId) {
+        for (const producer of peer.producers.values()) {
+          if (producer.kind === "audio") {
+            producer.pause().catch(() => {});
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  // Client-side: send forceMute event
+  io.to(roomCode).emit("forceMute", { userId });
+}
+
+function unmuteDebater(
+  roomCode: string,
+  userId: string | undefined,
+  io: SocketIOServer,
+): void {
+  if (!userId) return;
+
+  // Server-side: resume audio producer via mediasoup
+  const room = getRoom(roomCode);
+  if (room) {
+    for (const peer of room.peers.values()) {
+      if (peer.userId === userId) {
+        for (const producer of peer.producers.values()) {
+          if (producer.kind === "audio") {
+            producer.resume().catch(() => {});
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  // Client-side: send forceUnmute event
+  io.to(roomCode).emit("forceUnmute", { userId });
+}

--- a/realtime/src/index.ts
+++ b/realtime/src/index.ts
@@ -7,6 +7,7 @@ import { createWorkers } from "./mediasoup/workers.js";
 import { setupSignaling } from "./signaling.js";
 import { LISTEN_PORT } from "./config.js";
 import { createAuthMiddleware } from "./auth.js";
+import { recoverDebates } from "./debate.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -105,6 +106,9 @@ io.use(createAuthMiddleware());
 async function main(): Promise<void> {
   await createWorkers();
   setupSignaling(io);
+
+  // Recover any active debates from DB (after server restart)
+  await recoverDebates(io);
 
   server.listen(LISTEN_PORT, "0.0.0.0", () => {
     console.log(`\nArguably Realtime SFU running`);

--- a/realtime/src/signaling.ts
+++ b/realtime/src/signaling.ts
@@ -1,5 +1,14 @@
 import type { Server as SocketIOServer, Socket } from "socket.io";
-import type { Peer } from "./types.js";
+import type {
+  Peer,
+  JoinDebateRoomRequest,
+  StartDebateRequest,
+  NextTurnRequest,
+  PauseDebateRequest,
+  ResumeDebateRequest,
+  EndDebateRequest,
+  GetDebateStateRequest,
+} from "./types.js";
 import { iceServers } from "./config.js";
 import { getOrCreateRoom, addPeerToRoom, removePeerFromRoom, getRoom } from "./mediasoup/rooms.js";
 import { createWebRtcTransport, getTransportOptions } from "./mediasoup/transports.js";
@@ -7,14 +16,30 @@ import { createProducer } from "./mediasoup/producers.js";
 import { createConsumer } from "./mediasoup/consumers.js";
 import type { RtpCapabilities } from "mediasoup/types";
 import { schemas, validatePayload } from "./validation.js";
+import {
+  startDebate,
+  advanceTurn,
+  pauseDebate,
+  resumeDebate,
+  endDebate,
+  getOrLoadState,
+  checkAuthorization,
+  handleSpeakerDisconnect,
+} from "./debate.js";
 
 // Track which room each socket is in
 const socketRoomMap = new Map<string, string>();
 const socketPeerMap = new Map<string, { rtpCapabilities: RtpCapabilities }>();
+const socketUserMap = new Map<string, string>();
+const socketDebateRoomMap = new Map<string, string>();
 
 export function setupSignaling(io: SocketIOServer): void {
   io.on("connection", (socket: Socket) => {
     console.log(`Socket connected [id:${socket.id}]`);
+
+    // Extract userId from auth handshake
+    const authUserId = (socket.handshake.auth as Record<string, unknown>)?.userId as string | undefined;
+    if (authUserId) socketUserMap.set(socket.id, authUserId);
 
     // ── getRouterRtpCapabilities ──
     socket.on("getRouterRtpCapabilities", async (data: unknown, callback) => {
@@ -46,6 +71,7 @@ export function setupSignaling(io: SocketIOServer): void {
         const peer: Peer = {
           id: socket.id,
           displayName,
+          userId: authUserId,
           transports: new Map(),
           producers: new Map(),
           consumers: new Map(),
@@ -349,9 +375,99 @@ export function setupSignaling(io: SocketIOServer): void {
       }
     });
 
+    // ══════════════════════════════════════════
+    // ── DEBATE EVENTS ──
+    // ══════════════════════════════════════════
+
+    socket.on("joinDebateRoom", (data: JoinDebateRoomRequest, callback) => {
+      try {
+        socket.join(data.roomCode);
+        socketDebateRoomMap.set(socket.id, data.roomCode);
+        callback({ success: true });
+      } catch (error) {
+        callback({ success: false, error: String(error) });
+      }
+    });
+
+    socket.on("startDebate", async (data: StartDebateRequest, callback) => {
+      try {
+        const userId = socketUserMap.get(socket.id);
+        if (!userId) throw new Error("Not authenticated");
+        const authorized = await checkAuthorization(data.roomCode, userId);
+        if (!authorized) throw new Error("Not authorized");
+        const result = await startDebate(data.roomCode, data.debaters, data.turnLength, data.format, data.formatMeta ?? null, io);
+        callback(result);
+      } catch (error) {
+        callback({ success: false, error: String(error) });
+      }
+    });
+
+    socket.on("nextTurn", async (data: NextTurnRequest, callback) => {
+      try {
+        const userId = socketUserMap.get(socket.id);
+        if (!userId) throw new Error("Not authenticated");
+        const authorized = await checkAuthorization(data.roomCode, userId);
+        if (!authorized) throw new Error("Not authorized");
+        const result = await advanceTurn(data.roomCode, "MANUAL_ADVANCE", io, data.version);
+        callback(result);
+      } catch (error) {
+        callback({ success: false, error: String(error) });
+      }
+    });
+
+    socket.on("pauseDebate", async (data: PauseDebateRequest, callback) => {
+      try {
+        const userId = socketUserMap.get(socket.id);
+        if (!userId) throw new Error("Not authenticated");
+        const authorized = await checkAuthorization(data.roomCode, userId);
+        if (!authorized) throw new Error("Not authorized");
+        const result = await pauseDebate(data.roomCode, io);
+        callback(result);
+      } catch (error) {
+        callback({ success: false, error: String(error) });
+      }
+    });
+
+    socket.on("resumeDebate", async (data: ResumeDebateRequest, callback) => {
+      try {
+        const userId = socketUserMap.get(socket.id);
+        if (!userId) throw new Error("Not authenticated");
+        const authorized = await checkAuthorization(data.roomCode, userId);
+        if (!authorized) throw new Error("Not authorized");
+        const result = await resumeDebate(data.roomCode, io);
+        callback(result);
+      } catch (error) {
+        callback({ success: false, error: String(error) });
+      }
+    });
+
+    socket.on("endDebate", async (data: EndDebateRequest, callback) => {
+      try {
+        const userId = socketUserMap.get(socket.id);
+        if (!userId) throw new Error("Not authenticated");
+        const authorized = await checkAuthorization(data.roomCode, userId);
+        if (!authorized) throw new Error("Not authorized");
+        const result = await endDebate(data.roomCode, io);
+        callback(result);
+      } catch (error) {
+        callback({ success: false, error: String(error) });
+      }
+    });
+
+    socket.on("getDebateState", async (data: GetDebateStateRequest, callback) => {
+      try {
+        const state = await getOrLoadState(data.roomCode, io);
+        callback({ success: true, state });
+      } catch (error) {
+        callback({ success: false, error: String(error) });
+      }
+    });
+
     // ── disconnect ──
     socket.on("disconnect", () => {
       console.log(`Socket disconnected [id:${socket.id}]`);
+
+      const userId = socketUserMap.get(socket.id);
 
       // Clean up mediasoup peer
       const roomId = socketRoomMap.get(socket.id);
@@ -368,7 +484,21 @@ export function setupSignaling(io: SocketIOServer): void {
         }
         socketRoomMap.delete(socket.id);
         socketPeerMap.delete(socket.id);
+
+        // Handle debate speaker disconnect
+        if (userId) {
+          handleSpeakerDisconnect(roomId, userId, io).catch(console.error);
+        }
       }
+
+      // Handle debate room disconnect (for audience-only sockets)
+      const debateRoom = socketDebateRoomMap.get(socket.id);
+      if (debateRoom && debateRoom !== roomId && userId) {
+        handleSpeakerDisconnect(debateRoom, userId, io).catch(console.error);
+      }
+
+      socketUserMap.delete(socket.id);
+      socketDebateRoomMap.delete(socket.id);
     });
   });
 }

--- a/realtime/src/types.ts
+++ b/realtime/src/types.ts
@@ -16,6 +16,7 @@ import type {
 export interface Peer {
   id: string;
   displayName: string;
+  userId?: string;
   transports: Map<string, Transport>;
   producers: Map<string, Producer>;
   consumers: Map<string, Consumer>;
@@ -94,4 +95,37 @@ export interface AckResponse {
   success: boolean;
   [key: string]: unknown;
 }
+
+// ── Debate types ──
+
+export type DebateFormat = "ONE_ON_ONE" | "EXPERT_VS_CROWD" | "TEAM" | "PANEL";
+export type DebatePhase = "ACTIVE" | "GRACE" | "PAUSED" | "ENDED";
+export type TurnReason =
+  | "TIMER_EXPIRED"
+  | "MANUAL_ADVANCE"
+  | "SPEAKER_DISCONNECT"
+  | "DEBATE_START";
+
+export interface DebateParticipant {
+  userId: string;
+  displayName: string;
+}
+
+export interface JoinDebateRoomRequest { roomCode: string; }
+export interface StartDebateRequest { roomCode: string; debaters: DebateParticipant[]; turnLength: number; format: DebateFormat; formatMeta?: Record<string, unknown>; }
+export interface NextTurnRequest { roomCode: string; version: number; }
+export interface PauseDebateRequest { roomCode: string; }
+export interface ResumeDebateRequest { roomCode: string; }
+export interface EndDebateRequest { roomCode: string; }
+export interface GetDebateStateRequest { roomCode: string; }
+
+export interface TurnChangedPayload { version: number; currentIndex: number; debaterOrder: DebateParticipant[]; turnStartedAt: number; turnLength: number; phase: DebatePhase; }
+export interface TurnExpiringPayload { version: number; expiredUserId: string; }
+export interface TurnWarningPayload { secondsRemaining: number; }
+export interface DebatePausedPayload { version: number; timeRemaining: number; }
+export interface DebateResumedPayload { version: number; turnStartedAt: number; turnLength: number; }
+export interface DebateEndedPayload { version: number; }
+export interface ForceMutePayload { userId: string; }
+export interface ForceUnmutePayload { userId: string; }
+export interface DebateStatePayload { version: number; debaterOrder: DebateParticipant[]; currentIndex: number; turnLength: number; turnStartedAt: number | null; isPaused: boolean; pausedTimeRemaining: number; format: DebateFormat; formatMeta: Record<string, unknown> | null; phase: DebatePhase; }
 


### PR DESCRIPTION
## Summary

- **Server-side timers** auto-advance turns via `setTimeout` on the Socket.io realtime server — eliminates client-side race conditions
- **3-second grace period** between turns with dual auto-mute (mediasoup `producer.pause()` + `forceMute` event)  
- **Visual/audio warnings** at 30s and 10s remaining
- **Timer recovery** on refresh and server restart (phase-aware DB reconstruction)
- **Turn transition logging** via `TurnLog` model with `TurnReason` enum
- **Explicit FSM** with `DebatePhase` (ACTIVE, GRACE, PAUSED, ENDED) and monotonic version counter
- **Format support**: ONE_ON_ONE and PANEL rotation; EXPERT_VS_CROWD stubbed
- **Input validation** and auth checks throughout

15 files changed, 2,594 additions, 130 deletions. 126 new/updated tests (65 engine + 17 hook + 44 server actions).

## Test plan

- [x] TypeScript compiles clean (Next.js + realtime server)
- [x] 126 tests pass across debate engine, useDebateChannel hook, and server actions
- [x] Rebased cleanly on latest master (6be5e1f)

Closes #12