### PR TITLE
fix: ghost buttons showing white background on dark pages

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,18 +4,18 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "debate-button inline-flex items-center justify-center whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90 border-primary",
-        destructive: "bg-red-600 text-white hover:bg-red-700 border-red-600",
-        outline: "border-foreground bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-muted text-muted-foreground hover:bg-muted/80 border-muted",
-        ghost: "hover:bg-accent hover:text-accent-foreground border-transparent",
+        default: "debate-button bg-primary text-primary-foreground hover:bg-primary/90 border-primary",
+        destructive: "debate-button bg-red-600 text-white hover:bg-red-700 border-red-600",
+        outline: "debate-button border-foreground bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "debate-button bg-muted text-muted-foreground hover:bg-muted/80 border-muted",
+        ghost: "bg-transparent hover:bg-white/10 text-current border-transparent",
         link: "text-primary underline-offset-4 hover:underline border-transparent bg-transparent",
-        debate: "bg-blue-600 text-white hover:bg-blue-700 border-blue-600",
-        accent: "bg-yellow-400 text-black hover:bg-yellow-300 border-yellow-400",
+        debate: "debate-button bg-blue-600 text-white hover:bg-blue-700 border-blue-600",
+        accent: "debate-button bg-yellow-400 text-black hover:bg-yellow-300 border-yellow-400",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
The `debate-button` CSS class (which sets `background: white`) was applied as the base class for ALL button variants. Ghost/link buttons on dark pages rendered as white boxes. Moved `debate-button` to only the variants that need it.