### PR TITLE
fix: fall back to username when realname is missing

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -33,13 +33,13 @@ export default async function BrowsePage() {
     host: {
       id: session.host.id,
       username: session.host.username,
-      realname: session.host.realname || 'Unknown',
+      realname: session.host.realname || session.host.username,
     },
     moderator: session.moderator
     ? {
       id: session.moderator.id,
       username: session.moderator.username,
-      realname: session.moderator.realname || 'Unknown',
+      realname: session.moderator.realname || session.moderator.username,
     }
     : null,
     _count: { participatesIns: session._count.participates_ins },


### PR DESCRIPTION
## Summary
- Browse page was showing "Unknown" for room creators/moderators without a realname because the serialization defaulted to the string `'Unknown'` instead of falling back to `username`

## Test plan
- [x] Browse page shows username instead of "Unknown" for hosts without a realname set