### PR TITLE
fix: debate start timeout, transcript scroll, and silent skip

### DIFF
--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -146,10 +146,13 @@ export default function RoomClient({
     initialSegments: session.transcriptSegments,
   })
 
-  const transcriptEndRef = useRef<HTMLDivElement>(null)
+  const transcriptContainerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    transcriptEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    const container = transcriptContainerRef.current
+    if (container) {
+      container.scrollTop = container.scrollHeight
+    }
   }, [transcript.segments])
 
   const { claims } = useLiveClaims({
@@ -157,10 +160,13 @@ export default function RoomClient({
     initialClaims: session.detectedClaims,
   })
 
-  const claimsEndRef = useRef<HTMLDivElement>(null)
+  const claimsContainerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    claimsEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    const container = claimsContainerRef.current
+    if (container) {
+      container.scrollTop = container.scrollHeight
+    }
   }, [claims])
 
   const queueChannel = useQueueChannel({
@@ -362,6 +368,8 @@ export default function RoomClient({
         await debate.startDebate([expert], session.turnLength, session.type)
       } else if (debaterList.length >= 2) {
         await debate.startDebate(debaterList, session.turnLength, session.type)
+      } else {
+        throw new Error('Not enough debaters to start')
       }
 
       await updateSessionStatus(session.id, SessionStatus.LIVE)
@@ -1314,7 +1322,7 @@ export default function RoomClient({
                     </span>
                   </div>
                 </CardHeader>
-                <CardContent className="p-4 h-64 overflow-y-auto">
+                <CardContent ref={transcriptContainerRef} className="p-4 h-64 overflow-y-auto">
                   {transcript.segments.length === 0 ? (
                     <div className="h-full flex flex-col items-center justify-center text-center">
                       <p className="text-gray-500 debate-mono text-sm">{transcriptStatusMessage}</p>
@@ -1345,7 +1353,6 @@ export default function RoomClient({
                           </p>
                         </div>
                       ))}
-                      <div ref={transcriptEndRef} />
                     </div>
                   )}
                 </CardContent>
@@ -1364,7 +1371,7 @@ export default function RoomClient({
                     </span>
                   </div>
                 </CardHeader>
-                <CardContent className="p-4 h-64 overflow-y-auto">
+                <CardContent ref={claimsContainerRef} className="p-4 h-64 overflow-y-auto">
                   {claims.length === 0 ? (
                     <div className="h-full flex flex-col items-center justify-center text-center">
                       <p className="text-gray-500 debate-mono text-sm">No claims detected yet</p>
@@ -1412,7 +1419,6 @@ export default function RoomClient({
                           )}
                         </div>
                       ))}
-                      <div ref={claimsEndRef} />
                     </div>
                   )}
                 </CardContent>

--- a/hooks/useDebateChannel.ts
+++ b/hooks/useDebateChannel.ts
@@ -51,10 +51,15 @@ interface TurnWarningPayload { secondsRemaining: number }
 interface DebatePausedPayload { version: number; timeRemaining: number }
 interface DebateResumedPayload { version: number; turnStartedAt: number; turnLength: number }
 
-// Socket.io emit with ack helper
+// Socket.io emit with ack helper (10s timeout to prevent indefinite hangs)
 function request(socket: IoSocket, event: string, data: Record<string, unknown> = {}): Promise<SocketResponse> {
   return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Socket request "${event}" timed out after 10s`))
+    }, 10_000)
+
     socket.emit(event, data, (response: SocketResponse) => {
+      clearTimeout(timer)
       if (response.success) {
         resolve(response)
       } else {


### PR DESCRIPTION
## Summary
- Add 10-second timeout to `request()` in `useDebateChannel.ts` so the "Starting..." button can't hang forever when the realtime server doesn't ACK
- Fix transcript and claims panels using `scrollIntoView()` which scrolled the entire page — now uses `container.scrollTop` to scroll only within the panel
- Throw explicit error when debater count is insufficient instead of silently skipping `startDebate()`

## Test plan
- [ ] Start a debate — if realtime server is unreachable, button shows error after 10s instead of hanging
- [ ] During debate, transcript segments auto-scroll within their panel without moving the page
- [ ] Claims panel similarly scrolls within its container only