### PR TITLE
fix: harden Docker config (resource limits, credential validation, security docs)

### DIFF
--- a/realtime/.env.example
+++ b/realtime/.env.example
@@ -20,6 +20,9 @@ TURN_PORT=3478
 TURN_USERNAME=arguably
 TURN_PASSWORD=CHANGE_ME_IN_PRODUCTION
 
+# Environment (set to "production" to enforce credential validation on startup)
+NODE_ENV=development
+
 # CORS: comma-separated allowed origins (required in production, defaults to localhost in dev)
 # ALLOWED_ORIGINS=https://your-app.vercel.app
 

--- a/realtime/SECURITY.md
+++ b/realtime/SECURITY.md
@@ -1,0 +1,63 @@
+# Realtime Server — Deployment Security Guide
+
+## Credential Management
+
+Default TURN credentials (`arguably` / `arguably-turn-password`) are provided for local development only. **The server will refuse to start in production if defaults are still in use.**
+
+Set strong, unique credentials via environment variables:
+
+```bash
+TURN_USERNAME=your-secure-username
+TURN_PASSWORD=your-secure-password
+NODE_ENV=production
+```
+
+Update both the SFU environment (`.env` or `docker-compose.yml`) **and** `turnserver.conf` to match.
+
+## Firewall Requirements
+
+coturn uses `network_mode: host`, which binds directly to host interfaces — Docker network isolation does not apply.
+
+### Required ports
+
+| Port | Protocol | Service | Notes |
+|------|----------|---------|-------|
+| 3478 | TCP/UDP | TURN listening | Restrict to expected client IP ranges |
+| 49152–49252 | UDP | TURN relay range | Restrict to expected client IP ranges |
+| 3001 | TCP | SFU (HTTP + Socket.io) | Restrict or place behind reverse proxy |
+| 40000–40100 | UDP/TCP | mediasoup RTC | Restrict to expected client IP ranges |
+
+### Example (ufw)
+
+```bash
+# Allow TURN from your app's client CIDR
+ufw allow from <client-cidr> to any port 3478
+ufw allow from <client-cidr> to any port 49152:49252 proto udp
+
+# Allow SFU
+ufw allow from <client-cidr> to any port 3001 proto tcp
+
+# Allow mediasoup RTC
+ufw allow from <client-cidr> to any port 40000:40100 proto udp
+```
+
+## Why `network_mode: host` for coturn?
+
+TURN servers must see real client IPs for relay allocation and need to bind a large UDP port range. Docker's userland proxy adds latency and does not efficiently handle thousands of UDP flows. Host networking avoids these issues at the cost of container network isolation — hence the firewall requirements above.
+
+## Why TURN TLS is not enabled
+
+TLS/DTLS are intentionally disabled on the TURN server. This is safe because:
+
+1. **Media is already encrypted.** WebRTC mandates SRTP — TURN only relays opaque encrypted packets.
+2. **Credentials travel over TLS.** TURN credentials are sent to clients via the Socket.io connection, which uses WSS (TLS) in production.
+3. **No practical benefit.** Adding TLS to TURN would require certificate provisioning and rotation on the TURN server with no security improvement given (1) and (2).
+
+## Container Resource Limits
+
+Both containers have CPU and memory limits configured in `docker-compose.yml` to prevent a runaway process from consuming all host resources:
+
+- **sfu**: 2 CPUs, 1 GB RAM
+- **coturn**: 1 CPU, 512 MB RAM
+
+Adjust these based on expected concurrent session load.

--- a/realtime/docker-compose.yml
+++ b/realtime/docker-compose.yml
@@ -12,8 +12,14 @@ services:
       - RTC_MAX_PORT=40100
       - TURN_HOST=${ANNOUNCED_IP:-127.0.0.1}
       - TURN_PORT=3478
-      - TURN_USERNAME=arguably
-      - TURN_PASSWORD=arguably-turn-password
+      - TURN_USERNAME=${TURN_USERNAME:-arguably}
+      - TURN_PASSWORD=${TURN_PASSWORD:-arguably-turn-password}
+      - NODE_ENV=${NODE_ENV:-development}
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1g
     restart: unless-stopped
 
   coturn:
@@ -21,4 +27,9 @@ services:
     network_mode: host
     volumes:
       - ./turnserver.conf:/etc/turnserver.conf:ro
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512m
     restart: unless-stopped

--- a/realtime/src/config.ts
+++ b/realtime/src/config.ts
@@ -25,17 +25,18 @@ const DEFAULT_TURN_PASSWORD = "arguably-turn-password";
 const TURN_USERNAME = process.env.TURN_USERNAME || DEFAULT_TURN_USERNAME;
 const TURN_PASSWORD = process.env.TURN_PASSWORD || DEFAULT_TURN_PASSWORD;
 
-// Warn if default TURN credentials are used in production
+// Block startup if default TURN credentials are used in production
 if (process.env.NODE_ENV === "production") {
   if (TURN_USERNAME === DEFAULT_TURN_USERNAME || TURN_PASSWORD === DEFAULT_TURN_PASSWORD) {
-    console.warn(
+    console.error(
       "\n╔══════════════════════════════════════════════════════════╗\n" +
-        "║  WARNING: Default TURN credentials detected in prod!    ║\n" +
+        "║  FATAL: Default TURN credentials detected in production ║\n" +
         "║  Set TURN_USERNAME and TURN_PASSWORD env vars to        ║\n" +
         "║  strong, unique values. Default creds are public in     ║\n" +
         "║  source code and can be abused for bandwidth theft.     ║\n" +
         "╚══════════════════════════════════════════════════════════╝\n",
     );
+    process.exit(1);
   }
 }
 

--- a/realtime/turnserver.conf
+++ b/realtime/turnserver.conf
@@ -1,4 +1,29 @@
-# coturn configuration for Arguably Realtime (Phase 1)
+# coturn configuration for Arguably Realtime
+#
+# ── Security notes ──
+#
+# TLS/DTLS are intentionally disabled for TURN. This is safe because:
+#   1. WebRTC media is always SRTP-encrypted end-to-end — TURN only relays
+#      opaque encrypted packets, never plaintext media.
+#   2. TURN credentials are delivered to clients over the Socket.io connection,
+#      which runs over WSS (TLS) in production — credentials are never sent
+#      in the clear.
+#   3. Adding TLS to TURN would require certificate management on the TURN
+#      server with no meaningful security benefit given (1) and (2).
+#
+# ── Firewall requirements ──
+#
+# coturn runs with network_mode: host, so these ports are exposed on all
+# host interfaces. Configure your firewall to restrict access:
+#
+#   - TCP/UDP 3478   : TURN listening port — allow from expected client IPs
+#   - UDP 49152-49252: TURN relay port range — allow from expected client IPs
+#   - Block all other inbound traffic to these ports from untrusted sources
+#
+# Example (ufw):
+#   ufw allow from <client-cidr> to any port 3478
+#   ufw allow from <client-cidr> to any port 49152:49252 proto udp
+
 listening-port=3478
 fingerprint
 lt-cred-mech


### PR DESCRIPTION
## Summary
- Add CPU/memory resource limits to both Docker containers (`sfu`: 2 CPU/1GB, `coturn`: 1 CPU/512MB) to prevent runaway resource consumption
- Parameterize TURN credentials in `docker-compose.yml` via env vars instead of hardcoding defaults
- Upgrade production credential check from warning to **fatal error** (`process.exit(1)`) — server refuses to start with default creds when `NODE_ENV=production`
- Document TURN TLS rationale and firewall requirements directly in `turnserver.conf` comments
- Add `realtime/SECURITY.md` deployment security guide covering firewall rules, host networking rationale, and credential management
- Add `NODE_ENV` to `.env.example`

Closes #35

## Test plan
- [x] `docker compose config` validates compose file with resource limits
- [x] TypeScript compiles (no new errors introduced)
- [x] Credential validation: `NODE_ENV=production` + default creds → exits with code 1
- [x] Credential validation: `NODE_ENV=production` + custom creds → starts normally
- [x] Credential validation: `NODE_ENV=development` + default creds → starts normally (no block)