### PR TITLE
fix: dark background on video elements

### DIFF
--- a/components/VideoPanel.tsx
+++ b/components/VideoPanel.tsx
@@ -26,7 +26,7 @@ export default function VideoPanel({ stream, muted, label, className = '' }: Vid
           autoPlay
           playsInline
           muted={muted}
-          className="w-full h-full object-cover"
+          className="w-full h-full object-cover bg-gray-900"
         />
       ) : (
         <div className="absolute inset-0 flex items-center justify-center">


### PR DESCRIPTION
Video elements showed white before the camera stream loaded. Added bg-gray-900 to the video element.