### PR TITLE
fix: debate-button CSS overriding Tailwind colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -99,8 +99,6 @@ body {
   font-family: 'Syne', 'Inter', system-ui, sans-serif;
   font-weight: 600;
   border: 2px solid black;
-  background: white;
-  color: black;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   transform: skew(-2deg);


### PR DESCRIPTION
## Summary
`.debate-button` in globals.css hardcoded `background: white` and `color: black`. Since unlayered CSS always beats Tailwind v4 layered utilities, buttons with `bg-red-600 text-white` still rendered white. Removed the color declarations — debate-button now only handles decorative styling (font, skew, shadow, transition). Colors come from Tailwind classes on each variant.

## Test plan
- [x] Landing page: red "START DEBATING" + outlined "WATCH LIVE" look correct
- [x] Browse page: white "FILTER" button looks correct
- [ ] Replay page: skip/play/speed controls no longer show white boxes