### PR TITLE
fix: search icon overlapping placeholder text

### DIFF
--- a/app/browse/BrowseClient.tsx
+++ b/app/browse/BrowseClient.tsx
@@ -118,7 +118,8 @@ export default function BrowseClient({ sessions }: { sessions: SessionData[] }) 
               <input
                 type="text"
                 placeholder="SEARCH DEBATES..."
-                className="debate-input w-full pl-12"
+                className="debate-input w-full"
+                style={{ paddingLeft: '3rem' }}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
               />


### PR DESCRIPTION
## Summary
- Tailwind v4 `pl-12` utility couldn't override `.debate-input`'s `padding-left` because unlayered CSS always beats layered utilities in Tailwind v4
- Use inline `style={{ paddingLeft: '3rem' }}` on the browse search input to guarantee the override

## Test plan
- [x] Search icon no longer overlaps "SEARCH DEBATES..." placeholder