### PR TITLE
fix: restore debate-button defaults, fix replay controls only

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -99,6 +99,8 @@ body {
   font-family: 'Syne', 'Inter', system-ui, sans-serif;
   font-weight: 600;
   border: 2px solid black;
+  background: white;
+  color: black;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   transform: skew(-2deg);

--- a/app/room/[code]/replay/ReplayClient.tsx
+++ b/app/room/[code]/replay/ReplayClient.tsx
@@ -223,36 +223,32 @@ export default function ReplayClient({ data }: { data: ReplayData }) {
                           {/* Controls row */}
                           <div className="flex items-center justify-between">
                             <div className="flex items-center gap-2">
-                              <Button
-                                variant="ghost"
-                                size="icon"
+                              <button
                                 onClick={() => player.seek(Math.max(0, player.currentTime - 10))}
                                 title="Back 10s"
+                                className="h-10 w-10 inline-flex items-center justify-center text-gray-300 hover:text-white hover:bg-white/10 rounded transition-colors"
                               >
                                 <SkipBack className="w-4 h-4" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
+                              </button>
+                              <button
                                 onClick={player.togglePlayPause}
-                                className="text-white hover:bg-white/10"
+                                className="h-10 w-10 inline-flex items-center justify-center text-white hover:bg-white/10 rounded transition-colors"
                               >
                                 {player.isPlaying ? (
                                   <Pause className="w-5 h-5" />
                                 ) : (
                                   <Play className="w-5 h-5" />
                                 )}
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
+                              </button>
+                              <button
                                 onClick={() =>
                                   player.seek(Math.min(player.duration, player.currentTime + 10))
                                 }
                                 title="Forward 10s"
+                                className="h-10 w-10 inline-flex items-center justify-center text-gray-300 hover:text-white hover:bg-white/10 rounded transition-colors"
                               >
                                 <SkipForward className="w-4 h-4" />
-                              </Button>
+                              </button>
                             </div>
 
                             {/* Speed selector */}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,18 +4,18 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "debate-button inline-flex items-center justify-center whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "debate-button bg-primary text-primary-foreground hover:bg-primary/90 border-primary",
-        destructive: "debate-button bg-red-600 text-white hover:bg-red-700 border-red-600",
-        outline: "debate-button border-foreground bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary: "debate-button bg-muted text-muted-foreground hover:bg-muted/80 border-muted",
-        ghost: "bg-transparent hover:bg-white/10 text-current border-transparent",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90 border-primary",
+        destructive: "bg-red-600 text-white hover:bg-red-700 border-red-600",
+        outline: "border-foreground bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-muted text-muted-foreground hover:bg-muted/80 border-muted",
+        ghost: "hover:bg-accent hover:text-accent-foreground border-transparent",
         link: "text-primary underline-offset-4 hover:underline border-transparent bg-transparent",
-        debate: "debate-button bg-blue-600 text-white hover:bg-blue-700 border-blue-600",
-        accent: "debate-button bg-yellow-400 text-black hover:bg-yellow-300 border-yellow-400",
+        debate: "bg-blue-600 text-white hover:bg-blue-700 border-blue-600",
+        accent: "bg-yellow-400 text-black hover:bg-yellow-300 border-yellow-400",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
Reverts the debate-button CSS removal that made all buttons invisible. The 3 replay playback controls now use plain `<button>` elements with transparent backgrounds instead of the Button component.