### PR TITLE
fix: add missing prisma.user mock to session tests

### DIFF
--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -41,6 +41,9 @@ vi.mock('@/lib/prisma', () => {
     roleHistory: {
       create: vi.fn().mockResolvedValue({}),
     },
+    user: {
+      upsert: vi.fn().mockResolvedValue({}),
+    },
     teamAssignment: {
       count: vi.fn().mockResolvedValue(0),
       upsert: vi.fn().mockResolvedValue({}),


### PR DESCRIPTION
joinSession now calls prisma.user.upsert to ensure the user row exists. The test mock was missing the user model.