### PR TITLE
fix: clean up stale sessions and prevent connection pool exhaustion

### DIFF
--- a/app/browse/BrowseClient.tsx
+++ b/app/browse/BrowseClient.tsx
@@ -55,17 +55,14 @@ export default function BrowseClient({ sessions }: { sessions: SessionData[] }) 
   const router = useRouter()
 
   const filtered = sessions.filter((s) => {
-    // Hide sessions with no active participants
-    if (s._count.participatesIns === 0) return false
     if (!s.name.toLowerCase().includes(searchQuery.toLowerCase())) return false
     if (typeFilter.length > 0 && !typeFilter.includes(s.type)) return false
     if (statusFilter.length > 0 && !statusFilter.includes(s.status)) return false
     return true
   })
 
-  const nonEmpty = sessions.filter((s) => s._count.participatesIns > 0)
-  const liveCount = nonEmpty.filter((s) => s.status === 'LIVE').length
-  const totalParticipants = nonEmpty.reduce((sum, s) => sum + s._count.participatesIns, 0)
+  const liveCount = sessions.filter((s) => s.status === 'LIVE').length
+  const totalParticipants = sessions.reduce((sum, s) => sum + s._count.participatesIns, 0)
 
   async function handleJoin(session: SessionData) {
     setJoiningId(session.id)
@@ -176,7 +173,7 @@ export default function BrowseClient({ sessions }: { sessions: SessionData[] }) 
             {[
               { label: "LIVE DEBATES", value: String(liveCount), icon: Zap },
               { label: "PARTICIPANTS", value: String(totalParticipants), icon: Users },
-              { label: "TOTAL ROOMS", value: String(nonEmpty.length), icon: Clock },
+              { label: "TOTAL ROOMS", value: String(sessions.length), icon: Clock },
               { label: "FORMATS", value: "4", icon: TrendingUp },
             ].map((stat, index) => (
               <motion.div

--- a/lib/actions/session.ts
+++ b/lib/actions/session.ts
@@ -113,23 +113,14 @@ export async function getSessionsByFilters(filters?: {
         : { in: Object.values(SessionType) }
     
 
-    // Clean up stale participants: mark as left for ENDED sessions
-    await prisma.participatesIn.updateMany({
-        where: {
-            left_at: null,
-            session: { status: SessionStatus.ENDED },
-        },
-        data: { left_at: new Date() },
-    })
+    // Only return sessions that have at least one active participant
+    sessionsWhere.participates_ins = { some: { left_at: null } }
 
     const sessions = await prisma.session.findMany({
         where: sessionsWhere,
         include: {
-            // host username
             host: { select: { id: true, username: true, realname: true } },
-            // moderator username
             moderator: { select: { id: true, username: true, realname: true } },
-            // participant count (active only)
             _count: { select: { participates_ins: { where: { left_at: null } } } },
         },
         orderBy: { created_at: "desc" },
@@ -644,5 +635,40 @@ export async function updateSessionStatus(sessionId: string, status: SessionStat
         where: { id: sessionId },
         data
     })
-    
+
+}
+
+/**
+ * Purge stale sessions: mark all participants as left for ENDED sessions,
+ * then delete sessions with zero active participants.
+ */
+export async function purgeOldSessions() {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) throw new Error("Not authenticated")
+
+    // 1. Mark all participants as left for ENDED sessions
+    await prisma.participatesIn.updateMany({
+        where: {
+            left_at: null,
+            session: { status: SessionStatus.ENDED },
+        },
+        data: { left_at: new Date() },
+    })
+
+    // 2. Delete sessions that have no active participants
+    const emptySessions = await prisma.session.findMany({
+        where: {
+            participates_ins: { none: { left_at: null } },
+        },
+        select: { id: true },
+    })
+
+    if (emptySessions.length > 0) {
+        await prisma.session.deleteMany({
+            where: { id: { in: emptySessions.map(s => s.id) } },
+        })
+    }
+
+    return { deleted: emptySessions.length }
 }

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -6,6 +6,7 @@ const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 function createPrismaClient() {
   const adapter = new PrismaPg({
     connectionString: process.env.DATABASE_URL!,
+    pool: { max: 5 },
   });
   return new PrismaClient({ adapter });
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,8 +101,8 @@ model ParticipatesIn {
   left_at      DateTime?
   session_role SessionRole @default(AUDIENCE)
 
-  user    User    @relation(fields: [user_id], references: [id])
-  session Session @relation(fields: [session_id], references: [id])
+  user    User    @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  session Session @relation(fields: [session_id], references: [id], onDelete: Cascade)
 
   @@id([user_id, session_id])
 }


### PR DESCRIPTION
## Summary
- Add `onDelete: Cascade` to `ParticipatesIn` so deleting sessions cascades
- Filter empty sessions at DB level (`participates_ins: { some: { left_at: null } }`) instead of running a `updateMany` cleanup on every browse page load
- Add `purgeOldSessions()` server action for manual/periodic cleanup
- Limit Prisma `pg` pool to `max: 5` to prevent `MaxClientsInSessionMode` errors
- Purged 9 stale empty sessions from the database

## Test plan
- [x] Browse page only shows sessions with active participants
- [x] No more MaxClientsInSessionMode errors
- [x] Stale sessions purged from DB