### PR TITLE
fix: hide empty sessions and clean up stale participants

### DIFF
--- a/app/browse/BrowseClient.tsx
+++ b/app/browse/BrowseClient.tsx
@@ -55,14 +55,17 @@ export default function BrowseClient({ sessions }: { sessions: SessionData[] }) 
   const router = useRouter()
 
   const filtered = sessions.filter((s) => {
+    // Hide sessions with no active participants
+    if (s._count.participatesIns === 0) return false
     if (!s.name.toLowerCase().includes(searchQuery.toLowerCase())) return false
     if (typeFilter.length > 0 && !typeFilter.includes(s.type)) return false
     if (statusFilter.length > 0 && !statusFilter.includes(s.status)) return false
     return true
   })
 
-  const liveCount = sessions.filter((s) => s.status === 'LIVE').length
-  const totalParticipants = sessions.reduce((sum, s) => sum + s._count.participatesIns, 0)
+  const nonEmpty = sessions.filter((s) => s._count.participatesIns > 0)
+  const liveCount = nonEmpty.filter((s) => s.status === 'LIVE').length
+  const totalParticipants = nonEmpty.reduce((sum, s) => sum + s._count.participatesIns, 0)
 
   async function handleJoin(session: SessionData) {
     setJoiningId(session.id)
@@ -173,7 +176,7 @@ export default function BrowseClient({ sessions }: { sessions: SessionData[] }) 
             {[
               { label: "LIVE DEBATES", value: String(liveCount), icon: Zap },
               { label: "PARTICIPANTS", value: String(totalParticipants), icon: Users },
-              { label: "TOTAL ROOMS", value: String(sessions.length), icon: Clock },
+              { label: "TOTAL ROOMS", value: String(nonEmpty.length), icon: Clock },
               { label: "FORMATS", value: "4", icon: TrendingUp },
             ].map((stat, index) => (
               <motion.div

--- a/lib/actions/session.ts
+++ b/lib/actions/session.ts
@@ -113,6 +113,15 @@ export async function getSessionsByFilters(filters?: {
         : { in: Object.values(SessionType) }
     
 
+    // Clean up stale participants: mark as left for ENDED sessions
+    await prisma.participatesIn.updateMany({
+        where: {
+            left_at: null,
+            session: { status: SessionStatus.ENDED },
+        },
+        data: { left_at: new Date() },
+    })
+
     const sessions = await prisma.session.findMany({
         where: sessionsWhere,
         include: {
@@ -120,7 +129,7 @@ export async function getSessionsByFilters(filters?: {
             host: { select: { id: true, username: true, realname: true } },
             // moderator username
             moderator: { select: { id: true, username: true, realname: true } },
-            // participant count (active for live sessions, total for ended)
+            // participant count (active only)
             _count: { select: { participates_ins: { where: { left_at: null } } } },
         },
         orderBy: { created_at: "desc" },


### PR DESCRIPTION
## Summary
- Hide sessions with 0 active participants from the browse page grid and stats
- Auto-mark stale `ParticipatesIn` records as left for ENDED sessions (sets `left_at`) on browse page load

## Test plan
- [ ] Browse page no longer shows sessions with 0 participants
- [ ] Stats bar counts only non-empty sessions
- [ ] ENDED sessions get their stale participants cleaned up