### PR TITLE
fix: debate test mocks and mirror local camera

### DIFF
--- a/__tests__/realtime/debate.test.ts
+++ b/__tests__/realtime/debate.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../realtime/src/db', () => ({
   getSessionByCode: vi.fn().mockResolvedValue(null),
   getSessionCodeById: vi.fn().mockResolvedValue(null),
   validateDebaterIds: vi.fn().mockResolvedValue(true),
+  filterActiveDebaterIds: vi.fn().mockImplementation((_sid: string, ids: string[]) => Promise.resolve(ids)),
   isHostOrModerator: vi.fn().mockResolvedValue(true),
 }))
 
@@ -75,7 +76,7 @@ describe('debate engine', () => {
     // Re-establish default mock returns after clearAllMocks
     vi.mocked(db.persistDebateState).mockResolvedValue(undefined)
     vi.mocked(db.logTurnTransition).mockResolvedValue(undefined)
-    vi.mocked(db.validateDebaterIds).mockResolvedValue(true)
+    vi.mocked(db.filterActiveDebaterIds).mockImplementation((_sid: string, ids: string[]) => Promise.resolve(ids))
     vi.mocked(db.isHostOrModerator).mockResolvedValue(true)
     vi.mocked(db.loadAllActiveDebates).mockResolvedValue([])
     vi.mocked(db.loadDebateState).mockResolvedValue(null)
@@ -116,22 +117,24 @@ describe('debate engine', () => {
     })
 
     it('rejects < 2 debaters', async () => {
+      mockSession()
       const r = await startDebate(ROOM, [d2[0]], 60, 'ONE_ON_ONE', null, io)
       expect(r.success).toBe(false)
-      expect(r.error).toContain('At least 2')
+      expect(r.error).toContain('Not enough active debaters')
     })
 
     it('rejects ONE_ON_ONE with 3 debaters', async () => {
+      mockSession()
       const r = await startDebate(ROOM, d4.slice(0, 3), 60, 'ONE_ON_ONE', null, io)
       expect(r.success).toBe(false)
       expect(r.error).toContain('exactly 2')
     })
 
-    it('rejects PANEL with 2 debaters', async () => {
+    it('rejects PANEL with 1 debater', async () => {
       mockSession('PANEL')
-      const r = await startDebate(ROOM, d2, 60, 'PANEL', null, io)
+      const r = await startDebate(ROOM, [d2[0]], 60, 'PANEL', null, io)
       expect(r.success).toBe(false)
-      expect(r.error).toContain('3-6')
+      expect(r.error).toContain('Not enough active debaters')
     })
 
     it('rejects PANEL with 7 debaters', async () => {
@@ -147,11 +150,12 @@ describe('debate engine', () => {
       expect(r).toEqual({ success: false, error: 'Session not found' })
     })
 
-    it('rejects if debater IDs invalid', async () => {
+    it('rejects if no debaters are active participants', async () => {
       mockSession()
-      vi.mocked(db.validateDebaterIds).mockResolvedValue(false)
+      vi.mocked(db.filterActiveDebaterIds).mockResolvedValue([])
       const r = await startDebate(ROOM, d2, 60, 'ONE_ON_ONE', null, io)
-      expect(r).toEqual({ success: false, error: 'Invalid debater IDs' })
+      expect(r.success).toBe(false)
+      expect(r.error).toContain('Not enough active debaters')
     })
 
     it('rejects if format mismatches session type', async () => {

--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -918,7 +918,7 @@ export default function RoomClient({
                               ) : connectionState === 'connected' ? (
                                 <div className="grid grid-cols-2 gap-2">
                                   <div className="min-h-[200px]">
-                                    <VideoPanel stream={localStream} muted label="You" />
+                                    <VideoPanel stream={localStream} muted mirror label="You" />
                                   </div>
                                   {Array.from(remoteStreams.entries())
                                     .filter(([, rs]) => rs.kind === 'video')

--- a/components/VideoPanel.tsx
+++ b/components/VideoPanel.tsx
@@ -6,10 +6,11 @@ interface VideoPanelProps {
   stream: MediaStream | null
   muted: boolean
   label: string
+  mirror?: boolean
   className?: string
 }
 
-export default function VideoPanel({ stream, muted, label, className = '' }: VideoPanelProps) {
+export default function VideoPanel({ stream, muted, label, mirror = false, className = '' }: VideoPanelProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
 
   useEffect(() => {
@@ -26,7 +27,7 @@ export default function VideoPanel({ stream, muted, label, className = '' }: Vid
           autoPlay
           playsInline
           muted={muted}
-          className="w-full h-full object-cover bg-gray-900"
+          className={`w-full h-full object-cover bg-gray-900${mirror ? ' -scale-x-100' : ''}`}
         />
       ) : (
         <div className="absolute inset-0 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- Update debate engine test mocks for `filterActiveDebaterIds` (replaced `validateDebaterIds`)
- Update error message assertions to match current validation logic
- Add `mirror` prop to VideoPanel — local camera is now mirrored (natural mirror view)

## Test plan
- [x] All 121 SFU/realtime tests pass
- [ ] Local camera appears mirrored in room view