### PR TITLE
fix: only enable transcription when debate is LIVE

### DIFF
--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -140,7 +140,7 @@ export default function RoomClient({
     sessionId: session.id,
     currentUserId,
     localStream,
-    enabled: isDebater && session.status !== SessionStatus.ENDED,
+    enabled: isDebater && session.status === SessionStatus.LIVE,
     audioMuted,
     initialSegments: session.transcriptSegments,
   })


### PR DESCRIPTION
Transcription was active for debaters in WAITING/PAUSED status. Now only captures audio when session status is LIVE.