### PR TITLE
fix: remote camera not showing and transcript wrong speaker

### DIFF
--- a/app/room/[code]/RoomClient.tsx
+++ b/app/room/[code]/RoomClient.tsx
@@ -37,7 +37,6 @@ import type { ClaimView } from '@/lib/claims'
 import { useDebateChannel } from '@/hooks/useDebateChannel'
 import { useQueueChannel } from '@/hooks/useQueueChannel'
 import { useKickVoteChannel } from '@/hooks/useKickVoteChannel'
-import { createClient } from '@/lib/supabase/client'
 import VideoPanel from '@/components/VideoPanel'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -140,7 +139,7 @@ export default function RoomClient({
     sessionId: session.id,
     currentUserId,
     localStream,
-    enabled: isDebater && session.status === SessionStatus.LIVE,
+    enabled: isDebater && session.status === SessionStatus.LIVE && debate.isMyTurn,
     audioMuted,
     initialSegments: session.transcriptSegments,
   })

--- a/hooks/useMediasoup.ts
+++ b/hooks/useMediasoup.ts
@@ -134,6 +134,7 @@ export function useMediasoup({
   const localStreamRef = useRef<MediaStream | null>(null)
   const peerIdRef = useRef<string | null>(null)
   const routerDataRef = useRef<RouterCapabilitiesResponse | null>(null)
+  const pendingProducersRef = useRef<string[]>([])
   const cleanedUpRef = useRef(false)
 
   const cleanup = useCallback(() => {
@@ -375,9 +376,18 @@ export function useMediasoup({
             }
 
             const prodData = (await request(socket, 'getProducers')) as GetProducersResponse
+            const alreadyConsuming = new Set(prodData.producers.map(p => p.producerId))
             for (const p of prodData.producers) {
               await consumeProducer(socket, recvTransport, p.producerId)
             }
+
+            // Drain any newProducer events that arrived before recv transport was ready
+            for (const pid of pendingProducersRef.current) {
+              if (!alreadyConsuming.has(pid)) {
+                await consumeProducer(socket, recvTransport, pid)
+              }
+            }
+            pendingProducersRef.current = []
 
             clearTimeout(connectionTimeout)
             setConnectionState('connected')
@@ -403,6 +413,9 @@ export function useMediasoup({
         socket.on('newProducer', async (data: NewProducerEvent) => {
           if (recvTransportRef.current) {
             await consumeProducer(socket, recvTransportRef.current, data.producerId)
+          } else {
+            // Buffer if recv transport isn't ready yet (connect handler still running)
+            pendingProducersRef.current.push(data.producerId)
           }
         })
 


### PR DESCRIPTION
## Summary
**Camera**: `newProducer` socket events arriving before the recv transport was ready were silently dropped (recvTransportRef was null). Now buffered and drained after setup completes.

**Transcript**: Both debaters were recording their mics simultaneously, so each saw their own name on all segments. Now only the current speaker's mic is captured (`debate.isMyTurn`).

## Test plan
- [ ] Two browsers in same room — both should see each other's camera
- [ ] During debate, only the current speaker's transcript appears
- [ ] Turn advances → transcription switches to new speaker