### PR TITLE
fix: resolve hydration mismatch on create page

### DIFF
--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -30,8 +30,12 @@ export default function CreateRoom() {
   const [moderation, setModeration] = useState('auto')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [previewCode, setPreviewCode] = useState(generateRoomCode)
+  const [previewCode, setPreviewCode] = useState('')
   const [draftRestored, setDraftRestored] = useState(false)
+
+  useEffect(() => {
+    setPreviewCode(generateRoomCode())
+  }, [])
 
   useEffect(() => {
     const draft = localStorage.getItem('arguably-draft-room')


### PR DESCRIPTION
## Summary
- Move `generateRoomCode()` from `useState` initializer into `useEffect` so it only runs client-side, fixing the React hydration mismatch (server generated one code, client generated a different one)

## Test plan
- [x] Open /create — no hydration error in console