### PR TITLE
fix: filter out Whisper prompt echo from transcript

### DIFF
--- a/app/api/transcripts/route.ts
+++ b/app/api/transcripts/route.ts
@@ -98,11 +98,13 @@ export async function POST(request: Request) {
     return badRequest("OPENAI_API_KEY is not configured", 500)
   }
 
+  const WHISPER_PROMPT = "This is a live debate discussion. Speakers present arguments, counterarguments, and evidence on various topics."
+
   const upstreamForm = new FormData()
   upstreamForm.append("model", model)
   upstreamForm.append("file", audioFile, audioFile.name || `chunk-${chunkIndex}.webm`)
   upstreamForm.append("language", "en")
-  upstreamForm.append("prompt", "This is a live debate discussion. Speakers present arguments, counterarguments, and evidence on various topics.")
+  upstreamForm.append("prompt", WHISPER_PROMPT)
 
   const upstreamResponse = await fetch("https://api.openai.com/v1/audio/transcriptions", {
     method: "POST",
@@ -137,7 +139,7 @@ export async function POST(request: Request) {
       ? upstreamJson.text.trim()
       : ""
 
-  if (!text) {
+  if (!text || text === WHISPER_PROMPT) {
     return NextResponse.json({ skipped: true })
   }
 


### PR DESCRIPTION
## Summary
When audio is silent/quiet, OpenAI Whisper echoes back the prompt text as the transcription result ("This is a live debate discussion..."). Now filters out segments that exactly match the prompt.

## Also needed (Supabase config)
Run in Supabase SQL Editor to fix cross-user transcript visibility:
```sql
ALTER TABLE "TranscriptSegment" DISABLE ROW LEVEL SECURITY;
```